### PR TITLE
[feat] 공통 응답 객체 ApiResponse 추가

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/response/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.yujin.course_enrollment.global.response;
+
+import lombok.Getter;
+
+/**
+ * 공통 응답 객체
+ * 모든 API 응답을 감싸는 응답 포맷
+ */
+@Getter
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final String message;
+
+    private ApiResponse(boolean success, T data, String message) {
+        this.success = success;
+        this.data = data;
+        this.message = message;
+    }
+
+    /* 성공 응답 (데이터 있음) */
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    /* 성공 응답 (데이터 없음) */
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(true, null, null);
+    }
+
+    /* 실패 응답 */
+    public static <T> ApiResponse<T> fail(String message) {
+        return new ApiResponse<>(false, null, message);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 공통 응답 객체 ApiResponse 추가

## 구현 시 고려한 점
- 제네릭(T) 사용으로 모든 DTO 타입 수용 가능
- success, fail 정적 팩토리 메서드로 일관된 응답 포맷 사용
- 데이터 없는 성공 응답도 별도 메서드로 처리

## 테스트 방법
- 이후 feature/course 에서 ApiResponse 적용 후 확인

## 연관 이슈
없음