### PR TITLE
[feat] 공통 예외처리 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.yujin.course_enrollment.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 비즈니스 로직 예외
+ * 도메인 규칙 위반 시 발생하는 커스텀 예외
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public BusinessException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.yujin.course_enrollment.global.exception;
+
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리기
+ * 컨트롤러에서 발생하는 예외를 ApiResponse 포맷으로 통일하여 응답
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 비즈니스 로직 예외 처리
+     * BusinessException이 가진 HTTP 상태 코드로 응답
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<?>> handleBusinessException(BusinessException e) {
+        log.warn("[GlobalExceptionHandler] BusinessException: {}", e.getMessage());
+        return ResponseEntity.status(e.getStatus()).body(ApiResponse.fail(e.getStatus().value(), e.getMessage()));
+    }
+
+    /**
+     * 요청 바디 유효성 검증 실패 처리 (@Valid)
+     * 첫 번째 필드 오류 메시지를 응답
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getDefaultMessage())
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다.");
+        log.warn("[GlobalExceptionHandler] ValidationException: {}", message);
+        return ResponseEntity.badRequest().body(ApiResponse.fail(400, message));
+    }
+
+    /**
+     * 필수 요청 헤더 누락 처리
+     */
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<?>> handleMissingHeaderException(MissingRequestHeaderException e) {
+        String message = e.getHeaderName() + " 헤더가 누락되었습니다.";
+        log.warn("[GlobalExceptionHandler] MissingRequestHeaderException: {}", message);
+        return ResponseEntity.badRequest().body(ApiResponse.fail(400, message));
+    }
+
+    /**
+     * 그 외 예상치 못한 서버 오류 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("[GlobalExceptionHandler] Unexpected Exception", e);
+        return ResponseEntity.internalServerError().body(ApiResponse.fail(500, "서버 오류가 발생했습니다."));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -9,10 +9,12 @@ import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,31 +46,31 @@ public class CourseService {
         User user = userMapper.selectUserById(creatorId);
         if (user == null) {
             log.warn("[CourseService] 존재하지 않는 사용자 - creatorId: {}", creatorId);
-            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다.");
         }
 
         // 크리에이터 권한 확인
         if (!"CREATOR".equals(user.getRole())) {
             log.warn("[CourseService] 크리에이터 권한 없음 - creatorId: {}, role: {}", creatorId, user.getRole());
-            throw new IllegalArgumentException("강의 등록 권한이 없습니다.");
+            throw new BusinessException(HttpStatus.FORBIDDEN, "강의 등록 권한이 없습니다.");
         }
 
         // 시작일 과거 검증
         if (reqCourseCreateDto.getStartDate().isBefore(LocalDate.now())) {
             log.warn("[CourseService] 시작일이 과거 - startDate: {}", reqCourseCreateDto.getStartDate());
-            throw new IllegalArgumentException("시작일은 오늘 이후여야 합니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "시작일은 오늘 이후여야 합니다.");
         }
 
         // 종료일 과거 검증
         if (reqCourseCreateDto.getEndDate().isBefore(LocalDate.now())) {
             log.warn("[CourseService] 종료일이 과거 - endDate: {}", reqCourseCreateDto.getEndDate());
-            throw new IllegalArgumentException("종료일은 오늘 이후여야 합니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "종료일은 오늘 이후여야 합니다.");
         }
 
         // 날짜 유효성 확인
         if (reqCourseCreateDto.getEndDate().isBefore(reqCourseCreateDto.getStartDate())) {
             log.warn("[CourseService] 날짜 유효성 오류 - startDate: {}, endDate: {}", reqCourseCreateDto.getStartDate(), reqCourseCreateDto.getEndDate());
-            throw new IllegalArgumentException("종료일은 시작일보다 이전일 수 없습니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "종료일은 시작일보다 이전일 수 없습니다.");
         }
 
         Course course = reqCourseCreateDto.toEntity(creatorId);
@@ -79,7 +81,7 @@ public class CourseService {
         Course savedCourse = courseMapper.selectCourseById(course.getId());
         if (savedCourse == null) {
             log.error("[CourseService] 강의 등록 후 조회 실패 - courseId: {}", course.getId());
-            throw new IllegalStateException("강의 등록에 실패했습니다.");
+            throw new BusinessException(HttpStatus.INTERNAL_SERVER_ERROR, "강의 등록에 실패했습니다.");
         }
 
         return RespCourseCreateDto.from(savedCourse);
@@ -110,7 +112,7 @@ public class CourseService {
         RespCourseDetailDto course = courseMapper.selectCourseDetailById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
-            throw new IllegalArgumentException("존재하지 않는 강의입니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
         log.info("[CourseService] 강의 상세 조회 완료 - courseId: {}", courseId);
@@ -131,25 +133,25 @@ public class CourseService {
         Course course = courseMapper.selectCourseById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
-            throw new IllegalArgumentException("존재하지 않는 강의입니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
         // 크리에이터 권한 확인
         if (!course.getCreatorId().equals(creatorId)) {
             log.warn("[CourseService] 수정 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
-            throw new IllegalArgumentException("강의 수정 권한이 없습니다.");
+            throw new BusinessException(HttpStatus.FORBIDDEN, "강의 수정 권한이 없습니다.");
         }
 
         // DRAFT 상태에서만 수정 가능
         if (!"DRAFT".equals(course.getStatus())) {
             log.warn("[CourseService] DRAFT 상태가 아님 - courseId: {}, status: {}", courseId, course.getStatus());
-            throw new IllegalArgumentException("DRAFT 상태의 강의만 수정할 수 있습니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "DRAFT 상태의 강의만 수정할 수 있습니다.");
         }
 
         // 날짜 유효성 확인
         if (reqCourseUpdateDto.getEndDate().isBefore(reqCourseUpdateDto.getStartDate())) {
             log.warn("[CourseService] 날짜 유효성 오류 - startDate: {}, endDate: {}", reqCourseUpdateDto.getStartDate(), reqCourseUpdateDto.getEndDate());
-            throw new IllegalArgumentException("종료일은 시작일보다 이전일 수 없습니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "종료일은 시작일보다 이전일 수 없습니다.");
         }
 
         courseMapper.updateCourse(reqCourseUpdateDto.toEntity(courseId, creatorId));
@@ -170,17 +172,17 @@ public class CourseService {
         Course course = courseMapper.selectCourseById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
-            throw new IllegalArgumentException("존재하지 않는 강의입니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
         if (!course.getCreatorId().equals(creatorId)) {
             log.warn("[CourseService] 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
-            throw new IllegalArgumentException("강의 공개 권한이 없습니다.");
+            throw new BusinessException(HttpStatus.FORBIDDEN, "강의 공개 권한이 없습니다.");
         }
 
         if (!"DRAFT".equals(course.getStatus())) {
             log.warn("[CourseService] DRAFT 상태 아님 - courseId: {}, status: {}", courseId, course.getStatus());
-            throw new IllegalArgumentException("DRAFT 상태의 강의만 공개할 수 있습니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "DRAFT 상태의 강의만 공개할 수 있습니다.");
         }
 
         courseMapper.updateCourseStatus(Course.builder().id(courseId).status("OPEN").build());
@@ -201,17 +203,17 @@ public class CourseService {
         Course course = courseMapper.selectCourseById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
-            throw new IllegalArgumentException("존재하지 않는 강의입니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
         if (!course.getCreatorId().equals(creatorId)) {
             log.warn("[CourseService] 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
-            throw new IllegalArgumentException("강의 마감 권한이 없습니다.");
+            throw new BusinessException(HttpStatus.FORBIDDEN, "강의 마감 권한이 없습니다.");
         }
 
         if (!"OPEN".equals(course.getStatus())) {
             log.warn("[CourseService] OPEN 상태 아님 - courseId: {}, status: {}", courseId, course.getStatus());
-            throw new IllegalArgumentException("OPEN 상태의 강의만 마감할 수 있습니다.");
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "OPEN 상태의 강의만 마감할 수 있습니다.");
         }
 
         courseMapper.updateCourseStatus(Course.builder().id(courseId).status("CLOSED").build());

--- a/backend/src/test/java/com/yujin/course_enrollment/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/CourseServiceTest.java
@@ -1,6 +1,7 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqCourseCreateDto;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.dto.req.ReqCourseUpdateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
@@ -88,7 +89,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.registerCourse(creatorId, req))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("존재하지 않는 사용자입니다.");
     }
 
@@ -108,7 +109,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.registerCourse(creatorId, req))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("강의 등록 권한이 없습니다.");
     }
 
@@ -128,7 +129,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.registerCourse(creatorId, req))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("종료일은 시작일보다 이전일 수 없습니다.");
     }
 
@@ -187,7 +188,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.registerCourse(creatorId, req))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("시작일은 오늘 이후여야 합니다.");
     }
 
@@ -207,7 +208,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.registerCourse(creatorId, req))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("종료일은 오늘 이후여야 합니다.");
     }
 
@@ -266,7 +267,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.modifyCourse(otherUserId, courseId, req))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("강의 수정 권한이 없습니다.");
     }
 
@@ -291,7 +292,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.modifyCourse(creatorId, courseId, resp))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("DRAFT 상태의 강의만 수정할 수 있습니다.");
     }
 
@@ -340,7 +341,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.publishCourse(otherUserId, courseId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("강의 공개 권한이 없습니다.");
     }
 
@@ -360,7 +361,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.publishCourse(creatorId, courseId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("DRAFT 상태의 강의만 공개할 수 있습니다.");
     }
 
@@ -409,7 +410,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.closeCourse(wrongUserId, courseId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("강의 마감 권한이 없습니다.");
     }
 
@@ -429,7 +430,7 @@ class CourseServiceTest {
 
         // when & then
         assertThatThrownBy(() -> courseService.closeCourse(creatorId, courseId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessage("OPEN 상태의 강의만 마감할 수 있습니다.");
     }
 }


### PR DESCRIPTION
## 작업 내용
- BusinessException 커스텀 예외 클래스 추가
- GlobalExceptionHandler 구현
- CourseService 예외를 BusinessException으로 교체

## 구현 시 고려한 점
- BusinessException에 HttpStatus 포함하여 상태 코드 명시적 관리
- 권한 없음은 403 Forbidden으로 응답
- Valid 검증 실패, 헤더 누락, 서버 오류 각각 처리
- 모든 예외를 ApiResponse 포맷으로 통일

## 테스트 방법
- 백엔드 실행 후 포스트맨으로 각 예외 케이스 확인

## 연관 이슈
Closes #13