### PR TITLE
[feat] 사용자 선택 로그인 페이지 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/UserController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 사용자 컨트롤러
+ * 사용자 관련 HTTP 요청을 처리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 전체 사용자 목록 조회
+     * GET /api/users
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<User>>> getUserList() {
+        log.debug("[UserController] 전체 사용자 목록 조회 요청");
+
+        List<User> users = userService.findUserList();
+
+        return ResponseEntity.ok(ApiResponse.success(users));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.yujin.course_enrollment.global.exception;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -48,6 +49,15 @@ public class GlobalExceptionHandler {
         String message = e.getHeaderName() + " 헤더가 누락되었습니다.";
         log.warn("[GlobalExceptionHandler] MissingRequestHeaderException: {}", message);
         return ResponseEntity.badRequest().body(ApiResponse.fail(400, message));
+    }
+
+    /**
+     * 요청 바디 파싱 실패 처리 (잘못된 JSON 형식, 타입 불일치 등)
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("[GlobalExceptionHandler] HttpMessageNotReadableException: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(ApiResponse.fail(400, "요청 형식이 올바르지 않습니다."));
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
@@ -3,6 +3,8 @@ package com.yujin.course_enrollment.mapper;
 import com.yujin.course_enrollment.entity.User;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 /**
  * 사용자 Mapper 인터페이스
  * UserMapper.xml과 매핑되어 사용자 관련 DB 접근을 담당
@@ -11,4 +13,7 @@ import org.apache.ibatis.annotations.Mapper;
 public interface UserMapper {
     /* 사용자 단건 조회 */
     User selectUserById(Long id);
+
+    /* 전체 사용자 목록 조회 */
+    List<User> selectUserList();
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -28,6 +28,7 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CourseService {
 
     private final CourseMapper courseMapper;
@@ -37,6 +38,7 @@ public class CourseService {
      * 강의 등록
      * @param creatorId 강의를 등록하는 크리에이터 ID
      * @param reqCourseCreateDto 강의 등록 요청 DTO
+     * @throws BusinessException 사용자 없음(400), 등록 권한 없음(403), 날짜 유효성 오류(400), 등록 실패(500)
      */
     @Transactional
     public RespCourseCreateDto registerCourse(Long creatorId, ReqCourseCreateDto reqCourseCreateDto) {
@@ -105,6 +107,7 @@ public class CourseService {
     /**
      * 강의 상세 조회
      * @param courseId 강의 ID
+     * @throws BusinessException 강의 없음(400)
      */
     public RespCourseDetailDto findCourseById(Long courseId) {
         log.info("[CourseService] 강의 상세 조회 - courseId: {}", courseId);
@@ -125,7 +128,9 @@ public class CourseService {
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
      * @param reqCourseUpdateDto 강의 수정 요청 DTO
+     * @throws BusinessException 강의 없음(400), 수정 권한 없음(403), DRAFT 상태 아님(400), 날짜 유효성 오류(400)
      */
+    @Transactional
     public RespCourseDetailDto modifyCourse(Long creatorId, Long courseId, ReqCourseUpdateDto reqCourseUpdateDto) {
         log.info("[CourseService] 강의 수정 - creatorId: {}, courseId: {}", creatorId, courseId);
 
@@ -165,7 +170,9 @@ public class CourseService {
      * 강의 공개 (DRAFT → OPEN)
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
+     * @throws BusinessException 강의 없음(400), 공개 권한 없음(403), DRAFT 상태 아님(400)
      */
+    @Transactional
     public RespCourseDetailDto publishCourse(Long creatorId, Long courseId) {
         log.info("[CourseService] 강의 공개 - creatorId: {}, courseId: {}", creatorId, courseId);
 
@@ -196,7 +203,9 @@ public class CourseService {
      * 강의 마감 (OPEN → CLOSED)
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
+     * @throws BusinessException 강의 없음(400), 마감 권한 없음(403), OPEN 상태 아님(400)
      */
+    @Transactional
     public RespCourseDetailDto closeCourse(Long creatorId, Long courseId) {
         log.info("[CourseService] 강의 마감 - creatorId: {}, courseId: {}", creatorId, courseId);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
@@ -1,0 +1,32 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 사용자 서비스
+ * 사용자 관련 비즈니스 로직을 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserMapper userMapper;
+
+    /**
+     * 전체 사용자 목록 조회
+     */
+    public List<User> findUserList() {
+        log.info("[UserService] 전체 사용자 목록 조회");
+
+        return userMapper.selectUserList();
+    }
+}

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -12,4 +12,13 @@
          WHERE id = #{id}
     </select>
 
+    <!-- 전체 사용자 목록 조회 -->
+    <select id="selectUserList" resultType="User">
+        SELECT id
+             , name
+             , role
+          FROM users
+        ORDER BY id
+    </select>
+
 </mapper>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,17 +1,40 @@
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { AuthProvider, useAuth } from './context/AuthContext'
+import Layout from './components/Layout'
+import LoginPage from './pages/LoginPage'
 import CourseRegisterPage from './pages/CourseRegisterPage'
 import CourseListPage from './pages/CourseListPage'
 import CourseDetailPage from './pages/CourseDetailPage'
 
-function App() {
+/* 인증 여부에 따라 라우트 보호 및 공통 레이아웃 적용 */
+const PrivateRoute = ({ children }) => {
+    const { user } = useAuth();
+    
+    return user ? <Layout>{children}</Layout> : <Navigate to="/login" replace />;
+};
 
+/* CREATOR 권한 전용 라우트 */
+const CreatorRoute = ({ children }) => {
+    const { user } = useAuth();
+
+    if (!user) return <Navigate to="/login" replace />;
+    if (user.role !== 'CREATOR') return <Navigate to="/courses" replace />;
+
+    return <Layout>{children}</Layout>;
+};
+
+function App() {
     return (
-        <Routes>
-            <Route path="/courses" element={<CourseListPage />} />
-            <Route path="/courses/:courseId" element={<CourseDetailPage />} />
-            <Route path="/courses/new" element={<CourseRegisterPage />} />
-            <Route path="/courses/:courseId/edit" element={<CourseRegisterPage />} />
-        </Routes>
+        <AuthProvider>
+            <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/courses" element={<PrivateRoute><CourseListPage /></PrivateRoute>} />
+                <Route path="/courses/:courseId" element={<PrivateRoute><CourseDetailPage /></PrivateRoute>} />
+                <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
+                <Route path="/courses/:courseId/edit" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
+                <Route path="*" element={<Navigate to="/courses" replace />} />
+            </Routes>
+        </AuthProvider>
     )
 }
 

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -7,4 +7,15 @@ const instance = axios.create({
     },
 });
 
+/* 요청 인터셉터: localStorage에서 유저 정보를 읽어 X-User-Id 헤더 자동 추가 */
+instance.interceptors.request.use(config => {
+    const user = localStorage.getItem('user');
+
+    if (user) {
+        config.headers['X-User-Id'] = JSON.parse(user).id;
+    }
+    
+    return config;
+});
+
 export default instance;

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -1,0 +1,6 @@
+import instance from './axios';
+
+/* 전체 사용자 목록 조회 */
+export const getUserList = () => {
+    return instance.get('/api/users').then(res => res.data);
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,45 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const Header = () => {
+    const navigate = useNavigate();
+    const { user, logout } = useAuth();
+
+    /* 로그아웃 처리 */
+    const handleLogout = () => {
+        logout();
+        navigate('/login');
+    };
+
+    const roleLabel = (role) => role === 'CREATOR' ? '강사' : '수강생';
+
+    return (
+        <header className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm">
+            <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between">
+                <span
+                    onClick={() => navigate('/courses')}
+                    className="font-extrabold text-gray-900 cursor-pointer hover:text-blue-600 transition-colors"
+                >
+                    강의 플랫폼
+                </span>
+
+                <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2 text-sm text-gray-600">
+                        <span className="font-medium">{user?.name}</span>
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">
+                            {roleLabel(user?.role)}
+                        </span>
+                    </div>
+                    <button
+                        onClick={handleLogout}
+                        className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+                    >
+                        로그아웃
+                    </button>
+                </div>
+            </div>
+        </header>
+    );
+};
+
+export default Header;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,12 @@
+import Header from './Header';
+
+const Layout = ({ children }) => {
+    return (
+        <>
+            <Header />
+            <main>{children}</main>
+        </>
+    );
+};
+
+export default Layout;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+    /* localStorage에서 초기 유저 상태 복원 */
+    const [user, setUser] = useState(() => {
+        const saved = localStorage.getItem('user');
+        return saved ? JSON.parse(saved) : null;
+    });
+
+    /* 로그인: 선택한 유저를 전역 상태 및 localStorage에 저장 */
+    const login = (selectedUser) => {
+        localStorage.setItem('user', JSON.stringify(selectedUser));
+        setUser(selectedUser);
+    };
+
+    /* 로그아웃: 전역 상태 및 localStorage 초기화 */
+    const logout = () => {
+        localStorage.removeItem('user');
+        setUser(null);
+    };
+
+    return (
+        <AuthContext.Provider value={{ user, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { closeCourse, getCourseDetail, publishCourse } from '../api/course';
+import { useAuth } from '../context/AuthContext';
 
 const CourseDetailPage = () => {
     const { courseId } = useParams();
@@ -8,9 +9,10 @@ const CourseDetailPage = () => {
     const location = useLocation();
 
     const [course, setCourse] = useState(null);
+    const { user } = useAuth();
 
-    /* 임시 현재 사용자 (로그인 기능 구현 전) */
-    const currentUser = { id: 1, role: 'CREATOR' };
+    /* 현재 로그인한 사용자가 강의 소유자인지 여부 */
+    const isOwner = course?.creatorId === user?.id;
 
     useEffect(() => {
         /* 강의 상세 조회 */
@@ -39,7 +41,7 @@ const CourseDetailPage = () => {
         if (!window.confirm('강의를 공개하시겠습니까?')) return;
 
         try {
-            const result = await publishCourse(courseId, 1); // 임시 크리에이터 ID
+            const result = await publishCourse(courseId, user?.id);
             setCourse(result.data);
         } catch (err) {
             alert(err.response?.data?.message || '강의 공개에 실패했습니다.');
@@ -51,7 +53,7 @@ const CourseDetailPage = () => {
         if (!window.confirm('강의를 마감하시겠습니까?')) return;
 
         try {
-            const result = await closeCourse(courseId, 1); // 임시 크리에이터 ID
+            const result = await closeCourse(courseId, user?.id);
             setCourse(result.data);
         } catch (err) {
             alert(err.response?.data?.message || '강의 마감에 실패했습니다.');
@@ -64,7 +66,7 @@ const CourseDetailPage = () => {
         <div className="max-w-7xl mx-auto mt-10 p-6">
             {/* 상단 헤더 섹션 */}
             <div className="flex justify-end gap-3 mb-8 border-b pb-6">
-                {course.status === 'DRAFT' && (
+                {isOwner && course.status === 'DRAFT' && (
                     <button onClick={() => navigate(`/courses/${courseId}/edit`, { state: { fromSearch: location.state?.fromSearch } })}
                         className="px-4 py-2 bg-blue-600 text-white rounded-md font-semibold hover:bg-blue-700 cursor-pointer transition-all shadow-sm text-sm">
                         수정하기
@@ -155,7 +157,7 @@ const CourseDetailPage = () => {
                                     </div>
                                 </div>
 
-                                {currentUser.role === 'CREATOR' ? (
+                                {isOwner ? (
                                     <>
                                         {course.status === 'DRAFT' && (
                                             <button onClick={handlePublish}

--- a/frontend/src/pages/CourseListPage.jsx
+++ b/frontend/src/pages/CourseListPage.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { getCourseList } from '../api/course';
+import { useAuth } from '../context/AuthContext';
 
 const CourseListPage = () => {
     const navigate = useNavigate();
     const location = useLocation();
+    const { user } = useAuth();
     const [searchParams, setSearchParams] = useSearchParams();
     const [tempKeyword, setTempKeyword] = useState(searchParams.get('keyword') || '');
 
@@ -89,10 +91,12 @@ const CourseListPage = () => {
         <div className="max-w-7xl mx-auto mt-10 p-6">
             <div className="flex justify-between items-center mb-8">
                 <h1 className="text-3xl font-extrabold text-gray-900">전체 강의</h1>
-                <button onClick={() => navigate('/courses/new', { state: { fromSearch: location.search } })}
-                    className="px-5 py-2 bg-blue-600 text-white rounded-md font-semibold hover:bg-blue-700 transition-all cursor-pointer shadow-sm">
-                    강의 등록
-                </button>
+                {user?.role === 'CREATOR' && (
+                    <button onClick={() => navigate('/courses/new', { state: { fromSearch: location.search } })}
+                        className="px-5 py-2 bg-blue-600 text-white rounded-md font-semibold hover:bg-blue-700 transition-all cursor-pointer shadow-sm">
+                        강의 등록
+                    </button>
+                )}
             </div>
 
             {/* 검색 섹션 */}

--- a/frontend/src/pages/CourseRegisterPage.jsx
+++ b/frontend/src/pages/CourseRegisterPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { registerCourse, getCourseDetail, updateCourse } from '../api/course';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 /* 강의 등록/수정 페이지 */
 const CourseRegisterPage = () => {
@@ -8,6 +9,7 @@ const CourseRegisterPage = () => {
     const isEdit = !!courseId;
     const navigate = useNavigate();
     const location = useLocation();
+    const { user } = useAuth();
     const previousSearch = location.state?.fromSearch || '';
 
     /* 오늘 날짜 */
@@ -81,11 +83,11 @@ const CourseRegisterPage = () => {
 
         try {
             if (isEdit) {
-                await updateCourse(courseId, 1, form); // 임시 크리에이터 ID
+                await updateCourse(courseId, user?.id, form);
                 alert('강의 정보가 수정되었습니다!');
                 navigate(`/courses/${courseId}`, { state: { fromSearch: previousSearch } });
             } else {
-                const result = await registerCourse(1, form); // 임시 크리에이터 ID
+                const result = await registerCourse(user?.id, form);
                 alert('강의가 등록되었습니다!');
                 navigate(`/courses/${result.data.id}`, { state: { fromSearch: previousSearch } });
             }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getUserList } from '../api/user';
+import { useAuth } from '../context/AuthContext';
+
+const LoginPage = () => {
+    const navigate = useNavigate();
+    const { login } = useAuth();
+
+    /* 유저 목록 상태 */
+    const [users, setUsers] = useState([]);
+
+    /* 유저 목록 조회 */
+    useEffect(() => {
+        const fetchUserList = async () => {
+            try {
+                const result = await getUserList();
+                setUsers(result.data);
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
+        fetchUserList();
+    }, []);
+
+    /* 유저 선택 시 로그인 처리 */
+    const handleSelectUser = (user) => {
+        login(user);
+        navigate('/courses');
+    };
+
+    const roleLabel = (role) => role === 'CREATOR' ? '강사' : '수강생';
+    const roleStyle = (role) => role === 'CREATOR'
+        ? 'bg-blue-100 text-blue-700'
+        : 'bg-green-100 text-green-700';
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+            <div className="w-full max-w-md">
+                <div className="text-center mb-8">
+                    <h1 className="text-3xl font-extrabold text-gray-900 mb-2">로그인</h1>
+                    <p className="text-sm text-gray-500">테스트할 계정을 선택하세요</p>
+                </div>
+
+                <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+                    {users.map((user, index) => (
+                        <button
+                            key={user.id}
+                            onClick={() => handleSelectUser(user)}
+                            className={`w-full flex items-center justify-between px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer text-left ${index !== 0 ? 'border-t border-gray-100' : ''}`}
+                        >
+                            <div className="flex items-center gap-3">
+                                <div className="w-9 h-9 rounded-full bg-gray-100 flex items-center justify-center text-sm font-bold text-gray-500">
+                                    {user.name.charAt(0)}
+                                </div>
+                                <span className="font-medium text-gray-800">{user.name}</span>
+                            </div>
+                            <span className={`text-xs font-semibold px-2 py-1 rounded-full ${roleStyle(user.role)}`}>
+                                {roleLabel(user.role)}
+                            </span>
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default LoginPage;


### PR DESCRIPTION
## 작업 내용                                                                                                                                                                      
  - 사용자 목록 조회 API 구현 (UserController, UserService, UserMapper)
  - GET /api/users 엔드포인트 추가 (더미 유저 목록 조회)
  - CourseService 전체 Transactional 정리
  - GlobalExceptionHandler HttpMessageNotReadableException 핸들러 추가
  - AuthContext 추가 및 LoginPage 구현 (더미 유저 선택 방식)
  - axios 인터셉터로 X-User-Id 헤더 자동 추가
  - Header/Layout 공통 컴포넌트 추가 (유저 정보 + 로그아웃)
  - PrivateRoute/CreatorRoute로 라우트 권한 보호

  ## 구현 시 고려한 점
  - localStorage에 유저 정보 저장해 새로고침 시 로그인 상태 유지
  - axios 인터셉터 도입으로 X-User-Id 헤더 중복 코드 제거
  - CREATOR 전용 라우트 분리로 URL 직접 접근 차단
  - 강의 상세에서 본인 강의일 때만 수정/공개/마감 버튼 노출

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - http://localhost:5173 접속 후 유저 선택 로그인 확인

  ## 연관 이슈
  Closes #10