### PR TITLE
[feat] 수강 신청 기능 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
@@ -61,13 +61,14 @@ public class CourseController {
     /**
      * 강의 상세 조회
      * GET /api/courses/{courseId}
+     * @param userId 사용자 ID (헤더로 전달, 수강 신청 여부 확인용)
      * @param courseId 강의 ID
      */
     @GetMapping("/{courseId}")
-    public ResponseEntity<ApiResponse<RespCourseDetailDto>> getCourseDetail(@PathVariable Long courseId) {
+    public ResponseEntity<ApiResponse<RespCourseDetailDto>> getCourseDetail(@RequestHeader("X-User-Id") Long userId, @PathVariable Long courseId) {
         log.debug("[CourseController] 강의 상세 조회 요청 - courseId: {}", courseId);
 
-        RespCourseDetailDto result = courseService.findCourseById(courseId);
+        RespCourseDetailDto result = courseService.findCourseById(courseId, userId);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
@@ -6,6 +6,7 @@ import com.yujin.course_enrollment.dto.req.ReqCourseUpdateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentCreatorDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.CourseService;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
 
 /**
  * 강의 컨트롤러
@@ -115,6 +117,35 @@ public class CourseController {
         log.debug("[CourseController] 강의 마감 요청 - creatorId: {}, courseId: {}", creatorId, courseId);
 
         RespCourseDetailDto result = courseService.closeCourse(creatorId, courseId);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    /**
+     * 나의 강의 목록 조회 (CREATOR 전용)
+     * GET /api/courses/my
+     * @param creatorId 크리에이터 ID (헤더로 전달)
+     */
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<RespCourseListDto>>> getMyCourses(@RequestHeader("X-User-Id") Long creatorId) {
+        log.debug("[CourseController] 나의 강의 목록 조회 요청 - creatorId: {}", creatorId);
+
+        List<RespCourseListDto> result = courseService.findMyCourses(creatorId);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    /**
+     * 강의별 수강생 목록 조회 (CREATOR 전용)
+     * GET /api/courses/{courseId}/enrollments
+     * @param creatorId 크리에이터 ID (헤더로 전달)
+     * @param courseId 강의 ID
+     */
+    @GetMapping("/{courseId}/enrollments")
+    public ResponseEntity<ApiResponse<List<RespEnrollmentCreatorDto>>> getCourseEnrollments(@RequestHeader("X-User-Id") Long creatorId, @PathVariable Long courseId) {
+        log.debug("[CourseController] 강의별 수강생 목록 조회 요청 - creatorId: {}, courseId: {}", creatorId, courseId);
+
+        List<RespEnrollmentCreatorDto> result = courseService.findCourseEnrollments(creatorId, courseId);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.EnrollmentService;
 import jakarta.validation.Valid;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 수강 신청 컨트롤러
@@ -33,6 +36,50 @@ public class EnrollmentController {
         log.debug("[EnrollmentController] 수강 신청 요청 - userId: {}, courseId: {}", userId, reqEnrollmentCreateDto.getCourseId());
 
         RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, reqEnrollmentCreateDto);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    /**
+     * 수강 신청 목록 조회
+     * GET /api/enrollments/me
+     * @param userId 사용자 ID (헤더로 전달)
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<RespEnrollmentStudentDto>>> getMyEnrollments(@RequestHeader("X-User-Id") Long userId) {
+        log.debug("[EnrollmentController] 수강 신청 목록 조회 요청 - userId: {}", userId);
+
+        List<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    /**
+     * 결제 요청 (PENDING → CONFIRMED)
+     * PATCH /api/enrollments/{enrollmentId}/confirm
+     * @param userId 사용자 ID (헤더로 전달)
+     * @param enrollmentId 수강 신청 ID
+     */
+    @PatchMapping("/{enrollmentId}/confirm")
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> confirmEnrollment(@RequestHeader("X-User-Id") Long userId, @PathVariable Long enrollmentId) {
+        log.debug("[EnrollmentController] 결제 요청 - userId: {}, enrollmentId: {}", userId, enrollmentId);
+
+        RespEnrollmentDto result = enrollmentService.confirmEnrollment(userId, enrollmentId);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    /**
+     * 수강 취소 (PENDING, CONFIRMED → CANCELLED)
+     * PATCH /api/enrollments/{enrollmentId}/cancel
+     * @param userId 사용자 ID (헤더로 전달)
+     * @param enrollmentId 수강 신청 ID
+     */
+    @PatchMapping("/{enrollmentId}/cancel")
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> cancelEnrollment(@RequestHeader("X-User-Id") Long userId, @PathVariable Long enrollmentId) {
+        log.debug("[EnrollmentController] 수강 취소 요청 - userId: {}, enrollmentId: {}", userId, enrollmentId);
+
+        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -1,0 +1,39 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.EnrollmentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 수강 신청 컨트롤러
+ * 수강 신청 등록 등 수강 신청 관련 HTTP 요청을 처리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/enrollments")
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    /**
+     * 수강 신청
+     * POST /api/enrollments
+     * @param userId 사용자 ID (헤더로 전달)
+     * @param reqEnrollmentCreateDto 수강 신청 요청 DTO
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> createEnrollment(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqEnrollmentCreateDto reqEnrollmentCreateDto) {
+        log.debug("[EnrollmentController] 수강 신청 요청 - userId: {}, courseId: {}", userId, reqEnrollmentCreateDto.getCourseId());
+
+        RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, reqEnrollmentCreateDto);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -41,13 +41,13 @@ public class EnrollmentController {
     }
 
     /**
-     * 수강 신청 목록 조회
+     * 나의 수강 신청 목록 조회
      * GET /api/enrollments/me
      * @param userId 사용자 ID (헤더로 전달)
      */
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<RespEnrollmentStudentDto>>> getMyEnrollments(@RequestHeader("X-User-Id") Long userId) {
-        log.debug("[EnrollmentController] 수강 신청 목록 조회 요청 - userId: {}", userId);
+        log.debug("[EnrollmentController] 나의 수강 신청 목록 조회 요청 - userId: {}", userId);
 
         List<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqCourseCreateDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqCourseCreateDto.java
@@ -46,6 +46,7 @@ public class ReqCourseCreateDto {
                 .capacity(this.capacity)
                 .startDate(this.startDate)
                 .endDate(this.endDate)
+                .status("DRAFT")
                 .build();
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentCreateDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentCreateDto.java
@@ -1,0 +1,26 @@
+package com.yujin.course_enrollment.dto.req;
+
+import com.yujin.course_enrollment.entity.Enrollment;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 수강 신청 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqEnrollmentCreateDto {
+    @NotNull(message = "강의 ID는 필수입니다.")
+    private Long courseId;
+
+    /* DTO → Enrollment 엔티티 변환 */
+    public Enrollment toEntity(Long userId) {
+        return Enrollment.builder()
+                .userId(userId)
+                .courseId(this.courseId)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentCreateDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentCreateDto.java
@@ -21,6 +21,7 @@ public class ReqEnrollmentCreateDto {
         return Enrollment.builder()
                 .userId(userId)
                 .courseId(this.courseId)
+                .status("PENDING")
                 .build();
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespCourseDetailDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespCourseDetailDto.java
@@ -29,4 +29,5 @@ public class RespCourseDetailDto {
     private LocalDate endDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean enrolled;
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentCreatorDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentCreatorDto.java
@@ -1,0 +1,24 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 강의별 수강생 목록 응답 DTO
+ * 강사가 본인 강의의 수강생 목록 조회 시 사용
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class RespEnrollmentCreatorDto {
+    private Long id;
+    private Long userId;
+    private String userName;
+    private String status;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentDto.java
@@ -1,0 +1,40 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import com.yujin.course_enrollment.entity.Enrollment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 수강 신청 응답 DTO
+ * 수강 신청/확정/취소 공통 응답
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class RespEnrollmentDto {
+    private Long id;
+    private Long userId;
+    private Long courseId;
+    private String courseTitle;
+    private String status;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private LocalDateTime createdAt;
+
+    /* Enrollment 엔티티 + 강의 제목 → 응답 DTO 변환 */
+    public static RespEnrollmentDto of(Enrollment enrollment, String courseTitle) {
+        return RespEnrollmentDto.builder()
+                .id(enrollment.getId())
+                .userId(enrollment.getUserId())
+                .courseId(enrollment.getCourseId())
+                .courseTitle(courseTitle)
+                .status(enrollment.getStatus())
+                .confirmedAt(enrollment.getConfirmedAt())
+                .cancelledAt(enrollment.getCancelledAt())
+                .createdAt(enrollment.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentStudentDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentStudentDto.java
@@ -1,0 +1,29 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 수강 신청 목록 응답 DTO
+ * 수강 신청 정보와 강의 요약 정보를 함께 반환
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class RespEnrollmentStudentDto {
+    private Long id;
+    private Long courseId;
+    private String courseTitle;
+    private String courseStatus;
+    private int price;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String status;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
@@ -25,4 +25,22 @@ public class Enrollment {
     private LocalDateTime cancelledAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    /* 결제 확정 상태로 변경할 엔티티 생성 */
+    public static Enrollment ofConfirm(Long id) {
+        return Enrollment.builder()
+                .id(id)
+                .status("CONFIRMED")
+                .confirmedAt(LocalDateTime.now())
+                .build();
+    }
+
+    /* 취소 상태로 변경할 엔티티 생성 */
+    public static Enrollment ofCancel(Long id) {
+        return Enrollment.builder()
+                .id(id)
+                .status("CANCELLED")
+                .cancelledAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
@@ -1,0 +1,28 @@
+package com.yujin.course_enrollment.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 수강 신청 엔티티
+ * 사용자가 신청한 수강 신청 정보를 담는 객체
+ * 상태: PENDING(신청 완료, 결제 대기) → CONFIRMED(결제 완료, 수강 확정) → CANCELLED(취소됨)
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Enrollment {
+    private Long id;
+    private Long userId;
+    private Long courseId;
+    private String status;
+    private LocalDateTime confirmedAt;
+    private LocalDateTime cancelledAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -36,5 +36,8 @@ public interface CourseMapper {
     void updateCourseStatus(Course course);
 
     /* 수강 인원 증가 (정원 미만일 때만, 반환값: 업데이트된 행 수) */
-    int incrementEnrolledCount(Long courseId);
+    int updateCourseEnrolledCountPlus(Long courseId);
+
+    /* 수강 인원 감소 */
+    void updateCourseEnrolledCountMinus(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -40,4 +40,7 @@ public interface CourseMapper {
 
     /* 수강 인원 감소 */
     void updateCourseEnrolledCountMinus(Long courseId);
+
+    /* 나의 강의 목록 조회 (CREATOR 전용) */
+    List<RespCourseListDto> selectCourseListByCreatorId(Long creatorId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -34,4 +34,7 @@ public interface CourseMapper {
 
     /* 강의 상태 변경 */
     void updateCourseStatus(Course course);
+
+    /* 수강 인원 증가 (정원 미만일 때만, 반환값: 업데이트된 행 수) */
+    int incrementEnrolledCount(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentCreatorDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
 import com.yujin.course_enrollment.entity.Enrollment;
 import org.apache.ibatis.annotations.Mapper;
@@ -25,6 +26,9 @@ public interface EnrollmentMapper {
     /* 수강 신청 상태 변경 */
     void updateEnrollmentStatus(Enrollment enrollment);
 
-    /* 수강 신청 목록 조회 */
+    /* 나의 수강 신청 목록 조회 */
     List<RespEnrollmentStudentDto> selectEnrollmentListByUserId(Long userId);
+
+    /* 강의별 수강생 목록 조회 (CREATOR 전용) */
+    List<RespEnrollmentCreatorDto> selectEnrollmentListByCourseId(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -1,0 +1,24 @@
+package com.yujin.course_enrollment.mapper;
+
+import com.yujin.course_enrollment.entity.Enrollment;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * 수강 신청 Mapper 인터페이스
+ * EnrollmentMapper.xml과 매핑되어 수강 신청 관련 DB 접근을 담당
+ */
+@Mapper
+public interface EnrollmentMapper {
+    /* 수강 신청 등록 */
+    void insertEnrollment(Enrollment enrollment);
+
+    /* 수강 신청 단건 조회 */
+    Enrollment selectEnrollmentById(Long id);
+
+    /* 사용자-강의 수강 신청 조회 (중복 신청 검증용) */
+    Enrollment selectEnrollmentByUserIdAndCourseId(@Param("userId") Long userId, @Param("courseId") Long courseId);
+
+    /* 수강 신청 상태 변경 */
+    void updateEnrollmentStatus(Enrollment enrollment);
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -1,8 +1,11 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
 import com.yujin.course_enrollment.entity.Enrollment;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 /**
  * 수강 신청 Mapper 인터페이스
@@ -21,4 +24,7 @@ public interface EnrollmentMapper {
 
     /* 수강 신청 상태 변경 */
     void updateEnrollmentStatus(Enrollment enrollment);
+
+    /* 수강 신청 목록 조회 */
+    List<RespEnrollmentStudentDto> selectEnrollmentListByUserId(Long userId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -6,6 +6,7 @@ import com.yujin.course_enrollment.dto.req.ReqCourseUpdateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentCreatorDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.User;
@@ -237,5 +238,38 @@ public class CourseService {
         log.info("[CourseService] 강의 마감 완료 - courseId: {}", courseId);
 
         return courseMapper.selectCourseDetailById(courseId);
+    }
+
+    /**
+     * 강의 목록 조회 (CREATOR 전용)
+     * @param creatorId 크리에이터 ID
+     */
+    public List<RespCourseListDto> findMyCourses(Long creatorId) {
+        log.info("[CourseService] 나의 강의 목록 조회 - creatorId: {}", creatorId);
+
+        return courseMapper.selectCourseListByCreatorId(creatorId);
+    }
+
+    /**
+     * 강의별 수강생 목록 조회 (CREATOR 전용)
+     * @param creatorId 크리에이터 ID
+     * @param courseId 강의 ID
+     * @throws BusinessException 강의 없음(400), 조회 권한 없음(403)
+     */
+    public List<RespEnrollmentCreatorDto> findCourseEnrollments(Long creatorId, Long courseId) {
+        log.info("[CourseService] 강의별 수강생 목록 조회 - creatorId: {}, courseId: {}", creatorId, courseId);
+
+        Course course = courseMapper.selectCourseById(courseId);
+        if (course == null) {
+            log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
+        }
+
+        if (!course.getCreatorId().equals(creatorId)) {
+            log.warn("[CourseService] 조회 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
+            throw new BusinessException(HttpStatus.FORBIDDEN, "본인의 강의만 조회할 수 있습니다.");
+        }
+
+        return enrollmentMapper.selectEnrollmentListByCourseId(courseId);
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -123,7 +123,7 @@ public class CourseService {
         }
 
         Enrollment enrollment = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
-        course.setEnrolled(enrollment != null);
+        course.setEnrolled(enrollment != null && !"CANCELLED".equals(enrollment.getStatus()));
 
         log.info("[CourseService] 강의 상세 조회 완료 - courseId: {}", courseId);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -10,7 +10,9 @@ import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class CourseService {
 
     private final CourseMapper courseMapper;
     private final UserMapper userMapper;
+    private final EnrollmentMapper enrollmentMapper;
 
     /**
      * 강의 등록
@@ -107,9 +110,10 @@ public class CourseService {
     /**
      * 강의 상세 조회
      * @param courseId 강의 ID
+     * @param userId 조회하는 사용자 ID (수강 신청 여부 확인용)
      * @throws BusinessException 강의 없음(400)
      */
-    public RespCourseDetailDto findCourseById(Long courseId) {
+    public RespCourseDetailDto findCourseById(Long courseId, Long userId) {
         log.info("[CourseService] 강의 상세 조회 - courseId: {}", courseId);
 
         RespCourseDetailDto course = courseMapper.selectCourseDetailById(courseId);
@@ -117,6 +121,9 @@ public class CourseService {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
+
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+        course.setEnrolled(enrollment != null);
 
         log.info("[CourseService] 강의 상세 조회 완료 - courseId: {}", courseId);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.User;
@@ -14,6 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 수강 신청 서비스
@@ -67,9 +71,9 @@ public class EnrollmentService {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "모집 중인 강의만 신청할 수 있습니다.");
         }
 
-        // 중복 신청 확인
+        // 중복 신청 확인 (CANCELLED 상태는 재신청 허용)
         Enrollment existing = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
-        if (existing != null) {
+        if (existing != null && !"CANCELLED".equals(existing.getStatus())) {
             log.warn("[EnrollmentService] 중복 신청 - userId: {}, courseId: {}", userId, courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
         }
@@ -84,15 +88,115 @@ public class EnrollmentService {
         enrollmentMapper.insertEnrollment(enrollment);
 
         // 수강 인원 증가 (0이면 동시 신청으로 정원 초과)
-        int updated = courseMapper.incrementEnrolledCount(courseId);
+        int updated = courseMapper.updateCourseEnrolledCountPlus(courseId);
         if (updated == 0) {
             log.warn("[EnrollmentService] 정원 초과 (동시 신청) - courseId: {}", courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 정원이 초과되었습니다.");
         }
 
-        log.info("[EnrollmentService] 수강 신청 완료 - enrollmentId: {}", enrollment.getId());
+        log.info("[EnrollmentService] 수강 신청 완료 - userId: {}, courseId: {}", userId, courseId);
 
-        Enrollment saved = enrollmentMapper.selectEnrollmentById(enrollment.getId());
+        Enrollment saved = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+
+        return RespEnrollmentDto.of(saved, course.getTitle());
+    }
+
+    /**
+     * 수강 신청 목록 조회
+     * @param userId 사용자 ID
+     */
+    public List<RespEnrollmentStudentDto> findMyEnrollments(Long userId) {
+        log.info("[EnrollmentService] 수강 신청 목록 조회 - userId: {}", userId);
+
+        return enrollmentMapper.selectEnrollmentListByUserId(userId);
+    }
+
+    /**
+     * 결제 요청 (PENDING → CONFIRMED)
+     * @param userId 사용자 ID
+     * @param enrollmentId 수강 신청 ID
+     * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), PENDING 상태 아님(400)
+     */
+    @Transactional
+    public RespEnrollmentDto confirmEnrollment(Long userId, Long enrollmentId) {
+        log.info("[EnrollmentService] 결제 요청 - userId: {}, enrollmentId: {}", userId, enrollmentId);
+
+        // 수강 신청 존재 여부 확인
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentById(enrollmentId);
+        if (enrollment == null) {
+            log.warn("[EnrollmentService] 수강 신청 없음 - enrollmentId: {}", enrollmentId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 수강 신청입니다.");
+        }
+
+        // 본인 신청 확인
+        if (!enrollment.getUserId().equals(userId)) {
+            log.warn("[EnrollmentService] 본인 신청 아님 - userId: {}, enrollmentId: {}", userId, enrollmentId);
+            throw new BusinessException(HttpStatus.FORBIDDEN, "본인의 수강 신청만 결제할 수 있습니다.");
+        }
+
+        // PENDING 상태 확인
+        if (!"PENDING".equals(enrollment.getStatus())) {
+            log.warn("[EnrollmentService] PENDING 상태 아님 - enrollmentId: {}, status: {}", enrollmentId, enrollment.getStatus());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "PENDING 상태의 수강 신청만 결제할 수 있습니다.");
+        }
+
+        enrollmentMapper.updateEnrollmentStatus(Enrollment.ofConfirm(enrollmentId));
+
+        log.info("[EnrollmentService] 결제 요청 완료 - enrollmentId: {}", enrollmentId);
+
+        Course course = courseMapper.selectCourseById(enrollment.getCourseId());
+
+        Enrollment saved = enrollmentMapper.selectEnrollmentById(enrollmentId);
+
+        return RespEnrollmentDto.of(saved, course.getTitle());
+    }
+
+    /**
+     * 수강 취소 (PENDING, CONFIRMED → CANCELLED)
+     * @param userId 사용자 ID
+     * @param enrollmentId 수강 신청 ID
+     * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), 이미 취소됨(400), CONFIRMED 7일 초과(400)
+     */
+    @Transactional
+    public RespEnrollmentDto cancelEnrollment(Long userId, Long enrollmentId) {
+        log.info("[EnrollmentService] 수강 취소 - userId: {}, enrollmentId: {}", userId, enrollmentId);
+
+        // 수강 신청 존재 여부 확인
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentById(enrollmentId);
+        if (enrollment == null) {
+            log.warn("[EnrollmentService] 수강 신청 없음 - enrollmentId: {}", enrollmentId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 수강 신청입니다.");
+        }
+
+        // 본인 신청 확인
+        if (!enrollment.getUserId().equals(userId)) {
+            log.warn("[EnrollmentService] 본인 신청 아님 - userId: {}, enrollmentId: {}", userId, enrollmentId);
+            throw new BusinessException(HttpStatus.FORBIDDEN, "본인의 수강 신청만 취소할 수 있습니다.");
+        }
+
+        // 이미 취소됨 확인
+        if ("CANCELLED".equals(enrollment.getStatus())) {
+            log.warn("[EnrollmentService] 이미 취소됨 - enrollmentId: {}", enrollmentId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 취소된 수강 신청입니다.");
+        }
+
+        // CONFIRMED 상태 취소 기간 확인 (확정 후 7일 이내)
+        if ("CONFIRMED".equals(enrollment.getStatus())) {
+            if (enrollment.getConfirmedAt().plusDays(7).isBefore(LocalDateTime.now())) {
+                log.warn("[EnrollmentService] 취소 기간 초과 - enrollmentId: {}, confirmedAt: {}", enrollmentId, enrollment.getConfirmedAt());
+                throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 확정 후 7일이 지나 취소할 수 없습니다.");
+            }
+        }
+
+        enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(enrollmentId));
+
+        courseMapper.updateCourseEnrolledCountMinus(enrollment.getCourseId());
+
+        log.info("[EnrollmentService] 수강 취소 완료 - enrollmentId: {}", enrollmentId);
+
+        Course course = courseMapper.selectCourseById(enrollment.getCourseId());
+
+        Enrollment saved = enrollmentMapper.selectEnrollmentById(enrollmentId);
 
         return RespEnrollmentDto.of(saved, course.getTitle());
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -1,0 +1,99 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
+import com.yujin.course_enrollment.entity.Course;
+import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 수강 신청 서비스
+ * 수강 신청 등록 등 수강 신청 관련 비즈니스 로직을 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentService {
+
+    private final EnrollmentMapper enrollmentMapper;
+    private final CourseMapper courseMapper;
+    private final UserMapper userMapper;
+
+    /**
+     * 수강 신청
+     * @param userId 신청하는 사용자 ID
+     * @param reqEnrollmentCreateDto 수강 신청 요청 DTO
+     * @throws BusinessException 사용자 없음(400), 강의 없음(400), 본인 강의 신청(403), 모집 중 아님(400), 중복 신청(400), 정원 초과(400)
+     */
+    @Transactional
+    public RespEnrollmentDto registerEnrollment(Long userId, ReqEnrollmentCreateDto reqEnrollmentCreateDto) {
+        log.info("[EnrollmentService] 수강 신청 - userId: {}, courseId: {}", userId, reqEnrollmentCreateDto.getCourseId());
+
+        // 사용자 존재 여부 확인
+        User user = userMapper.selectUserById(userId);
+        if (user == null) {
+            log.warn("[EnrollmentService] 존재하지 않는 사용자 - userId: {}", userId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다.");
+        }
+
+        Long courseId = reqEnrollmentCreateDto.getCourseId();
+
+        // 강의 존재 여부 확인
+        Course course = courseMapper.selectCourseById(courseId);
+        if (course == null) {
+            log.warn("[EnrollmentService] 강의 없음 - courseId: {}", courseId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
+        }
+
+        // 본인 강의 신청 불가
+        if (course.getCreatorId().equals(userId)) {
+            log.warn("[EnrollmentService] 본인 강의 신청 시도 - userId: {}, courseId: {}", userId, courseId);
+            throw new BusinessException(HttpStatus.FORBIDDEN, "본인이 개설한 강의는 신청할 수 없습니다.");
+        }
+
+        // 강의 모집 중 확인
+        if (!"OPEN".equals(course.getStatus())) {
+            log.warn("[EnrollmentService] 모집 중이 아님 - courseId: {}, status: {}", courseId, course.getStatus());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "모집 중인 강의만 신청할 수 있습니다.");
+        }
+
+        // 중복 신청 확인
+        Enrollment existing = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+        if (existing != null) {
+            log.warn("[EnrollmentService] 중복 신청 - userId: {}, courseId: {}", userId, courseId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
+        }
+
+        // 정원 초과 확인
+        if (course.getEnrolledCount() >= course.getCapacity()) {
+            log.warn("[EnrollmentService] 정원 초과 - courseId: {}, enrolledCount: {}, capacity: {}", courseId, course.getEnrolledCount(), course.getCapacity());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 정원이 초과되었습니다.");
+        }
+
+        Enrollment enrollment = reqEnrollmentCreateDto.toEntity(userId);
+        enrollmentMapper.insertEnrollment(enrollment);
+
+        // 수강 인원 증가 (0이면 동시 신청으로 정원 초과)
+        int updated = courseMapper.incrementEnrolledCount(courseId);
+        if (updated == 0) {
+            log.warn("[EnrollmentService] 정원 초과 (동시 신청) - courseId: {}", courseId);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 정원이 초과되었습니다.");
+        }
+
+        log.info("[EnrollmentService] 수강 신청 완료 - enrollmentId: {}", enrollment.getId());
+
+        Enrollment saved = enrollmentMapper.selectEnrollmentById(enrollment.getId());
+
+        return RespEnrollmentDto.of(saved, course.getTitle());
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -102,11 +102,11 @@ public class EnrollmentService {
     }
 
     /**
-     * 수강 신청 목록 조회
+     * 나의 수강 신청 목록 조회
      * @param userId 사용자 ID
      */
     public List<RespEnrollmentStudentDto> findMyEnrollments(Long userId) {
-        log.info("[EnrollmentService] 수강 신청 목록 조회 - userId: {}", userId);
+        log.info("[EnrollmentService] 나의 수강 신청 목록 조회 - userId: {}", userId);
 
         return enrollmentMapper.selectEnrollmentListByUserId(userId);
     }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -24,7 +24,7 @@ spring:
 
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml
-  type-aliases-package: com.yujin.course_enrollment.entity, com.yujin.course_enrollment.dto.resp, , com.yujin.course_enrollment.dto.req
+  type-aliases-package: com.yujin.course_enrollment.entity, com.yujin.course_enrollment.dto.resp, com.yujin.course_enrollment.dto.req
   configuration:
     map-underscore-to-camel-case: true
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -27,7 +27,7 @@
     </insert>
 
     <!-- 강의 단건 조회 -->
-    <select id="selectCourseById" parameterType="long" resultType="Course">
+    <select id="selectCourseById" parameterType="Long" resultType="Course">
         SELECT id
              , creator_id
              , title
@@ -117,7 +117,7 @@
     </select>
 
     <!-- 강의 상세 조회 -->
-    <select id="selectCourseDetailById" parameterType="long" resultType="RespCourseDetailDto">
+    <select id="selectCourseDetailById" parameterType="Long" resultType="RespCourseDetailDto">
         SELECT c.id
              , c.creator_id
              , u.name AS creatorName
@@ -156,15 +156,36 @@
     </update>
 
     <!-- 수강 인원 증가 (정원 미만일 때만) -->
-    <update id="updateCourseEnrolledCountPlus" parameterType="long">
+    <update id="updateCourseEnrolledCountPlus" parameterType="Long">
         UPDATE courses
            SET enrolled_count = enrolled_count + 1
          WHERE id = #{courseId}
            AND <![CDATA[ enrolled_count < capacity ]]>
     </update>
 
+    <!-- 나의 강의 목록 조회 (CREATOR 전용) -->
+    <select id="selectCourseListByCreatorId" parameterType="Long" resultType="RespCourseListDto">
+        SELECT c.id
+             , c.creator_id
+             , u.name AS creatorName
+             , c.title
+             , c.description
+             , c.price
+             , c.capacity
+             , c.enrolled_count
+             , c.status
+             , c.start_date
+             , c.end_date
+             , c.created_at
+             , c.updated_at
+          FROM courses c
+          JOIN users u ON c.creator_id = u.id
+         WHERE c.creator_id = #{creatorId}
+        ORDER BY c.created_at DESC
+    </select>
+
     <!-- 수강 인원 감소 -->
-    <update id="updateCourseEnrolledCountMinus" parameterType="long">
+    <update id="updateCourseEnrolledCountMinus" parameterType="Long">
         UPDATE courses
            SET enrolled_count = enrolled_count - 1
          WHERE id = #{courseId}

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -20,7 +20,7 @@
               , #{description}
               , #{price}
               , #{capacity}
-              , 'DRAFT'
+              , #{status}
               , #{startDate}
               , #{endDate}
         )
@@ -156,11 +156,19 @@
     </update>
 
     <!-- 수강 인원 증가 (정원 미만일 때만) -->
-    <update id="incrementEnrolledCount" parameterType="long">
+    <update id="updateCourseEnrolledCountPlus" parameterType="long">
         UPDATE courses
            SET enrolled_count = enrolled_count + 1
          WHERE id = #{courseId}
            AND <![CDATA[ enrolled_count < capacity ]]>
+    </update>
+
+    <!-- 수강 인원 감소 -->
+    <update id="updateCourseEnrolledCountMinus" parameterType="long">
+        UPDATE courses
+           SET enrolled_count = enrolled_count - 1
+         WHERE id = #{courseId}
+           AND enrolled_count > 0
     </update>
 
 </mapper>

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -155,4 +155,12 @@
          WHERE id = #{id}
     </update>
 
+    <!-- 수강 인원 증가 (정원 미만일 때만) -->
+    <update id="incrementEnrolledCount" parameterType="long">
+        UPDATE courses
+           SET enrolled_count = enrolled_count + 1
+         WHERE id = #{courseId}
+           AND <![CDATA[ enrolled_count < capacity ]]>
+    </update>
+
 </mapper>

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -21,7 +21,7 @@
     </insert>
 
     <!-- 수강 신청 단건 조회 -->
-    <select id="selectEnrollmentById" parameterType="long" resultType="Enrollment">
+    <select id="selectEnrollmentById" parameterType="Long" resultType="Enrollment">
         SELECT id
              , user_id
              , course_id
@@ -58,7 +58,22 @@
          WHERE id = #{id}
     </update>
 
-    <!-- 수강 신청 목록 조회 -->
+    <!-- 강의별 수강생 목록 조회 (CREATOR 전용) -->
+    <select id="selectEnrollmentListByCourseId" parameterType="Long" resultType="RespEnrollmentCreatorDto">
+        SELECT e.id
+             , e.user_id
+             , u.name AS userName
+             , e.status
+             , e.confirmed_at
+             , e.cancelled_at
+             , e.created_at
+          FROM enrollments e
+          JOIN users u ON e.user_id = u.id
+         WHERE e.course_id = #{courseId}
+        ORDER BY e.created_at DESC
+    </select>
+
+    <!-- 나의 수강 신청 목록 조회 -->
     <select id="selectEnrollmentListByUserId" parameterType="long" resultType="RespEnrollmentStudentDto">
         SELECT e.id
              , e.course_id
@@ -74,7 +89,7 @@
           FROM enrollments e
           JOIN courses c ON e.course_id = c.id
          WHERE e.user_id = #{userId}
-         ORDER BY e.created_at DESC
+        ORDER BY e.created_at DESC
     </select>
 
 </mapper>

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.yujin.course_enrollment.mapper.EnrollmentMapper">
 
-    <!-- 수강 신청 등록 -->
+    <!-- 수강 신청 등록 (취소 후 재신청 시 ON DUPLICATE KEY UPDATE로 PENDING 초기화) -->
     <insert id="insertEnrollment" parameterType="Enrollment" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO enrollments (
                 user_id
@@ -12,8 +12,12 @@
         ) VALUES (
                 #{userId}
               , #{courseId}
-              , 'PENDING'
+              , #{status}
         )
+        ON DUPLICATE KEY UPDATE
+              status = #{status}
+            , confirmed_at = NULL
+            , cancelled_at = NULL
     </insert>
 
     <!-- 수강 신청 단건 조회 -->
@@ -41,17 +45,36 @@
              , created_at
              , updated_at
           FROM enrollments
-         WHERE user_id   = #{userId}
+         WHERE user_id = #{userId}
            AND course_id = #{courseId}
     </select>
 
     <!-- 수강 신청 상태 변경 -->
     <update id="updateEnrollmentStatus" parameterType="Enrollment">
         UPDATE enrollments
-           SET status       = #{status}
+           SET status = #{status}
              , confirmed_at = #{confirmedAt}
              , cancelled_at = #{cancelledAt}
          WHERE id = #{id}
     </update>
+
+    <!-- 수강 신청 목록 조회 -->
+    <select id="selectEnrollmentListByUserId" parameterType="long" resultType="RespEnrollmentStudentDto">
+        SELECT e.id
+             , e.course_id
+             , c.title AS courseTitle
+             , c.status AS courseStatus
+             , c.price
+             , c.start_date
+             , c.end_date
+             , e.status
+             , e.confirmed_at
+             , e.cancelled_at
+             , e.created_at
+          FROM enrollments e
+          JOIN courses c ON e.course_id = c.id
+         WHERE e.user_id = #{userId}
+         ORDER BY e.created_at DESC
+    </select>
 
 </mapper>

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yujin.course_enrollment.mapper.EnrollmentMapper">
+
+    <!-- 수강 신청 등록 -->
+    <insert id="insertEnrollment" parameterType="Enrollment" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO enrollments (
+                user_id
+              , course_id
+              , status
+        ) VALUES (
+                #{userId}
+              , #{courseId}
+              , 'PENDING'
+        )
+    </insert>
+
+    <!-- 수강 신청 단건 조회 -->
+    <select id="selectEnrollmentById" parameterType="long" resultType="Enrollment">
+        SELECT id
+             , user_id
+             , course_id
+             , status
+             , confirmed_at
+             , cancelled_at
+             , created_at
+             , updated_at
+          FROM enrollments
+         WHERE id = #{id}
+    </select>
+
+    <!-- 사용자-강의 수강 신청 조회 -->
+    <select id="selectEnrollmentByUserIdAndCourseId" resultType="Enrollment">
+        SELECT id
+             , user_id
+             , course_id
+             , status
+             , confirmed_at
+             , cancelled_at
+             , created_at
+             , updated_at
+          FROM enrollments
+         WHERE user_id   = #{userId}
+           AND course_id = #{courseId}
+    </select>
+
+    <!-- 수강 신청 상태 변경 -->
+    <update id="updateEnrollmentStatus" parameterType="Enrollment">
+        UPDATE enrollments
+           SET status       = #{status}
+             , confirmed_at = #{confirmedAt}
+             , cancelled_at = #{cancelledAt}
+         WHERE id = #{id}
+    </update>
+
+</mapper>

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -4,7 +4,7 @@
 <mapper namespace="com.yujin.course_enrollment.mapper.UserMapper">
 
     <!-- 사용자 단건 조회 -->
-    <select id="selectUserById" parameterType="long" resultType="User">
+    <select id="selectUserById" parameterType="Long" resultType="User">
         SELECT id
              , name
              , role

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -37,5 +37,5 @@ CREATE TABLE enrollments (
                              FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE RESTRICT
 );
 
-CREATE INDEX idx_enrollment_user_course ON enrollments(user_id, course_id);
-CREATE INDEX idx_enrollment_course      ON enrollments(course_id);
+CREATE UNIQUE INDEX idx_enrollment_user_course ON enrollments(user_id, course_id);
+CREATE INDEX idx_enrollment_course             ON enrollments(course_id);

--- a/backend/src/test/java/com/yujin/course_enrollment/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/CourseServiceTest.java
@@ -8,6 +8,7 @@ import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,9 @@ class CourseServiceTest {
 
     @Mock
     private UserMapper userMapper;
+
+    @Mock
+    private EnrollmentMapper enrollmentMapper;
 
     @Test
     @DisplayName("강의 등록 성공")

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -1,0 +1,244 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
+import com.yujin.course_enrollment.entity.Course;
+import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * 수강 신청 서비스 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class EnrollmentServiceTest {
+
+    @InjectMocks
+    private EnrollmentService enrollmentService;
+
+    @Mock
+    private EnrollmentMapper enrollmentMapper;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Test
+    @DisplayName("수강 신청 성공")
+    void registerEnrollment_success() {
+        // given
+        Long userId = 4L;
+        Long courseId = 1L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        Course openCourse = Course.builder()
+                .id(courseId)
+                .creatorId(1L)
+                .title("Spring Boot 강의")
+                .status("OPEN")
+                .capacity(30)
+                .enrolledCount(10)
+                .build();
+        Enrollment saved = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(courseId)
+                .status("PENDING")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
+        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
+        given(courseMapper.incrementEnrolledCount(courseId)).willReturn(1);
+        given(enrollmentMapper.selectEnrollmentById(any())).willReturn(saved);
+
+        // when
+        RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+
+        // then
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getCourseId()).isEqualTo(courseId);
+        assertThat(result.getStatus()).isEqualTo("PENDING");
+        then(enrollmentMapper).should().insertEnrollment(any());
+        then(courseMapper).should().incrementEnrolledCount(courseId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 - 수강 신청 실패")
+    void registerEnrollment_userNotFound() {
+        // given
+        Long userId = 999L;
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(1L);
+        given(userMapper.selectUserById(userId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("존재하지 않는 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 강의 - 수강 신청 실패")
+    void registerEnrollment_courseNotFound() {
+        // given
+        Long userId = 4L;
+        Long courseId = 999L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("존재하지 않는 강의입니다.");
+    }
+
+    @Test
+    @DisplayName("본인 강의 신청 - 수강 신청 실패")
+    void registerEnrollment_ownCourse() {
+        // given
+        Long userId = 1L;
+        Long courseId = 1L;
+        User creator = new User(userId, "강사A", "CREATOR");
+        Course ownCourse = Course.builder()
+                .id(courseId)
+                .creatorId(userId)
+                .status("OPEN")
+                .build();
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(creator);
+        given(courseMapper.selectCourseById(courseId)).willReturn(ownCourse);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("본인이 개설한 강의는 신청할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("모집 중이 아닌 강의 - 수강 신청 실패")
+    void registerEnrollment_courseNotOpen() {
+        // given
+        Long userId = 4L;
+        Long courseId = 1L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        Course closedCourse = Course.builder()
+                .id(courseId)
+                .creatorId(1L)
+                .status("CLOSED")
+                .build();
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(closedCourse);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("모집 중인 강의만 신청할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("중복 신청 - 수강 신청 실패")
+    void registerEnrollment_duplicate() {
+        // given
+        Long userId = 4L;
+        Long courseId = 1L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        Course openCourse = Course.builder()
+                .id(courseId)
+                .creatorId(1L)
+                .status("OPEN")
+                .build();
+        Enrollment existing = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(courseId)
+                .status("PENDING")
+                .build();
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(existing);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 신청한 강의입니다.");
+    }
+
+    @Test
+    @DisplayName("동시 신청으로 정원 초과 - 수강 신청 실패")
+    void registerEnrollment_capacityExceeded_concurrent() {
+        // given
+        Long userId = 4L;
+        Long courseId = 1L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        Course openCourse = Course.builder()
+                .id(courseId)
+                .creatorId(1L)
+                .status("OPEN")
+                .capacity(10)
+                .enrolledCount(9)
+                .build();
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
+        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
+        given(courseMapper.incrementEnrolledCount(courseId)).willReturn(0);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("수강 정원이 초과되었습니다.");
+    }
+
+    @Test
+    @DisplayName("정원 초과 - 수강 신청 실패")
+    void registerEnrollment_capacityExceeded() {
+        // given
+        Long userId = 4L;
+        Long courseId = 1L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        Course fullCourse = Course.builder()
+                .id(courseId)
+                .creatorId(1L)
+                .status("OPEN")
+                .capacity(10)
+                .enrolledCount(10)
+                .build();
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(fullCourse);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("수강 정원이 초과되었습니다.");
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
+import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.User;
@@ -17,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -64,10 +66,9 @@ class EnrollmentServiceTest {
 
         given(userMapper.selectUserById(userId)).willReturn(student);
         given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
-        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null).willReturn(saved);
         willDoNothing().given(enrollmentMapper).insertEnrollment(any());
-        given(courseMapper.incrementEnrolledCount(courseId)).willReturn(1);
-        given(enrollmentMapper.selectEnrollmentById(any())).willReturn(saved);
+        given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(1);
 
         // when
         RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
@@ -77,7 +78,7 @@ class EnrollmentServiceTest {
         assertThat(result.getCourseId()).isEqualTo(courseId);
         assertThat(result.getStatus()).isEqualTo("PENDING");
         then(enrollmentMapper).should().insertEnrollment(any());
-        then(courseMapper).should().incrementEnrolledCount(courseId);
+        then(courseMapper).should().updateCourseEnrolledCountPlus(courseId);
     }
 
     @Test
@@ -189,6 +190,51 @@ class EnrollmentServiceTest {
     }
 
     @Test
+    @DisplayName("취소 후 재신청 성공")
+    void registerEnrollment_reEnrollAfterCancel() {
+        // given
+        Long userId = 4L;
+        Long courseId = 1L;
+        User student = new User(userId, "수강생A", "STUDENT");
+        Course openCourse = Course.builder()
+                .id(courseId)
+                .creatorId(1L)
+                .title("Spring Boot 강의")
+                .status("OPEN")
+                .capacity(30)
+                .enrolledCount(10)
+                .build();
+        Enrollment cancelled = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(courseId)
+                .status("CANCELLED")
+                .build();
+        Enrollment reEnrolled = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(courseId)
+                .status("PENDING")
+                .createdAt(LocalDateTime.now())
+                .build();
+        ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(cancelled).willReturn(reEnrolled);
+        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
+        given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(1);
+
+        // when
+        RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, req);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo("PENDING");
+        then(enrollmentMapper).should().insertEnrollment(any());
+        then(courseMapper).should().updateCourseEnrolledCountPlus(courseId);
+    }
+
+    @Test
     @DisplayName("동시 신청으로 정원 초과 - 수강 신청 실패")
     void registerEnrollment_capacityExceeded_concurrent() {
         // given
@@ -208,7 +254,7 @@ class EnrollmentServiceTest {
         given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
         given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
         willDoNothing().given(enrollmentMapper).insertEnrollment(any());
-        given(courseMapper.incrementEnrolledCount(courseId)).willReturn(0);
+        given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(0);
 
         // when & then
         assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
@@ -240,5 +286,174 @@ class EnrollmentServiceTest {
         assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("수강 정원이 초과되었습니다.");
+    }
+
+    @Test
+    @DisplayName("수강 신청 목록 조회 성공")
+    void findMyEnrollments_success() {
+        // given
+        Long userId = 4L;
+        List<RespEnrollmentStudentDto> list = List.of(new RespEnrollmentStudentDto(), new RespEnrollmentStudentDto());
+        given(enrollmentMapper.selectEnrollmentListByUserId(userId)).willReturn(list);
+
+        // when
+        List<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId);
+
+        // then
+        assertThat(result).hasSize(2);
+        then(enrollmentMapper).should().selectEnrollmentListByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("결제 요청 성공 - PENDING → CONFIRMED")
+    void confirmEnrollment_success() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Enrollment pending = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("PENDING")
+                .build();
+        Course course = Course.builder().id(1L).title("Spring Boot 강의").build();
+        Enrollment confirmed = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("CONFIRMED")
+                .confirmedAt(LocalDateTime.now())
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(pending).willReturn(confirmed);
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+
+        // when
+        RespEnrollmentDto result = enrollmentService.confirmEnrollment(userId, enrollmentId);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo("CONFIRMED");
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+    }
+
+    @Test
+    @DisplayName("본인 신청 아님 - 결제 요청 실패")
+    void confirmEnrollment_fail_notOwner() {
+        // given
+        Long userId = 99L;
+        Long enrollmentId = 1L;
+        Enrollment pending = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(4L)
+                .courseId(1L)
+                .status("PENDING")
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(pending);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.confirmEnrollment(userId, enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("본인의 수강 신청만 결제할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("PENDING 상태 아님 - 결제 요청 실패")
+    void confirmEnrollment_fail_notPending() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Enrollment confirmed = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("CONFIRMED")
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(confirmed);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.confirmEnrollment(userId, enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("PENDING 상태의 수강 신청만 결제할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("수강 취소 성공 - PENDING → CANCELLED")
+    void cancelEnrollment_success_pending() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Enrollment pending = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("PENDING")
+                .build();
+        Course course = Course.builder().id(1L).title("Spring Boot 강의").build();
+        Enrollment cancelled = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("CANCELLED")
+                .cancelledAt(LocalDateTime.now())
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(pending).willReturn(cancelled);
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+        willDoNothing().given(courseMapper).updateCourseEnrolledCountMinus(1L);
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+
+        // when
+        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo("CANCELLED");
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+        then(courseMapper).should().updateCourseEnrolledCountMinus(1L);
+    }
+
+    @Test
+    @DisplayName("이미 취소됨 - 수강 취소 실패")
+    void cancelEnrollment_fail_alreadyCancelled() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Enrollment cancelled = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("CANCELLED")
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(cancelled);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 취소된 수강 신청입니다.");
+    }
+
+    @Test
+    @DisplayName("취소 기간 초과 - 수강 취소 실패")
+    void cancelEnrollment_fail_expiredCancelPeriod() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Enrollment confirmed = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("CONFIRMED")
+                .confirmedAt(LocalDateTime.now().minusDays(8))
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(confirmed);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("수강 확정 후 7일이 지나 취소할 수 없습니다.");
     }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import LoginPage from './pages/LoginPage'
 import CourseRegisterPage from './pages/CourseRegisterPage'
 import CourseListPage from './pages/CourseListPage'
 import CourseDetailPage from './pages/CourseDetailPage'
+import MyPage from './pages/MyPage'
 
 /* 인증 여부에 따라 라우트 보호 및 공통 레이아웃 적용 */
 const PrivateRoute = ({ children }) => {
@@ -32,6 +33,7 @@ function App() {
                 <Route path="/courses/:courseId" element={<PrivateRoute><CourseDetailPage /></PrivateRoute>} />
                 <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
                 <Route path="/courses/:courseId/edit" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
+                <Route path="/my-page" element={<PrivateRoute><MyPage /></PrivateRoute>} />
                 <Route path="*" element={<Navigate to="/courses" replace />} />
             </Routes>
         </AuthProvider>

--- a/frontend/src/api/course.js
+++ b/frontend/src/api/course.js
@@ -37,3 +37,13 @@ export const closeCourse = (courseId, creatorId) => {
         headers: { 'X-User-Id': creatorId },
     }).then(res => res.data);
 };
+
+/* 나의 강의 목록 조회 (CREATOR 전용) */
+export const getMyCourses = () => {
+    return instance.get('/api/courses/my').then(res => res.data);
+};
+
+/* 강의별 수강생 목록 조회 (CREATOR 전용) */
+export const getCourseEnrollments = (courseId) => {
+    return instance.get(`/api/courses/${courseId}/enrollments`).then(res => res.data);
+};

--- a/frontend/src/api/enrollment.js
+++ b/frontend/src/api/enrollment.js
@@ -1,0 +1,6 @@
+import instance from './axios';
+
+/* 수강 신청 */
+export const createEnrollment = (courseId) => {
+    return instance.post('/api/enrollments', { courseId }).then(res => res.data);
+};

--- a/frontend/src/api/enrollment.js
+++ b/frontend/src/api/enrollment.js
@@ -5,7 +5,7 @@ export const createEnrollment = (courseId) => {
     return instance.post('/api/enrollments', { courseId }).then(res => res.data);
 };
 
-/* 수강 신청 목록 조회 */
+/* 나의 수강 신청 목록 조회 */
 export const getMyEnrollments = () => {
     return instance.get('/api/enrollments/me').then(res => res.data);
 };

--- a/frontend/src/api/enrollment.js
+++ b/frontend/src/api/enrollment.js
@@ -4,3 +4,18 @@ import instance from './axios';
 export const createEnrollment = (courseId) => {
     return instance.post('/api/enrollments', { courseId }).then(res => res.data);
 };
+
+/* 수강 신청 목록 조회 */
+export const getMyEnrollments = () => {
+    return instance.get('/api/enrollments/me').then(res => res.data);
+};
+
+/* 결제 요청 (PENDING → CONFIRMED) */
+export const confirmEnrollment = (enrollmentId) => {
+    return instance.patch(`/api/enrollments/${enrollmentId}/confirm`).then(res => res.data);
+};
+
+/* 수강 취소 */
+export const cancelEnrollment = (enrollmentId) => {
+    return instance.patch(`/api/enrollments/${enrollmentId}/cancel`).then(res => res.data);
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -31,6 +31,12 @@ const Header = () => {
                         </span>
                     </div>
                     <button
+                        onClick={() => navigate('/my-page')}
+                        className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+                    >
+                        마이페이지
+                    </button>
+                    <button
                         onClick={handleLogout}
                         className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
                     >

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -99,7 +99,7 @@ const CourseDetailPage = () => {
             {/* 제목 및 강사 섹션 */}
             <div className="mb-10">
                 <div className="flex items-center gap-3 mb-6">
-                    <h1 className="text-4xl font-extrabold text-gray-900 tracking-tight leading-tight">
+                    <h1 className="text-3xl font-extrabold text-gray-900 tracking-tight leading-tight">
                         {course.title}
                     </h1>
                     <span className={`text-xs font-bold px-3 py-1.5 rounded-md border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { closeCourse, getCourseDetail, publishCourse } from '../api/course';
 import { createEnrollment } from '../api/enrollment';
 import { useAuth } from '../context/AuthContext';
+import { COURSE_STATUS_BADGE_STYLE, COURSE_STATUS_LABEL } from '../utils/statusConfig';
 
 const CourseDetailPage = () => {
     const { courseId } = useParams();
@@ -101,11 +102,8 @@ const CourseDetailPage = () => {
                     <h1 className="text-4xl font-extrabold text-gray-900 tracking-tight leading-tight">
                         {course.title}
                     </h1>
-                    <span className={`text-xs font-bold px-3 py-1.5 rounded-md border ${course.status === 'OPEN'
-                        ? 'bg-blue-50 text-blue-600 border-blue-100'
-                        : 'bg-gray-50 text-gray-500 border-gray-200'
-                        }`}>
-                        {course.status === 'OPEN' ? '모집 중' : course.status === 'DRAFT' ? '준비 중' : '마감'}
+                    <span className={`text-xs font-bold px-3 py-1.5 rounded-md border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>
+                        {COURSE_STATUS_LABEL[course.status]}
                     </span>
                 </div>
 

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { closeCourse, getCourseDetail, publishCourse } from '../api/course';
+import { createEnrollment } from '../api/enrollment';
 import { useAuth } from '../context/AuthContext';
 
 const CourseDetailPage = () => {
@@ -45,6 +46,20 @@ const CourseDetailPage = () => {
             setCourse(result.data);
         } catch (err) {
             alert(err.response?.data?.message || '강의 공개에 실패했습니다.');
+        }
+    };
+
+    /* 수강 신청 */
+    const handleEnroll = async () => {
+        if (!window.confirm('수강 신청하시겠습니까?')) return;
+
+        try {
+            await createEnrollment(Number(courseId));
+            alert('수강 신청이 완료되었습니다.');
+            const result = await getCourseDetail(courseId);
+            setCourse(result.data);
+        } catch (err) {
+            alert(err.response?.data?.message || '수강 신청에 실패했습니다.');
         }
     };
 
@@ -179,15 +194,25 @@ const CourseDetailPage = () => {
                                         )}
                                     </>
                                 ) : (
-                                    <button
-                                        className={`w-full mt-8 py-4 font-bold rounded-md transition-all shadow-md active:scale-95 cursor-pointer ${course.status === 'OPEN'
-                                                ? 'bg-blue-600 text-white hover:bg-blue-700'
-                                                : 'bg-gray-200 text-gray-500 cursor-not-allowed'
-                                            }`}
-                                        disabled={course.status !== 'OPEN'}
-                                    >
-                                        {course.status === 'OPEN' ? '수강 신청하기' : '지금은 신청할 수 없습니다'}
-                                    </button>
+                                    <>
+                                        {course.enrolled ? (
+                                            <button disabled
+                                                className="w-full mt-8 py-4 font-bold rounded-md transition-all shadow-md cursor-not-allowed bg-gray-200 text-gray-500">
+                                                이미 신청한 강의입니다
+                                            </button>
+                                        ) : (
+                                            <button
+                                                onClick={course.status === 'OPEN' ? handleEnroll : undefined}
+                                                className={`w-full mt-8 py-4 font-bold rounded-md transition-all shadow-md active:scale-95 cursor-pointer ${course.status === 'OPEN'
+                                                        ? 'bg-blue-600 text-white hover:bg-blue-700'
+                                                        : 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                                                    }`}
+                                                disabled={course.status !== 'OPEN'}
+                                            >
+                                                {course.status === 'OPEN' ? '수강 신청하기' : '지금은 신청할 수 없습니다'}
+                                            </button>
+                                        )}
+                                    </>
                                 )}
                             </div>
                         </div>

--- a/frontend/src/pages/CourseListPage.jsx
+++ b/frontend/src/pages/CourseListPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { getCourseList } from '../api/course';
 import { useAuth } from '../context/AuthContext';
+import { COURSE_STATUS_CARD_STYLE, COURSE_STATUS_LABEL } from '../utils/statusConfig';
 
 const CourseListPage = () => {
     const navigate = useNavigate();
@@ -162,9 +163,8 @@ const CourseListPage = () => {
                                 </span>
                                 {/* 상태 배지 */}
                                 <div className="absolute top-2 left-2">
-                                    <span className={`text-[10px] font-bold px-2 py-1 rounded-sm shadow-sm ${course.status === 'OPEN' ? 'bg-green-500 text-white' : 'bg-gray-500 text-white'
-                                        }`}>
-                                        {course.status === 'OPEN' ? '모집 중' : '준비 중'}
+                                    <span className={`text-[10px] font-bold px-2 py-1 rounded-sm shadow-sm ${COURSE_STATUS_CARD_STYLE[course.status]}`}>
+                                        {COURSE_STATUS_LABEL[course.status]}
                                     </span>
                                 </div>
                             </div>

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { cancelEnrollment, confirmEnrollment, getMyEnrollments } from '../api/enrollment';
+import { useAuth } from '../context/AuthContext';
+import { ENROLLMENT_STATUS_BADGE_STYLE, ENROLLMENT_STATUS_LABEL } from '../utils/statusConfig';
+
+const MyPage = () => {
+    const navigate = useNavigate();
+    const { user } = useAuth();
+    const [activeTab, setActiveTab] = useState('enrollments');
+    const [enrollments, setEnrollments] = useState([]);
+
+    useEffect(() => {
+        const fetchMyEnrollments = async () => {
+            try {
+                const result = await getMyEnrollments();
+                setEnrollments(result.data);
+            } catch (err) {
+                console.error(err);
+                alert('수강 신청 목록을 불러오는데 실패했습니다.');
+            }
+        };
+
+        fetchMyEnrollments();
+    }, []);
+
+    /* 결제 요청 */
+    const handleConfirm = async (enrollmentId) => {
+        if (!window.confirm('결제하시겠습니까?')) return;
+
+        try {
+            await confirmEnrollment(enrollmentId);
+            alert('결제가 완료되었습니다.');
+            const result = await getMyEnrollments();
+            setEnrollments(result.data);
+        } catch (err) {
+            alert(err.response?.data?.message || '결제에 실패했습니다.');
+        }
+    };
+
+    /* 수강 취소 */
+    const handleCancel = async (enrollmentId) => {
+        if (!window.confirm('수강을 취소하시겠습니까?')) return;
+
+        try {
+            await cancelEnrollment(enrollmentId);
+            alert('수강이 취소되었습니다.');
+            const result = await getMyEnrollments();
+            setEnrollments(result.data);
+        } catch (err) {
+            alert(err.response?.data?.message || '수강 취소에 실패했습니다.');
+        }
+    };
+
+    const tabs = [
+        { key: 'enrollments', label: '나의 수강목록' },
+        ...(user?.role === 'CREATOR' ? [{ key: 'students', label: '강의별 수강생 목록' }] : []),
+    ];
+
+    return (
+        <div className="max-w-4xl mx-auto mt-10 p-6">
+            <h1 className="text-3xl font-extrabold text-gray-900 mb-8">마이페이지</h1>
+
+            {/* 탭 */}
+            <div className="flex gap-1 border-b border-gray-200 mb-8">
+                {tabs.map(tab => (
+                    <button
+                        key={tab.key}
+                        onClick={() => setActiveTab(tab.key)}
+                        className={`px-5 py-2.5 text-sm font-semibold transition-colors cursor-pointer ${
+                            activeTab === tab.key
+                                ? 'border-b-2 border-blue-600 text-blue-600'
+                                : 'text-gray-500 hover:text-gray-700'
+                        }`}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+            </div>
+
+            {/* 나의 수강목록 */}
+            {activeTab === 'enrollments' && (
+                <>
+                    {enrollments.length === 0 ? (
+                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                            수강 신청 내역이 없습니다.
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-4">
+                            {enrollments.map(enrollment => (
+                                <div key={enrollment.id}
+                                    className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+
+                                    {/* 강의 정보 */}
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <span
+                                                onClick={() => navigate(`/courses/${enrollment.courseId}`)}
+                                                className="text-base font-bold text-gray-900 truncate cursor-pointer hover:text-blue-600 transition-colors"
+                                            >
+                                                {enrollment.courseTitle}
+                                            </span>
+                                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ENROLLMENT_STATUS_BADGE_STYLE[enrollment.status]}`}>
+                                                {ENROLLMENT_STATUS_LABEL[enrollment.status]}
+                                            </span>
+                                        </div>
+
+                                        <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
+                                            <span>{enrollment.price === 0 ? '무료' : `${enrollment.price.toLocaleString()}원`}</span>
+                                            <span className="text-gray-300">|</span>
+                                            <span>{enrollment.startDate} ~ {enrollment.endDate}</span>
+                                            <span className="text-gray-300">|</span>
+                                            <span>신청일 {enrollment.createdAt?.substring(0, 10)}</span>
+                                        </div>
+
+                                        {enrollment.status === 'CONFIRMED' && enrollment.confirmedAt && (
+                                            <p className="text-xs text-green-600 mt-1">
+                                                결제일 {enrollment.confirmedAt.substring(0, 10)}
+                                            </p>
+                                        )}
+                                        {enrollment.status === 'CANCELLED' && enrollment.cancelledAt && (
+                                            <p className="text-xs text-gray-400 mt-1">
+                                                취소일 {enrollment.cancelledAt.substring(0, 10)}
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    {/* 액션 버튼 */}
+                                    <div className="flex gap-2 shrink-0">
+                                        {enrollment.status === 'PENDING' && (
+                                            <>
+                                                <button
+                                                    onClick={() => handleConfirm(enrollment.id)}
+                                                    className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer"
+                                                >
+                                                    결제하기
+                                                </button>
+                                                <button
+                                                    onClick={() => handleCancel(enrollment.id)}
+                                                    className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                                                >
+                                                    취소하기
+                                                </button>
+                                            </>
+                                        )}
+                                        {enrollment.status === 'CONFIRMED' && (
+                                            <button
+                                                onClick={() => handleCancel(enrollment.id)}
+                                                className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                                            >
+                                                취소하기
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </>
+            )}
+
+            {/* 강의별 수강생 목록 (CREATOR 전용) */}
+            {activeTab === 'students' && (
+                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                    준비 중입니다.
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default MyPage;

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { cancelEnrollment, confirmEnrollment, getMyEnrollments } from '../api/enrollment';
+import { getCourseEnrollments, getMyCourses } from '../api/course';
 import { useAuth } from '../context/AuthContext';
 import { ENROLLMENT_STATUS_BADGE_STYLE, ENROLLMENT_STATUS_LABEL } from '../utils/statusConfig';
 
@@ -9,6 +10,9 @@ const MyPage = () => {
     const { user } = useAuth();
     const [activeTab, setActiveTab] = useState('enrollments');
     const [enrollments, setEnrollments] = useState([]);
+    const [myCourses, setMyCourses] = useState([]);
+    const [selectedCourseId, setSelectedCourseId] = useState('');
+    const [courseEnrollments, setCourseEnrollments] = useState([]);
 
     useEffect(() => {
         const fetchMyEnrollments = async () => {
@@ -23,6 +27,41 @@ const MyPage = () => {
 
         fetchMyEnrollments();
     }, []);
+
+    /* 강의별 수강생 목록 탭 진입 시 나의 강의 목록 조회 */
+    useEffect(() => {
+        if (activeTab !== 'students') return;
+
+        const fetchMyCourses = async () => {
+            try {
+                const result = await getMyCourses();
+                setMyCourses(result.data);
+                setSelectedCourseId('');
+                setCourseEnrollments([]);
+            } catch (err) {
+                console.error(err);
+                alert('강의 목록을 불러오는데 실패했습니다.');
+            }
+        };
+
+        fetchMyCourses();
+    }, [activeTab]);
+
+    /* 강의 선택 시 수강생 목록 조회 */
+    const handleCourseSelect = async (courseId) => {
+        setSelectedCourseId(courseId);
+        if (!courseId) {
+            setCourseEnrollments([]);
+            return;
+        }
+
+        try {
+            const result = await getCourseEnrollments(courseId);
+            setCourseEnrollments(result.data);
+        } catch (err) {
+            alert(err.response?.data?.message || '수강생 목록을 불러오는데 실패했습니다.');
+        }
+    };
 
     /* 결제 요청 */
     const handleConfirm = async (enrollmentId) => {
@@ -156,14 +195,73 @@ const MyPage = () => {
                             ))}
                         </div>
                     )}
+
                 </>
             )}
 
             {/* 강의별 수강생 목록 (CREATOR 전용) */}
             {activeTab === 'students' && (
-                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                    준비 중입니다.
-                </div>
+                <>
+                    {/* 강의 선택 */}
+                    <div className="mb-6">
+                        <select
+                            value={selectedCourseId}
+                            onChange={(e) => handleCourseSelect(e.target.value)}
+                            className="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                            <option value="">강의를 선택하세요</option>
+                            {myCourses.map(course => (
+                                <option key={course.id} value={course.id}>
+                                    {course.title}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    {/* 수강생 목록 */}
+                    {!selectedCourseId ? (
+                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                            강의를 선택하면 수강생 목록이 표시됩니다.
+                        </div>
+                    ) : courseEnrollments.length === 0 ? (
+                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                            수강생이 없습니다.
+                        </div>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm text-left">
+                                <thead>
+                                    <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
+                                        <th className="pb-3 pr-6 font-semibold">수강생</th>
+                                        <th className="pb-3 pr-6 font-semibold">상태</th>
+                                        <th className="pb-3 pr-6 font-semibold">신청일</th>
+                                        <th className="pb-3 font-semibold">결제일 / 취소일</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-100">
+                                    {courseEnrollments.map(enrollment => (
+                                        <tr key={enrollment.id} className="hover:bg-gray-50">
+                                            <td className="py-4 pr-6 font-medium text-gray-900">{enrollment.userName}</td>
+                                            <td className="py-4 pr-6">
+                                                <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ENROLLMENT_STATUS_BADGE_STYLE[enrollment.status]}`}>
+                                                    {ENROLLMENT_STATUS_LABEL[enrollment.status]}
+                                                </span>
+                                            </td>
+                                            <td className="py-4 pr-6 text-gray-500">{enrollment.createdAt?.substring(0, 10)}</td>
+                                            <td className="py-4 text-gray-500">
+                                                {enrollment.status === 'CONFIRMED' && enrollment.confirmedAt
+                                                    ? enrollment.confirmedAt.substring(0, 10)
+                                                    : enrollment.status === 'CANCELLED' && enrollment.cancelledAt
+                                                        ? enrollment.cancelledAt.substring(0, 10)
+                                                        : '-'}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </>
             )}
         </div>
     );

--- a/frontend/src/utils/statusConfig.js
+++ b/frontend/src/utils/statusConfig.js
@@ -1,0 +1,34 @@
+/* 강의 상태 레이블 */
+export const COURSE_STATUS_LABEL = {
+    DRAFT: '준비 중',
+    OPEN: '모집 중',
+    CLOSED: '마감',
+};
+
+/* 강의 상태 뱃지 스타일 - 카드 썸네일용 (채워진 스타일) */
+export const COURSE_STATUS_CARD_STYLE = {
+    DRAFT: 'bg-gray-500 text-white',
+    OPEN: 'bg-green-500 text-white',
+    CLOSED: 'bg-gray-500 text-white',
+};
+
+/* 강의 상태 뱃지 스타일 - 인라인 뱃지용 (테두리 스타일) */
+export const COURSE_STATUS_BADGE_STYLE = {
+    DRAFT: 'bg-gray-50 text-gray-500 border-gray-200',
+    OPEN: 'bg-blue-50 text-blue-600 border-blue-100',
+    CLOSED: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+
+/* 수강 신청 상태 레이블 */
+export const ENROLLMENT_STATUS_LABEL = {
+    PENDING: '결제 대기',
+    CONFIRMED: '수강 확정',
+    CANCELLED: '취소됨',
+};
+
+/* 수강 신청 상태 뱃지 스타일 */
+export const ENROLLMENT_STATUS_BADGE_STYLE = {
+    PENDING: 'bg-amber-50 text-amber-600 border-amber-100',
+    CONFIRMED: 'bg-green-50 text-green-600 border-green-100',
+    CANCELLED: 'bg-gray-50 text-gray-400 border-gray-200',
+};


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - 수강 신청/목록 조회/결제 요청/수강 취소 API 구현
  - 개설 강의 목록 조회, 강의별 수강생 목록 조회 API 구현 (CREATOR 전용)
  - 강의 상태 전이 (PENDING → CONFIRMED → CANCELLED)
  - 마이페이지 구현 (나의 수강목록, 강의별 수강생 목록 탭)

  ## 구현 시 고려한 점
  - 중복 신청 방지, 본인 강의 신청 불가, 정원 초과 방지 검증 추가
  - 동시 신청 방어: 조건부 UPDATE (enrolled_count < capacity)로 마지막 자리 동시 신청 처리
  - 취소 후 재신청 허용: ON DUPLICATE KEY UPDATE로 PENDING 상태 초기화
  - 수강 확정(CONFIRMED) 후 7일 이내만 취소 가능하도록 제한
  - 강의별 수강생 목록은 본인 강의만 조회 가능하도록 권한 검증 추가
  - 강의/수강 신청 상태 레이블·스타일 statusConfig.js로 공용화
  
  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - http://localhost:5173/my-page

  ## 연관 이슈
  Closes #16
  Closes #17
  Closes #18