### PR TITLE
[feat] 수강 신청 목록 페이지네이션 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -1,8 +1,10 @@
 package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.EnrollmentService;
 import jakarta.validation.Valid;
@@ -10,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * 수강 신청 컨트롤러
@@ -42,14 +42,15 @@ public class EnrollmentController {
 
     /**
      * 나의 수강 신청 목록 조회
-     * GET /api/enrollments/me
+     * GET /api/enrollments/me?page=0&size=5
      * @param userId 사용자 ID (헤더로 전달)
+     * @param reqEnrollmentPageDto 페이징 조건 (page, size)
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<List<RespEnrollmentStudentDto>>> getMyEnrollments(@RequestHeader("X-User-Id") Long userId) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespEnrollmentStudentDto>>> getMyEnrollments(@RequestHeader("X-User-Id") Long userId, ReqEnrollmentPageDto reqEnrollmentPageDto) {
         log.debug("[EnrollmentController] 나의 수강 신청 목록 조회 요청 - userId: {}", userId);
 
-        List<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId);
+        RespPageDto<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId, reqEnrollmentPageDto);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentPageDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentPageDto.java
@@ -1,0 +1,22 @@
+package com.yujin.course_enrollment.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 수강 신청 목록 페이징 조건 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqEnrollmentPageDto {
+    private Long userId;
+    private int page = 0;
+    private int size = 5;
+
+    /* offset 계산 */
+    public int getOffset() {
+        return page * size;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentCreatorDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
 import com.yujin.course_enrollment.entity.Enrollment;
@@ -27,7 +28,10 @@ public interface EnrollmentMapper {
     void updateEnrollmentStatus(Enrollment enrollment);
 
     /* 나의 수강 신청 목록 조회 */
-    List<RespEnrollmentStudentDto> selectEnrollmentListByUserId(Long userId);
+    List<RespEnrollmentStudentDto> selectEnrollmentListByUserId(ReqEnrollmentPageDto reqEnrollmentPageDto);
+
+    /* 나의 수강 신청 목록 전체 수 조회 (페이징용) */
+    int selectEnrollmentListByUserIdCount(Long userId);
 
     /* 강의별 수강생 목록 조회 (CREATOR 전용) */
     List<RespEnrollmentCreatorDto> selectEnrollmentListByCourseId(Long courseId);

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -1,8 +1,10 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.User;
@@ -104,11 +106,17 @@ public class EnrollmentService {
     /**
      * 나의 수강 신청 목록 조회
      * @param userId 사용자 ID
+     * @param reqEnrollmentPageDto 페이징 조건 DTO
      */
-    public List<RespEnrollmentStudentDto> findMyEnrollments(Long userId) {
-        log.info("[EnrollmentService] 나의 수강 신청 목록 조회 - userId: {}", userId);
+    public RespPageDto<RespEnrollmentStudentDto> findMyEnrollments(Long userId, ReqEnrollmentPageDto reqEnrollmentPageDto) {
+        log.info("[EnrollmentService] 나의 수강 신청 목록 조회 - userId: {}, page: {}, size: {}", userId, reqEnrollmentPageDto.getPage(), reqEnrollmentPageDto.getSize());
 
-        return enrollmentMapper.selectEnrollmentListByUserId(userId);
+        reqEnrollmentPageDto.setUserId(userId);
+
+        List<RespEnrollmentStudentDto> content = enrollmentMapper.selectEnrollmentListByUserId(reqEnrollmentPageDto);
+        int totalCount = enrollmentMapper.selectEnrollmentListByUserIdCount(userId);
+
+        return RespPageDto.of(content, reqEnrollmentPageDto.getPage(), reqEnrollmentPageDto.getSize(), totalCount);
     }
 
     /**

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -74,7 +74,7 @@
     </select>
 
     <!-- 나의 수강 신청 목록 조회 -->
-    <select id="selectEnrollmentListByUserId" parameterType="long" resultType="RespEnrollmentStudentDto">
+    <select id="selectEnrollmentListByUserId" parameterType="ReqEnrollmentPageDto" resultType="RespEnrollmentStudentDto">
         SELECT e.id
              , e.course_id
              , c.title AS courseTitle
@@ -90,6 +90,14 @@
           JOIN courses c ON e.course_id = c.id
          WHERE e.user_id = #{userId}
         ORDER BY e.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 나의 수강 신청 목록 전체 수 조회 -->
+    <select id="selectEnrollmentListByUserIdCount" parameterType="Long" resultType="int">
+        SELECT COUNT(*)
+          FROM enrollments
+         WHERE user_id = #{userId}
     </select>
 
 </mapper>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -1,8 +1,10 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentStudentDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.User;
@@ -293,15 +295,19 @@ class EnrollmentServiceTest {
     void findMyEnrollments_success() {
         // given
         Long userId = 4L;
+        ReqEnrollmentPageDto pageDto = new ReqEnrollmentPageDto();
         List<RespEnrollmentStudentDto> list = List.of(new RespEnrollmentStudentDto(), new RespEnrollmentStudentDto());
-        given(enrollmentMapper.selectEnrollmentListByUserId(userId)).willReturn(list);
+        given(enrollmentMapper.selectEnrollmentListByUserId(pageDto)).willReturn(list);
+        given(enrollmentMapper.selectEnrollmentListByUserIdCount(userId)).willReturn(2);
 
         // when
-        List<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId);
+        RespPageDto<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId, pageDto);
 
         // then
-        assertThat(result).hasSize(2);
-        then(enrollmentMapper).should().selectEnrollmentListByUserId(userId);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalCount()).isEqualTo(2);
+        then(enrollmentMapper).should().selectEnrollmentListByUserId(pageDto);
+        then(enrollmentMapper).should().selectEnrollmentListByUserIdCount(userId);
     }
 
     @Test

--- a/frontend/src/api/enrollment.js
+++ b/frontend/src/api/enrollment.js
@@ -6,8 +6,8 @@ export const createEnrollment = (courseId) => {
 };
 
 /* 나의 수강 신청 목록 조회 */
-export const getMyEnrollments = () => {
-    return instance.get('/api/enrollments/me').then(res => res.data);
+export const getMyEnrollments = (page = 0, size = 5) => {
+    return instance.get('/api/enrollments/me', { params: { page, size } }).then(res => res.data);
 };
 
 /* 결제 요청 (PENDING → CONFIRMED) */

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -9,24 +9,25 @@ const MyPage = () => {
     const navigate = useNavigate();
     const { user } = useAuth();
     const [activeTab, setActiveTab] = useState('enrollments');
-    const [enrollments, setEnrollments] = useState([]);
+    const [enrollmentData, setEnrollmentData] = useState({ content: [], totalCount: 0, totalPages: 0, last: false });
+    const [enrollmentPage, setEnrollmentPage] = useState(0);
     const [myCourses, setMyCourses] = useState([]);
     const [selectedCourseId, setSelectedCourseId] = useState('');
     const [courseEnrollments, setCourseEnrollments] = useState([]);
 
-    useEffect(() => {
-        const fetchMyEnrollments = async () => {
-            try {
-                const result = await getMyEnrollments();
-                setEnrollments(result.data);
-            } catch (err) {
-                console.error(err);
-                alert('수강 신청 목록을 불러오는데 실패했습니다.');
-            }
-        };
+    const fetchMyEnrollments = async (page = 0) => {
+        try {
+            const result = await getMyEnrollments(page);
+            setEnrollmentData(result.data);
+        } catch (err) {
+            console.error(err);
+            alert('수강 신청 목록을 불러오는데 실패했습니다.');
+        }
+    };
 
-        fetchMyEnrollments();
-    }, []);
+    useEffect(() => {
+        fetchMyEnrollments(enrollmentPage);
+    }, [enrollmentPage]);
 
     /* 강의별 수강생 목록 탭 진입 시 나의 강의 목록 조회 */
     useEffect(() => {
@@ -70,8 +71,7 @@ const MyPage = () => {
         try {
             await confirmEnrollment(enrollmentId);
             alert('결제가 완료되었습니다.');
-            const result = await getMyEnrollments();
-            setEnrollments(result.data);
+            fetchMyEnrollments(enrollmentPage);
         } catch (err) {
             alert(err.response?.data?.message || '결제에 실패했습니다.');
         }
@@ -84,8 +84,7 @@ const MyPage = () => {
         try {
             await cancelEnrollment(enrollmentId);
             alert('수강이 취소되었습니다.');
-            const result = await getMyEnrollments();
-            setEnrollments(result.data);
+            fetchMyEnrollments(enrollmentPage);
         } catch (err) {
             alert(err.response?.data?.message || '수강 취소에 실패했습니다.');
         }
@@ -120,13 +119,13 @@ const MyPage = () => {
             {/* 나의 수강목록 */}
             {activeTab === 'enrollments' && (
                 <>
-                    {enrollments.length === 0 ? (
+                    {enrollmentData.content.length === 0 ? (
                         <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
                             수강 신청 내역이 없습니다.
                         </div>
                     ) : (
                         <div className="flex flex-col gap-4">
-                            {enrollments.map(enrollment => (
+                            {enrollmentData.content.map(enrollment => (
                                 <div key={enrollment.id}
                                     className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4">
 
@@ -196,6 +195,28 @@ const MyPage = () => {
                         </div>
                     )}
 
+                    {/* 페이징 섹션 */}
+                    {(enrollmentData?.totalPages ?? 0) > 1 && (
+                        <div className="flex justify-center items-center gap-4 mt-8">
+                            <button disabled={enrollmentPage === 0}
+                                onClick={() => setEnrollmentPage(prev => prev - 1)}
+                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                                </svg>
+                            </button>
+                            <span className="text-sm font-medium text-gray-700">
+                                <span className="text-blue-600">{enrollmentPage + 1}</span> / {enrollmentData.totalPages}
+                            </span>
+                            <button disabled={enrollmentData.last}
+                                onClick={() => setEnrollmentPage(prev => prev + 1)}
+                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                                </svg>
+                            </button>
+                        </div>
+                    )}
                 </>
             )}
 


### PR DESCRIPTION
### 작업 내용
  - 수강 신청 목록 조회 API 페이지네이션 적용 (GET /api/enrollments/me?page=0&size=5)
  - ReqEnrollmentPageDto 추가 (page, size, offset 계산)
  - 마이페이지 수강 신청 목록 페이지네이션 UI 구현 (이전/다음 버튼)

### 구현 시 고려한 점
  - RespPageDto로 반환 (content, totalCount, totalPages, last 포함)
  - CourseListPage와 동일한 페이지네이션 UI 적용

### 테스트 방법
  - 백엔드: IntelliJ에서 CourseEnrollmentApplication 실행 (Port: 8080)
  - 프론트: npm run dev (Port: 5173)
  - 접속: http://localhost:5173/my-page

### 연관 이슈
  Closes #20
