### PR TITLE
[feat] 수강 대기열 기능 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentStudentDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespEnrollmentStudentDto.java
@@ -26,4 +26,5 @@ public class RespEnrollmentStudentDto {
     private LocalDateTime confirmedAt;
     private LocalDateTime cancelledAt;
     private LocalDateTime createdAt;
+    private Integer waitlistPosition;
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
  * 수강 신청 엔티티
  * 사용자가 신청한 수강 신청 정보를 담는 객체
  * 상태: PENDING(신청 완료, 결제 대기) → CONFIRMED(결제 완료, 수강 확정) → CANCELLED(취소됨)
+ *       WAITLIST(대기 중) → PENDING(자동 승격)
  */
 @Getter
 @Builder
@@ -41,6 +42,23 @@ public class Enrollment {
                 .id(id)
                 .status("CANCELLED")
                 .cancelledAt(LocalDateTime.now())
+                .build();
+    }
+
+    /* 대기열 상태로 변경할 엔티티 생성 */
+    public static Enrollment ofWaitlist(Long userId, Long courseId) {
+        return Enrollment.builder()
+                .userId(userId)
+                .courseId(courseId)
+                .status("WAITLIST")
+                .build();
+    }
+
+    /* 대기열에서 PENDING으로 승격할 엔티티 생성 */
+    public static Enrollment ofPromote(Long id) {
+        return Enrollment.builder()
+                .id(id)
+                .status("PENDING")
                 .build();
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -35,4 +35,7 @@ public interface EnrollmentMapper {
 
     /* 강의별 수강생 목록 조회 (CREATOR 전용) */
     List<RespEnrollmentCreatorDto> selectEnrollmentListByCourseId(Long courseId);
+
+    /* 대기열 첫 번째 조회 (자동 승격용) */
+    Enrollment selectNextWaitlist(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -37,9 +37,10 @@ public class EnrollmentService {
 
     /**
      * 수강 신청
+     * 정원이 남아있으면 PENDING, 초과 시 WAITLIST로 등록
      * @param userId 신청하는 사용자 ID
      * @param reqEnrollmentCreateDto 수강 신청 요청 DTO
-     * @throws BusinessException 사용자 없음(400), 강의 없음(400), 본인 강의 신청(403), 모집 중 아님(400), 중복 신청(400), 정원 초과(400)
+     * @throws BusinessException 사용자 없음(400), 강의 없음(400), 본인 강의 신청(403), 모집 중 아님(400), 중복 신청(400)
      */
     @Transactional
     public RespEnrollmentDto registerEnrollment(Long userId, ReqEnrollmentCreateDto reqEnrollmentCreateDto) {
@@ -73,29 +74,35 @@ public class EnrollmentService {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "모집 중인 강의만 신청할 수 있습니다.");
         }
 
-        // 중복 신청 확인 (CANCELLED 상태는 재신청 허용)
+        // 중복 신청 확인 (CANCELLED 상태만 재신청 허용)
         Enrollment existing = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
         if (existing != null && !"CANCELLED".equals(existing.getStatus())) {
+            if ("WAITLIST".equals(existing.getStatus())) {
+                log.warn("[EnrollmentService] 이미 대기 중 - userId: {}, courseId: {}", userId, courseId);
+                throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 대기 중인 강의입니다.");
+            }
             log.warn("[EnrollmentService] 중복 신청 - userId: {}, courseId: {}", userId, courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
         }
 
-        // 정원 초과 확인
+        // 정원 초과 시 WAITLIST 등록
         if (course.getEnrolledCount() >= course.getCapacity()) {
-            log.warn("[EnrollmentService] 정원 초과 - courseId: {}, enrolledCount: {}, capacity: {}", courseId, course.getEnrolledCount(), course.getCapacity());
-            throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 정원이 초과되었습니다.");
+            log.info("[EnrollmentService] 정원 초과 - 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
+            enrollmentMapper.insertEnrollment(Enrollment.ofWaitlist(userId, courseId));
+            Enrollment saved = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+            return RespEnrollmentDto.of(saved, course.getTitle());
         }
 
-        Enrollment enrollment = reqEnrollmentCreateDto.toEntity(userId);
-        enrollmentMapper.insertEnrollment(enrollment);
-
-        // 수강 인원 증가 (0이면 동시 신청으로 정원 초과)
+        // 자리 확보 먼저 → 성공하면 PENDING, 실패하면 WAITLIST
         int updated = courseMapper.updateCourseEnrolledCountPlus(courseId);
         if (updated == 0) {
-            log.warn("[EnrollmentService] 정원 초과 (동시 신청) - courseId: {}", courseId);
-            throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 정원이 초과되었습니다.");
+            log.info("[EnrollmentService] 동시 신청으로 정원 초과 - 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
+            enrollmentMapper.insertEnrollment(Enrollment.ofWaitlist(userId, courseId));
+            Enrollment saved = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+            return RespEnrollmentDto.of(saved, course.getTitle());
         }
 
+        enrollmentMapper.insertEnrollment(reqEnrollmentCreateDto.toEntity(userId));
         log.info("[EnrollmentService] 수강 신청 완료 - userId: {}, courseId: {}", userId, courseId);
 
         Enrollment saved = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
@@ -160,7 +167,8 @@ public class EnrollmentService {
     }
 
     /**
-     * 수강 취소 (PENDING, CONFIRMED → CANCELLED)
+     * 수강 취소 (PENDING, CONFIRMED, WAITLIST → CANCELLED)
+     * PENDING/CONFIRMED 취소 시 대기열 첫 번째 사람 자동 PENDING 승격
      * @param userId 사용자 ID
      * @param enrollmentId 수강 신청 ID
      * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), 이미 취소됨(400), CONFIRMED 7일 초과(400)
@@ -198,12 +206,32 @@ public class EnrollmentService {
 
         enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(enrollmentId));
 
+        // WAITLIST 취소는 enrolled_count 변경 및 승격 없음
+        if ("WAITLIST".equals(enrollment.getStatus())) {
+            log.info("[EnrollmentService] 대기 취소 완료 - enrollmentId: {}", enrollmentId);
+
+            Course course = courseMapper.selectCourseById(enrollment.getCourseId());
+            Enrollment saved = enrollmentMapper.selectEnrollmentById(enrollmentId);
+
+            return RespEnrollmentDto.of(saved, course.getTitle());
+        }
+
         courseMapper.updateCourseEnrolledCountMinus(enrollment.getCourseId());
+
+        // 대기열 첫 번째 사람 자동 PENDING 승격
+        Enrollment nextWaitlist = enrollmentMapper.selectNextWaitlist(enrollment.getCourseId());
+        if (nextWaitlist != null) {
+            int updated = courseMapper.updateCourseEnrolledCountPlus(enrollment.getCourseId());
+
+            if (updated > 0) {
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofPromote(nextWaitlist.getId()));
+                log.info("[EnrollmentService] 대기열 승격 - enrollmentId: {}", nextWaitlist.getId());
+            }
+        }
 
         log.info("[EnrollmentService] 수강 취소 완료 - enrollmentId: {}", enrollmentId);
 
         Course course = courseMapper.selectCourseById(enrollment.getCourseId());
-
         Enrollment saved = enrollmentMapper.selectEnrollmentById(enrollmentId);
 
         return RespEnrollmentDto.of(saved, course.getTitle());

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -86,6 +86,14 @@
              , e.confirmed_at
              , e.cancelled_at
              , e.created_at
+             , CASE WHEN e.status = 'WAITLIST'
+                    THEN (SELECT COUNT(*) + 1
+                            FROM enrollments e2
+                           WHERE e2.course_id = e.course_id
+                             AND e2.status = 'WAITLIST'
+                             AND e2.created_at <![CDATA[ < ]]> e.created_at)
+                    ELSE NULL
+               END AS waitlistPosition
           FROM enrollments e
           JOIN courses c ON e.course_id = c.id
          WHERE e.user_id = #{userId}
@@ -98,6 +106,23 @@
         SELECT COUNT(*)
           FROM enrollments
          WHERE user_id = #{userId}
+    </select>
+
+    <!-- 대기열 첫 번째 조회 (자동 승격용) -->
+    <select id="selectNextWaitlist" parameterType="Long" resultType="Enrollment">
+        SELECT id
+             , user_id
+             , course_id
+             , status
+             , confirmed_at
+             , cancelled_at
+             , created_at
+             , updated_at
+          FROM enrollments
+         WHERE course_id = #{courseId}
+           AND status = 'WAITLIST'
+        ORDER BY created_at ASC
+        LIMIT 1
     </select>
 
 </mapper>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
 
 /**
  * 수강 신청 서비스 단위 테스트
@@ -69,8 +70,8 @@ class EnrollmentServiceTest {
         given(userMapper.selectUserById(userId)).willReturn(student);
         given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
         given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null).willReturn(saved);
-        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
         given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(1);
+        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
 
         // when
         RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
@@ -237,7 +238,7 @@ class EnrollmentServiceTest {
     }
 
     @Test
-    @DisplayName("동시 신청으로 정원 초과 - 수강 신청 실패")
+    @DisplayName("동시 신청으로 정원 초과 - 대기열 등록")
     void registerEnrollment_capacityExceeded_concurrent() {
         // given
         Long userId = 4L;
@@ -246,26 +247,37 @@ class EnrollmentServiceTest {
         Course openCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
+                .title("Spring Boot 강의")
                 .status("OPEN")
                 .capacity(10)
                 .enrolledCount(9)
+                .build();
+        Enrollment waitlisted = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(courseId)
+                .status("WAITLIST")
+                .createdAt(LocalDateTime.now())
                 .build();
         ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
 
         given(userMapper.selectUserById(userId)).willReturn(student);
         given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
-        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null).willReturn(waitlisted);
         willDoNothing().given(enrollmentMapper).insertEnrollment(any());
         given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(0);
 
-        // when & then
-        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("수강 정원이 초과되었습니다.");
+        // when
+        RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, req);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo("WAITLIST");
+        then(enrollmentMapper).should(times(1)).insertEnrollment(any());
+        then(courseMapper).should().updateCourseEnrolledCountPlus(courseId);
     }
 
     @Test
-    @DisplayName("정원 초과 - 수강 신청 실패")
+    @DisplayName("정원 초과 - 대기열 등록")
     void registerEnrollment_capacityExceeded() {
         // given
         Long userId = 4L;
@@ -274,20 +286,32 @@ class EnrollmentServiceTest {
         Course fullCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
+                .title("Spring Boot 강의")
                 .status("OPEN")
                 .capacity(10)
                 .enrolledCount(10)
+                .build();
+        Enrollment waitlisted = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(courseId)
+                .status("WAITLIST")
+                .createdAt(LocalDateTime.now())
                 .build();
         ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
 
         given(userMapper.selectUserById(userId)).willReturn(student);
         given(courseMapper.selectCourseById(courseId)).willReturn(fullCourse);
-        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null);
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(null).willReturn(waitlisted);
+        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
 
-        // when & then
-        assertThatThrownBy(() -> enrollmentService.registerEnrollment(userId, req))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("수강 정원이 초과되었습니다.");
+        // when
+        RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, req);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo("WAITLIST");
+        then(enrollmentMapper).should().insertEnrollment(any());
+        then(courseMapper).should(never()).updateCourseEnrolledCountPlus(courseId);
     }
 
     @Test

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -52,11 +52,16 @@ const CourseDetailPage = () => {
 
     /* 수강 신청 */
     const handleEnroll = async () => {
-        if (!window.confirm('수강 신청하시겠습니까?')) return;
+        const isFull = course.enrolledCount >= course.capacity;
+        const confirmMsg = isFull ? '현재 정원이 초과되었습니다. 대기열에 등록하시겠습니까?' : '수강 신청하시겠습니까?';
+
+        if (!window.confirm(confirmMsg)) return;
 
         try {
-            await createEnrollment(Number(courseId));
-            alert('수강 신청이 완료되었습니다.');
+            const enrolled = await createEnrollment(Number(courseId));
+
+            alert(enrolled.data?.status === 'WAITLIST' ? '정원이 초과되어 대기열에 등록되었습니다.\n마이페이지에서 대기 순번을 확인하세요.' : '수강 신청이 완료되었습니다.');
+            
             const result = await getCourseDetail(courseId);
             setCourse(result.data);
         } catch (err) {

--- a/frontend/src/pages/CourseRegisterPage.jsx
+++ b/frontend/src/pages/CourseRegisterPage.jsx
@@ -33,6 +33,7 @@ const CourseRegisterPage = () => {
                 try {
                     const response = await getCourseDetail(courseId);
                     const data = response.data;
+
                     setForm({
                         ...data,
                         priceDisplay: data.price.toLocaleString()
@@ -55,7 +56,6 @@ const CourseRegisterPage = () => {
 
     /* 가격 입력 핸들러 */
     const handlePriceChange = (e) => {
-
         const raw = e.target.value.replace(/[^0-9]/g, '');
 
         if (raw === '') {

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -36,6 +36,7 @@ const MyPage = () => {
         const fetchMyCourses = async () => {
             try {
                 const result = await getMyCourses();
+                
                 setMyCourses(result.data);
                 setSelectedCourseId('');
                 setCourseEnrollments([]);
@@ -51,6 +52,7 @@ const MyPage = () => {
     /* 강의 선택 시 수강생 목록 조회 */
     const handleCourseSelect = async (courseId) => {
         setSelectedCourseId(courseId);
+        
         if (!courseId) {
             setCourseEnrollments([]);
             return;
@@ -105,11 +107,10 @@ const MyPage = () => {
                     <button
                         key={tab.key}
                         onClick={() => setActiveTab(tab.key)}
-                        className={`px-5 py-2.5 text-sm font-semibold transition-colors cursor-pointer ${
-                            activeTab === tab.key
+                        className={`px-5 py-2.5 text-sm font-semibold transition-colors cursor-pointer ${activeTab === tab.key
                                 ? 'border-b-2 border-blue-600 text-blue-600'
                                 : 'text-gray-500 hover:text-gray-700'
-                        }`}
+                            }`}
                     >
                         {tab.label}
                     </button>
@@ -161,6 +162,11 @@ const MyPage = () => {
                                                 취소일 {enrollment.cancelledAt.substring(0, 10)}
                                             </p>
                                         )}
+                                        {enrollment.status === 'WAITLIST' && enrollment.waitlistPosition && (
+                                            <p className="text-xs text-purple-600 mt-1">
+                                                대기 순번 {enrollment.waitlistPosition}번
+                                            </p>
+                                        )}
                                     </div>
 
                                     {/* 액션 버튼 */}
@@ -187,6 +193,14 @@ const MyPage = () => {
                                                 className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
                                             >
                                                 취소하기
+                                            </button>
+                                        )}
+                                        {enrollment.status === 'WAITLIST' && (
+                                            <button
+                                                onClick={() => handleCancel(enrollment.id)}
+                                                className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                                            >
+                                                대기 취소
                                             </button>
                                         )}
                                     </div>

--- a/frontend/src/utils/statusConfig.js
+++ b/frontend/src/utils/statusConfig.js
@@ -24,6 +24,7 @@ export const ENROLLMENT_STATUS_LABEL = {
     PENDING: '결제 대기',
     CONFIRMED: '수강 확정',
     CANCELLED: '취소됨',
+    WAITLIST: '대기 중',
 };
 
 /* 수강 신청 상태 뱃지 스타일 */
@@ -31,4 +32,5 @@ export const ENROLLMENT_STATUS_BADGE_STYLE = {
     PENDING: 'bg-amber-50 text-amber-600 border-amber-100',
     CONFIRMED: 'bg-green-50 text-green-600 border-green-100',
     CANCELLED: 'bg-gray-50 text-gray-400 border-gray-200',
+    WAITLIST: 'bg-purple-50 text-purple-600 border-purple-100',
 };


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - 정원 초과 시 WAITLIST 상태로 대기열 자동 등록
  - 수강 취소 시 대기열 첫 번째 사용자 자동 PENDING 승격                                                                                                                            
  - 나의 수강 목록에 대기 순번(waitlistPosition) 동적 계산 및 반환
  - 마이페이지 WAITLIST 상태 뱃지, 대기 순번, 대기 취소 버튼 추가                                                                                                                   
  - 정원 초과 강의 신청 시 confirm/alert 메시지 분기 처리
  
  ## 구현 시 고려한 점
  - enrolled_count 증가(자리 확보) 성공 후 PENDING INSERT
  - 동시성 처리: updateCourseEnrolledCountPlus 조건부 UPDATE로 동시 신청 시 WAITLIST 자동 전환
  - 대기열 취소 시 enrolled_count 변경 및 승격 로직 없이 CANCELLED 처리
  - 대기열 승격 시에도 updateCourseEnrolledCountPlus로 자리 확보 후 승격
  - 대기 순번은 별도 컬럼 없이 스칼라 서브쿼리로 동적 계산
  - 이미 대기 중인 강의 재신청 불가 검증 추가
  
  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - http://localhost:5173 접속 후 유저 선택 로그인 확인
  - 정원 마감인 강의 신청 → 대기열 등록 확인
  - http://localhost:5173/my-page 에서 대기 순번 및 대기 취소 확인

  ## 연관 이슈
  Closes #22