### PR TITLE
[fix] 대기열 처리 안정성 개선 및 조회 쿼리 개선 

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -42,4 +42,7 @@ public interface EnrollmentMapper {
 
     /* 대기열 첫 번째 조회 (자동 승격용) */
     Enrollment selectNextWaitlist(Long courseId);
+
+    /* 대기열 승격 (WAITLIST 상태일 때만 PENDING으로 변경) */
+    int updateEnrollmentStatusPromote(Long id);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -79,6 +79,7 @@ public class EnrollmentService {
         // 중복 신청 확인 (CANCELLED 상태만 재신청 허용)
         Enrollment existing = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
         if (existing != null && !EnrollmentStatus.CANCELLED.equals(existing.getStatus())) {
+
             if (EnrollmentStatus.WAITLIST.equals(existing.getStatus())) {
                 log.warn("[EnrollmentService] 이미 대기 중 - userId: {}, courseId: {}", userId, courseId);
                 throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 대기 중인 강의입니다.");
@@ -91,8 +92,10 @@ public class EnrollmentService {
         // 정원 초과 시 WAITLIST 등록
         if (course.getEnrolledCount() >= course.getCapacity()) {
             log.info("[EnrollmentService] 정원 초과 - 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
+
             enrollmentMapper.insertEnrollment(Enrollment.ofWaitlist(userId, courseId));
             Enrollment saved = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+
             return RespEnrollmentDto.of(saved, course.getTitle());
         }
 
@@ -100,8 +103,10 @@ public class EnrollmentService {
         int updated = courseMapper.updateCourseEnrolledCountPlus(courseId);
         if (updated == 0) {
             log.info("[EnrollmentService] 동시 신청으로 정원 초과 - 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
+
             enrollmentMapper.insertEnrollment(Enrollment.ofWaitlist(userId, courseId));
             Enrollment saved = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
+
             return RespEnrollmentDto.of(saved, course.getTitle());
         }
 
@@ -223,14 +228,15 @@ public class EnrollmentService {
 
         courseMapper.updateCourseEnrolledCountMinus(enrollment.getCourseId());
 
-        // 대기열 첫 번째 사람 자동 PENDING 승격
-        Enrollment nextWaitlist = enrollmentMapper.selectNextWaitlist(enrollment.getCourseId());
-        if (nextWaitlist != null) {
-            int updated = courseMapper.updateCourseEnrolledCountPlus(enrollment.getCourseId());
+        // 대기열 승격 시도 (동시 경쟁 실패 시 다음 대기자로 재시도)
+        Enrollment nextWaitlist;
+        while ((nextWaitlist = enrollmentMapper.selectNextWaitlist(enrollment.getCourseId())) != null) {
+            int promoted = enrollmentMapper.updateEnrollmentStatusPromote(nextWaitlist.getId());
 
-            if (updated > 0) {
-                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofPromote(nextWaitlist.getId()));
+            if (promoted > 0) {
+                courseMapper.updateCourseEnrolledCountPlus(enrollment.getCourseId());
                 log.info("[EnrollmentService] 대기열 승격 - enrollmentId: {}", nextWaitlist.getId());
+                break;
             }
         }
 

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -85,8 +85,8 @@
     <select id="selectEnrollmentListByUserId" parameterType="ReqEnrollmentPageDto" resultType="RespEnrollmentStudentDto">
         SELECT e.id
              , e.course_id
-             , c.title AS courseTitle
-             , c.status AS courseStatus
+             , c.title        AS courseTitle
+             , c.status       AS courseStatus
              , c.price
              , c.start_date
              , c.end_date
@@ -94,16 +94,15 @@
              , e.confirmed_at
              , e.cancelled_at
              , e.created_at
-             , CASE WHEN e.status = 'WAITLIST'
-                    THEN (SELECT COUNT(*) + 1
-                            FROM enrollments e2
-                           WHERE e2.course_id = e.course_id
-                             AND e2.status = 'WAITLIST'
-                             AND e2.created_at <![CDATA[ < ]]> e.created_at)
-                    ELSE NULL
-               END AS waitlistPosition
+             , wr.waitlist_rank AS waitlistPosition
           FROM enrollments e
           JOIN courses c ON e.course_id = c.id
+          LEFT JOIN (
+              SELECT id
+                   , RANK() OVER (PARTITION BY course_id ORDER BY created_at) AS waitlist_rank
+                FROM enrollments
+               WHERE status = 'WAITLIST'
+          ) wr ON wr.id = e.id
          WHERE e.user_id = #{userId}
         ORDER BY CASE WHEN e.status != 'CANCELLED' THEN 0 ELSE 1 END ASC
                , e.updated_at DESC
@@ -116,6 +115,14 @@
           FROM enrollments
          WHERE user_id = #{userId}
     </select>
+
+    <!-- 대기열 승격 (WAITLIST 상태일 때만 PENDING으로 변경) -->
+    <update id="updateEnrollmentStatusPromote" parameterType="Long">
+        UPDATE enrollments
+           SET status = 'PENDING'
+         WHERE id = #{id}
+           AND status = 'WAITLIST'
+    </update>
 
     <!-- 대기열 첫 번째 조회 (자동 승격용) -->
     <select id="selectNextWaitlist" parameterType="Long" resultType="Enrollment">

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
@@ -134,11 +134,15 @@ class EnrollmentConcurrencyTest {
         long waitlistCount = statuses.stream().filter(EnrollmentStatus.WAITLIST::equals).count();
         long errorCount    = statuses.stream().filter(s -> s.startsWith("ERROR")).count();
 
+        System.out.println("[결과] PENDING: " + pendingCount + " / WAITLIST: " + waitlistCount + " / ERROR: " + errorCount);
+
         assertThat(errorCount).isEqualTo(0);
         assertThat(pendingCount).isEqualTo(1);
         assertThat(waitlistCount).isEqualTo(19);
 
         Course updated = courseMapper.selectCourseById(courseId);
+        System.out.println("[enrolled_count] " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
+
         assertThat(updated.getEnrolledCount()).isEqualTo(1);
         assertThat(updated.getEnrolledCount()).isLessThanOrEqualTo(updated.getCapacity());
     }
@@ -158,11 +162,15 @@ class EnrollmentConcurrencyTest {
         long waitlistCount = statuses.stream().filter(EnrollmentStatus.WAITLIST::equals).count();
         long errorCount    = statuses.stream().filter(s -> s.startsWith("ERROR")).count();
 
+        System.out.println("[결과] PENDING: " + pendingCount + " / WAITLIST: " + waitlistCount + " / ERROR: " + errorCount);
+
         assertThat(errorCount).isEqualTo(0);
         assertThat(pendingCount).isEqualTo(5);
         assertThat(waitlistCount).isEqualTo(25);
 
         Course updated = courseMapper.selectCourseById(courseId);
+        System.out.println("[enrolled_count] " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
+
         assertThat(updated.getEnrolledCount()).isEqualTo(5);
         assertThat(updated.getEnrolledCount()).isLessThanOrEqualTo(updated.getCapacity());
     }
@@ -175,8 +183,8 @@ class EnrollmentConcurrencyTest {
      *   → 대기자 3명이 모두 PENDING으로 승격되어야 함
      *   → enrolled_count = 3 (승격 인원수, cap 초과 없음)
      *
-     * 예외 가능 상황: 모든 스레드가 selectNextWaitlist에서 동일 대기자를 발견
-     *   → updateCourseEnrolledCountPlus가 중복 실행되면 enrolled_count 불일치
+     * updateEnrollmentStatusPromote가 AND status = 'WAITLIST' 조건으로 실행되어
+     * 동일 대기자에 대한 중복 승격을 방지함
      */
     @Test
     @DisplayName("5명 동시 취소 - WAITLIST 3명 전원 PENDING 승격, enrolled_count 정합성 유지")
@@ -237,8 +245,138 @@ class EnrollmentConcurrencyTest {
 
         Course updated = courseMapper.selectCourseById(courseId);
 
+        System.out.println("[승격 결과] PENDING 승격: " + promotedCount + " / enrolled_count: " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
+
         assertThat(promotedCount).isEqualTo(3); // WAITLIST 3명 모두 PENDING 승격
         assertThat(updated.getEnrolledCount()).isEqualTo(3); // enrolled_count = 승격 인원수
         assertThat(updated.getEnrolledCount()).isLessThanOrEqualTo(updated.getCapacity()); // cap 초과 없음
+    }
+
+    /**
+     * 동시 취소 시 WAITLIST 승격 정확성 테스트 (취소 수 < 대기자 수)
+     *
+     * 시나리오: cap=5, 수강생 5명(PENDING) + 대기자 5명(WAITLIST)
+     *   → 수강생 2명만 동시 취소
+     *   → 대기자 2명만 PENDING으로 승격되어야 함
+     *   → enrolled_count = 5 유지 (2명 취소 + 2명 승격)
+     */
+    @Test
+    @DisplayName("2명 동시 취소 - WAITLIST 5명 중 2명만 PENDING 승격, enrolled_count 불변")
+    void cancelEnrollment_concurrent_cancelLessThanWaitlist() throws InterruptedException {
+        // given - cap=5 강의에 수강생 5명 + 대기자 5명 세팅
+        List<Long> enrolledUsers = insertStudents(5);
+        List<Long> waitlistUsers = insertStudents(5);
+        Long courseId = createOpenCourse(1L, 5).getId();
+
+        for (Long userId : enrolledUsers) {
+            enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+        }
+        for (Long userId : waitlistUsers) {
+            enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+        }
+
+        // 수강 중인 5명 중 2명만 취소 대상으로 선정
+        List<Long[]> cancelTargets = new ArrayList<>();
+        for (Long userId : enrolledUsers.subList(0, 2)) {
+            Long enrollmentId = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId).getId();
+            cancelTargets.add(new Long[]{userId, enrollmentId});
+        }
+
+        // when - 2명 동시 취소
+        int count = cancelTargets.size();
+        ExecutorService executor = Executors.newFixedThreadPool(count);
+        CountDownLatch readyLatch = new CountDownLatch(count);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(count);
+
+        for (Long[] target : cancelTargets) {
+            executor.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+                    enrollmentService.cancelEnrollment(target[0], target[1]);
+                } catch (Exception ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then
+        long promotedCount = waitlistUsers.stream()
+                .map(uid -> enrollmentMapper.selectEnrollmentByUserIdAndCourseId(uid, courseId))
+                .filter(e -> EnrollmentStatus.PENDING.equals(e.getStatus()))
+                .count();
+
+        Course updated = courseMapper.selectCourseById(courseId);
+
+        System.out.println("[승격 결과] PENDING 승격: " + promotedCount + " / enrolled_count: " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
+
+        assertThat(promotedCount).isEqualTo(2); // 취소 2명 → 승격 2명
+        assertThat(updated.getEnrolledCount()).isEqualTo(5); // 2명 취소 + 2명 승격 = enrolled_count 불변
+        assertThat(updated.getEnrolledCount()).isLessThanOrEqualTo(updated.getCapacity());
+    }
+
+    /**
+     * 동시 취소 시 WAITLIST 없는 경우 enrolled_count 정합성 테스트
+     *
+     * 시나리오: cap=5, 수강생 3명(PENDING), WAITLIST 없음
+     *   → 수강생 3명 동시 취소
+     *   → enrolled_count = 0
+     */
+    @Test
+    @DisplayName("3명 동시 취소 - WAITLIST 없음, enrolled_count 정확히 감소")
+    void cancelEnrollment_concurrent_noWaitlist() throws InterruptedException {
+        // given - cap=5 강의에 수강생 3명만 세팅
+        List<Long> enrolledUsers = insertStudents(3);
+        Long courseId = createOpenCourse(1L, 5).getId();
+
+        for (Long userId : enrolledUsers) {
+            enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+        }
+
+        List<Long[]> cancelTargets = new ArrayList<>();
+        for (Long userId : enrolledUsers) {
+            Long enrollmentId = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId).getId();
+            cancelTargets.add(new Long[]{userId, enrollmentId});
+        }
+
+        // when - 3명 동시 취소
+        int count = cancelTargets.size();
+        ExecutorService executor = Executors.newFixedThreadPool(count);
+        CountDownLatch readyLatch = new CountDownLatch(count);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(count);
+
+        for (Long[] target : cancelTargets) {
+            executor.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+                    enrollmentService.cancelEnrollment(target[0], target[1]);
+                } catch (Exception ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then
+        Course updated = courseMapper.selectCourseById(courseId);
+
+        System.out.println("[취소 결과] enrolled_count: " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
+
+        assertThat(updated.getEnrolledCount()).isEqualTo(0);
+        assertThat(updated.getEnrolledCount()).isLessThanOrEqualTo(updated.getCapacity());
     }
 }


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - 동시 수강 취소 시 대기열 승격 누락 버그 수정
  - updateEnrollmentStatusPromote 추가 (AND status = 'WAITLIST' 조건으로 원자적 승격)
  - 마이페이지 대기열 순번 조회 N+1 서브쿼리 → RANK() 윈도우 함수(LEFT JOIN)로 개선
  - 동시 취소 시나리오 테스트 케이스 2건 추가
  
  ## 구현 시 고려한 점
  - 기존 승격 로직은 동시 취소 시 여러 스레드가 동일 대기자를 조회해 일부 대기자가 승격되지 않는 문제 존재
  - updateEnrollmentStatusPromote에 AND status = 'WAITLIST' 조건을 추가해 중복 승격 방지
  - enrolled_count 선차감 후 승격 재시도 루프로 다중 대기자 순차 승격 보장
  - 순번 조회는 전체 WAITLIST 대상으로 먼저 계산 후 userId 필터 적용
  
  ## 테스트 방법
  - 백엔드: IDE에서 CourseEnrollmentApplication 실행 (Port: 8080)
  - 프론트: npm run dev (Port: 5173)
  - http://localhost:5173/my-page 에서 자바 최적화(GC의 이해) 강의 대기 순번 1, 2번 확인
  - 동시성 테스트: EnrollmentConcurrencyTest 전체 실행
  
 ## 연관 이슈
 Closes #26 