### PR TITLE
[feat] 토스페이먼츠 결제 연동 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/config/TossPaymentConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/TossPaymentConfig.java
@@ -1,0 +1,16 @@
+package com.yujin.course_enrollment.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 토스페이먼츠 HTTP 클라이언트 설정
+ */
+@Configuration
+public class TossPaymentConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
@@ -1,0 +1,40 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.PaymentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 결제 컨트롤러
+ * 토스페이먼츠 결제 승인 관련 HTTP 요청을 처리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    /**
+     * 토스페이먼츠 결제 승인
+     * POST /api/payments/confirm
+     * @param userId 사용자 ID (헤더로 전달)
+     * @param req 결제 승인 요청 DTO (enrollmentId, paymentKey, orderId, orderName, amount)
+     * @return 저장된 결제 응답 DTO
+     */
+    @PostMapping("/confirm")
+    public ResponseEntity<ApiResponse<RespPaymentDto>> confirmPayment(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqPaymentConfirmDto req) {
+        log.debug("[PaymentController] 결제 승인 요청 - userId: {}, enrollmentId: {}", userId, req.getEnrollmentId());
+
+        RespPaymentDto result = paymentService.confirmPayment(userId, req);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqPaymentConfirmDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqPaymentConfirmDto.java
@@ -1,0 +1,31 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 승인 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqPaymentConfirmDto {
+    @NotNull(message = "수강 신청 ID는 필수입니다.")
+    private Long enrollmentId;
+
+    @NotBlank(message = "결제 키는 필수입니다.")
+    private String paymentKey;
+
+    @NotBlank(message = "주문 ID는 필수입니다.")
+    private String orderId;
+
+    @NotBlank(message = "주문명은 필수입니다.")
+    private String orderName;
+
+    @Positive(message = "결제 금액은 0보다 커야 합니다.")
+    private int amount;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespPaymentDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespPaymentDto.java
@@ -1,0 +1,50 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import com.yujin.course_enrollment.entity.Payment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 결제 응답 DTO
+ * 결제 승인 응답
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class RespPaymentDto {
+    private Long id;
+    private Long enrollmentId;
+    private String paymentKey;
+    private String orderId;
+    private String orderName;
+    private int amount;
+    private String method;
+    private String status;
+    private LocalDateTime paidAt;
+    private LocalDateTime canceledAt;
+    private String cancelReason;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /* Payment 엔티티 → 응답 DTO 변환 */
+    public static RespPaymentDto of(Payment payment) {
+        return RespPaymentDto.builder()
+                .id(payment.getId())
+                .enrollmentId(payment.getEnrollmentId())
+                .paymentKey(payment.getPaymentKey())
+                .orderId(payment.getOrderId())
+                .orderName(payment.getOrderName())
+                .amount(payment.getAmount())
+                .method(payment.getMethod())
+                .status(payment.getStatus())
+                .paidAt(payment.getPaidAt())
+                .canceledAt(payment.getCanceledAt())
+                .cancelReason(payment.getCancelReason())
+                .createdAt(payment.getCreatedAt())
+                .updatedAt(payment.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Payment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Payment.java
@@ -1,0 +1,54 @@
+package com.yujin.course_enrollment.entity;
+
+import com.yujin.course_enrollment.global.PaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 결제 엔티티
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment {
+    private Long id;
+    private Long enrollmentId;
+    private String paymentKey;
+    private String orderId;
+    private String orderName;
+    private int amount;
+    private String method;
+    private String status;
+    private LocalDateTime paidAt;
+    private LocalDateTime canceledAt;
+    private String cancelReason;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /* 토스 API 호출 전 결제 선저장용 엔티티 생성 */
+    public static Payment ofPending(Long enrollmentId, String orderId, String orderName, int amount) {
+        return Payment.builder()
+                .enrollmentId(enrollmentId)
+                .orderId(orderId)
+                .orderName(orderName)
+                .amount(amount)
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+
+    /* 토스 승인 완료 후 DONE 업데이트용 엔티티 생성 */
+    public static Payment ofDone(Long id, String paymentKey, String method, LocalDateTime paidAt) {
+        return Payment.builder()
+                .id(id)
+                .paymentKey(paymentKey)
+                .method(method)
+                .status(PaymentStatus.DONE)
+                .paidAt(paidAt)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/global/PaymentStatus.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/PaymentStatus.java
@@ -1,0 +1,13 @@
+package com.yujin.course_enrollment.global;
+
+/**
+ * 결제 상태 관리 클래스
+ */
+public class PaymentStatus {
+    public static final String PENDING = "PENDING";
+    public static final String DONE = "DONE";
+    public static final String FAILED = "FAILED";
+    public static final String CANCELLED = "CANCELLED";
+
+    private PaymentStatus() {}
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -1,0 +1,23 @@
+package com.yujin.course_enrollment.mapper;
+
+import com.yujin.course_enrollment.entity.Payment;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 결제 Mapper 인터페이스
+ * PaymentMapper.xml과 매핑되어 결제 관련 DB 접근을 담당
+ */
+@Mapper
+public interface PaymentMapper {
+    /* 결제 저장 (PENDING 상태로 선저장) */
+    void insertPayment(Payment payment);
+
+    /* 결제 승인 완료 (DONE 상태로 업데이트) */
+    void updatePaymentDone(Payment payment);
+
+    /* 결제 승인 실패 (FAILED 상태로 업데이트) */
+    void updatePaymentFailed(Long id);
+
+    /* 주문 ID로 결제 조회 */
+    Payment selectPaymentByOrderId(String orderId);
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -2,9 +2,11 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
 import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
+import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.Payment;
 import com.yujin.course_enrollment.global.EnrollmentStatus;
+import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
@@ -63,23 +65,35 @@ public class PaymentService {
         }
 
         // 결제 금액 검증 (프론트 조작 방지)
-        int coursePrice = courseMapper.selectCourseById(enrollment.getCourseId()).getPrice();
+        Course course = courseMapper.selectCourseById(enrollment.getCourseId());
+        if (course == null) {
+            log.warn("[PaymentService] 강의 없음 - courseId: {}", enrollment.getCourseId());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
+        }
+
+        int coursePrice = course.getPrice();
         if (coursePrice != reqPaymentConfirmDto.getAmount()) {
             log.warn("[PaymentService] 금액 불일치 - enrollmentId: {}, coursePrice: {}, reqAmount: {}", reqPaymentConfirmDto.getEnrollmentId(), coursePrice, reqPaymentConfirmDto.getAmount());
             throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 금액이 강의 가격과 일치하지 않습니다.");
         }
 
-        // 중복 결제 방지
-        if (paymentMapper.selectPaymentByOrderId(reqPaymentConfirmDto.getOrderId()) != null) {
-            log.warn("[PaymentService] 중복 결제 - orderId: {}", reqPaymentConfirmDto.getOrderId());
-            throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다.");
-        }
-
-        // PENDING 선저장 (토스 API 호출 전 DB에 기록)
+        // PENDING 선저장 (INSERT IGNORE: 중복 orderId는 무시하고 기존 레코드 유지)
         Payment pending = Payment.ofPending(reqPaymentConfirmDto.getEnrollmentId(), reqPaymentConfirmDto.getOrderId(), reqPaymentConfirmDto.getOrderName(), reqPaymentConfirmDto.getAmount());
         paymentMapper.insertPayment(pending);
 
         Payment inserted = paymentMapper.selectPaymentByOrderId(reqPaymentConfirmDto.getOrderId());
+
+        // 이미 완료된 결제 (페이지 새로고침 등 재요청) → 기존 결과 반환
+        if (PaymentStatus.DONE.equals(inserted.getStatus())) {
+            log.info("[PaymentService] 이미 완료된 결제 재요청 - orderId: {}", reqPaymentConfirmDto.getOrderId());
+            return RespPaymentDto.of(inserted);
+        }
+
+        // PENDING 이외 상태 (FAILED 등) → 재시도 불가
+        if (!PaymentStatus.PENDING.equals(inserted.getStatus())) {
+            log.warn("[PaymentService] 처리 불가 상태 - orderId: {}, status: {}", reqPaymentConfirmDto.getOrderId(), inserted.getStatus());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "처리할 수 없는 결제 상태입니다.");
+        }
 
         // 토스 API 결제 승인
         try {

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -1,0 +1,103 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
+import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.entity.Payment;
+import com.yujin.course_enrollment.global.EnrollmentStatus;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.PaymentMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 서비스
+ * 토스페이먼츠 결제 승인 및 수강 신청 상태 변경을 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+    private final PaymentMapper paymentMapper;
+    private final EnrollmentMapper enrollmentMapper;
+    private final CourseMapper courseMapper;
+    private final TossPaymentClient tossPaymentClient;
+
+    /**
+     * 토스페이먼츠 결제 승인
+     * 결제 전 금액을 DB 강의 가격과 교차 검증하고, PENDING 선저장 후 승인
+     * 토스 API 실패 시 FAILED로 업데이트 (noRollbackFor로 커밋 보장)
+     * @param userId 사용자 ID
+     * @param reqPaymentConfirmDto 결제 승인 요청 DTO (enrollmentId, paymentKey, orderId, orderName, amount)
+     * @return 저장된 결제 응답 DTO
+     * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), PENDING 아님(400), 금액 불일치(400), 중복 결제(400), 토스 API 실패(400)
+     */
+    @Transactional(noRollbackFor = BusinessException.class)
+    public RespPaymentDto confirmPayment(Long userId, ReqPaymentConfirmDto reqPaymentConfirmDto) {
+        log.info("[PaymentService] 결제 승인 - userId: {}, enrollmentId: {}, orderId: {}", userId, reqPaymentConfirmDto.getEnrollmentId(), reqPaymentConfirmDto.getOrderId());
+
+        // 수강 신청 존재 여부 확인
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentById(reqPaymentConfirmDto.getEnrollmentId());
+        if (enrollment == null) {
+            log.warn("[PaymentService] 수강 신청 없음 - enrollmentId: {}", reqPaymentConfirmDto.getEnrollmentId());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 수강 신청입니다.");
+        }
+
+        // 본인 신청 확인
+        if (!enrollment.getUserId().equals(userId)) {
+            log.warn("[PaymentService] 본인 신청 아님 - userId: {}, enrollmentId: {}", userId, reqPaymentConfirmDto.getEnrollmentId());
+            throw new BusinessException(HttpStatus.FORBIDDEN, "본인의 수강 신청만 결제할 수 있습니다.");
+        }
+
+        // PENDING 상태 확인
+        if (!EnrollmentStatus.PENDING.equals(enrollment.getStatus())) {
+            log.warn("[PaymentService] PENDING 상태 아님 - enrollmentId: {}, status: {}", reqPaymentConfirmDto.getEnrollmentId(), enrollment.getStatus());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "PENDING 상태의 수강 신청만 결제할 수 있습니다.");
+        }
+
+        // 결제 금액 검증 (프론트 조작 방지)
+        int coursePrice = courseMapper.selectCourseById(enrollment.getCourseId()).getPrice();
+        if (coursePrice != reqPaymentConfirmDto.getAmount()) {
+            log.warn("[PaymentService] 금액 불일치 - enrollmentId: {}, coursePrice: {}, reqAmount: {}", reqPaymentConfirmDto.getEnrollmentId(), coursePrice, reqPaymentConfirmDto.getAmount());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 금액이 강의 가격과 일치하지 않습니다.");
+        }
+
+        // 중복 결제 방지
+        if (paymentMapper.selectPaymentByOrderId(reqPaymentConfirmDto.getOrderId()) != null) {
+            log.warn("[PaymentService] 중복 결제 - orderId: {}", reqPaymentConfirmDto.getOrderId());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다.");
+        }
+
+        // PENDING 선저장 (토스 API 호출 전 DB에 기록)
+        Payment pending = Payment.ofPending(reqPaymentConfirmDto.getEnrollmentId(), reqPaymentConfirmDto.getOrderId(), reqPaymentConfirmDto.getOrderName(), reqPaymentConfirmDto.getAmount());
+        paymentMapper.insertPayment(pending);
+
+        Payment inserted = paymentMapper.selectPaymentByOrderId(reqPaymentConfirmDto.getOrderId());
+
+        // 토스 API 결제 승인
+        try {
+            TossPaymentClient.TossConfirmResponse tossResponse = tossPaymentClient.confirm(reqPaymentConfirmDto.getPaymentKey(), reqPaymentConfirmDto.getOrderId(), reqPaymentConfirmDto.getAmount());
+
+            // 결제 완료: DONE 업데이트 + enrollment CONFIRMED
+            paymentMapper.updatePaymentDone(Payment.ofDone(inserted.getId(), tossResponse.getPaymentKey(), tossResponse.getMethod(), tossResponse.getApprovedAtAsLocalDateTime()));
+            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofConfirm(reqPaymentConfirmDto.getEnrollmentId()));
+
+        } catch (BusinessException e) {
+            // 토스 API 실패: FAILED 업데이트 후 예외 전파 (noRollbackFor로 커밋됨)
+            log.warn("[PaymentService] 결제 승인 실패 - enrollmentId: {}, orderId: {}", reqPaymentConfirmDto.getEnrollmentId(), reqPaymentConfirmDto.getOrderId());
+            paymentMapper.updatePaymentFailed(inserted.getId());
+            throw e;
+        }
+
+        log.info("[PaymentService] 결제 승인 완료 - enrollmentId: {}, orderId: {}", reqPaymentConfirmDto.getEnrollmentId(), reqPaymentConfirmDto.getOrderId());
+
+        return RespPaymentDto.of(paymentMapper.selectPaymentByOrderId(reqPaymentConfirmDto.getOrderId()));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/TossPaymentClient.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/TossPaymentClient.java
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class TossPaymentClient {
      */
     public TossConfirmResponse confirm(String paymentKey, String orderId, int amount) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Basic " + Base64.getEncoder().encodeToString((secretKey + ":").getBytes()));
+        headers.set("Authorization", "Basic " + Base64.getEncoder().encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8)));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, Object> body = new HashMap<>();
@@ -56,14 +57,22 @@ public class TossPaymentClient {
 
         try {
             ResponseEntity<TossConfirmResponse> response = restTemplate.exchange(confirmUrl, HttpMethod.POST, new HttpEntity<>(body, headers), TossConfirmResponse.class);
+            TossConfirmResponse responseBody = response.getBody();
+
+            if (responseBody == null) {
+                log.error("[TossPaymentClient] 결제 승인 응답 body 없음 - orderId: {}", orderId);
+                throw new BusinessException(HttpStatus.INTERNAL_SERVER_ERROR, "결제 승인 응답이 비어있습니다.");
+            }
+
             log.info("[TossPaymentClient] 결제 승인 성공 - orderId: {}", orderId);
-            return response.getBody();
+
+            return responseBody;
         } catch (HttpClientErrorException e) {
-            log.warn("[TossPaymentClient] 결제 승인 실패 - orderId: {}, status: {}", orderId, e.getStatusCode());
+            log.warn("[TossPaymentClient] 결제 승인 실패 - orderId: {}, status: {}, body: {}", orderId, e.getStatusCode(), e.getResponseBodyAsString());
             throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 승인에 실패했습니다.");
         } catch (RestClientException e) {
             log.error("[TossPaymentClient] 토스 API 통신 오류 - orderId: {}, message: {}", orderId, e.getMessage());
-            throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 처리 중 오류가 발생했습니다.");
+            throw new BusinessException(HttpStatus.BAD_GATEWAY, "결제 처리 중 오류가 발생했습니다.");
         }
     }
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/TossPaymentClient.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/TossPaymentClient.java
@@ -1,0 +1,92 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 토스페이먼츠 결제 API 클라이언트
+ * 결제 승인 API 호출을 담당
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TossPaymentClient {
+
+    @Value("${toss.secret-key}")
+    private String secretKey;
+
+    @Value("${toss.confirm-url}")
+    private String confirmUrl;
+
+    private final RestTemplate restTemplate;
+
+    /**
+     * 토스페이먼츠 결제 승인 API 호출
+     * @param paymentKey 결제 키
+     * @param orderId 주문 ID
+     * @param amount 결제 금액
+     * @return 토스페이먼츠 결제 승인 응답
+     * @throws BusinessException 토스 API 승인 실패 시 (400)
+     */
+    public TossConfirmResponse confirm(String paymentKey, String orderId, int amount) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Basic " + Base64.getEncoder().encodeToString((secretKey + ":").getBytes()));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("paymentKey", paymentKey);
+        body.put("orderId", orderId);
+        body.put("amount", amount);
+
+        try {
+            ResponseEntity<TossConfirmResponse> response = restTemplate.exchange(confirmUrl, HttpMethod.POST, new HttpEntity<>(body, headers), TossConfirmResponse.class);
+            log.info("[TossPaymentClient] 결제 승인 성공 - orderId: {}", orderId);
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            log.warn("[TossPaymentClient] 결제 승인 실패 - orderId: {}, status: {}", orderId, e.getStatusCode());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 승인에 실패했습니다.");
+        } catch (RestClientException e) {
+            log.error("[TossPaymentClient] 토스 API 통신 오류 - orderId: {}, message: {}", orderId, e.getMessage());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 토스페이먼츠 결제 승인 응답
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TossConfirmResponse {
+        private String paymentKey;
+        private String orderId;
+        private String orderName;
+        private int totalAmount;
+        private String method;
+        private String status;
+        private String approvedAt;
+
+        /* ISO 8601 문자열 → LocalDateTime 변환 (e.g. "2024-01-01T10:00:00+09:00") */
+        public LocalDateTime getApprovedAtAsLocalDateTime() {
+            if (approvedAt == null) return null;
+
+            return OffsetDateTime.parse(approvedAt).toLocalDateTime();
+        }
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -32,3 +32,7 @@ mybatis:
 logging:
   level:
     com.yujin.course_enrollment: DEBUG
+
+toss:
+  secret-key: ${TOSS_SECRET_KEY:}
+  confirm-url: https://api.tosspayments.com/v1/payments/confirm

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -85,8 +85,8 @@
     <select id="selectEnrollmentListByUserId" parameterType="ReqEnrollmentPageDto" resultType="RespEnrollmentStudentDto">
         SELECT e.id
              , e.course_id
-             , c.title        AS courseTitle
-             , c.status       AS courseStatus
+             , c.title AS courseTitle
+             , c.status AS courseStatus
              , c.price
              , c.start_date
              , c.end_date

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yujin.course_enrollment.mapper.PaymentMapper">
+
+    <!-- 결제 저장 -->
+    <insert id="insertPayment" parameterType="Payment" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO payments (
+                enrollment_id
+              , payment_key
+              , order_id
+              , order_name
+              , amount
+              , method
+              , status
+              , paid_at
+        ) VALUES (
+                #{enrollmentId}
+              , #{paymentKey}
+              , #{orderId}
+              , #{orderName}
+              , #{amount}
+              , #{method}
+              , #{status}
+              , #{paidAt}
+        )
+    </insert>
+
+    <!-- 결제 승인 완료 (DONE 업데이트) -->
+    <update id="updatePaymentDone" parameterType="Payment">
+        UPDATE payments
+           SET payment_key = #{paymentKey}
+             , method      = #{method}
+             , status      = #{status}
+             , paid_at     = #{paidAt}
+         WHERE id = #{id}
+    </update>
+
+    <!-- 결제 승인 실패 (FAILED 업데이트) -->
+    <update id="updatePaymentFailed" parameterType="Long">
+        UPDATE payments
+           SET status = 'FAILED'
+         WHERE id = #{id}
+    </update>
+
+    <!-- 주문 ID로 결제 조회 -->
+    <select id="selectPaymentByOrderId" parameterType="String" resultType="Payment">
+        SELECT id
+             , enrollment_id
+             , payment_key
+             , order_id
+             , order_name
+             , amount
+             , method
+             , status
+             , paid_at
+             , canceled_at
+             , cancel_reason
+             , created_at
+             , updated_at
+          FROM payments
+         WHERE order_id = #{orderId}
+    </select>
+
+</mapper>

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -5,7 +5,7 @@
 
     <!-- 결제 저장 -->
     <insert id="insertPayment" parameterType="Payment" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO payments (
+        INSERT IGNORE INTO payments (
                 enrollment_id
               , payment_key
               , order_id

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS payments;
 DROP TABLE IF EXISTS enrollments;
 DROP TABLE IF EXISTS courses;
 DROP TABLE IF EXISTS users;
@@ -39,3 +40,20 @@ CREATE TABLE enrollments (
 
 CREATE UNIQUE INDEX idx_enrollment_user_course ON enrollments(user_id, course_id);
 CREATE INDEX idx_enrollment_course             ON enrollments(course_id);
+
+CREATE TABLE payments (
+                          id            BIGINT       AUTO_INCREMENT PRIMARY KEY,
+                          enrollment_id BIGINT       NOT NULL,
+                          payment_key   VARCHAR(200),
+                          order_id      VARCHAR(64)  NOT NULL UNIQUE,
+                          order_name    VARCHAR(200) NOT NULL,
+                          amount        INT          NOT NULL,
+                          method        VARCHAR(20),
+                          status        VARCHAR(20)  NOT NULL,
+                          paid_at       DATETIME,
+                          canceled_at   DATETIME,
+                          cancel_reason VARCHAR(200),
+                          created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                          updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                          FOREIGN KEY (enrollment_id) REFERENCES enrollments(id) ON DELETE RESTRICT
+);

--- a/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
@@ -1,0 +1,249 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
+import com.yujin.course_enrollment.entity.Course;
+import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.entity.Payment;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.PaymentMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * 결제 서비스 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Mock
+    private PaymentMapper paymentMapper;
+
+    @Mock
+    private EnrollmentMapper enrollmentMapper;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @Mock
+    private TossPaymentClient tossPaymentClient;
+
+    @Test
+    @DisplayName("결제 승인 성공")
+    void confirmPayment_success() {
+        // given
+        Long userId = 4L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(1L, "tgen_abc123", "order_001", "Spring Boot 강의", 50000);
+        Enrollment pending = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(1L)
+                .status("PENDING").build();
+        Course course = Course.builder()
+                .id(1L)
+                .price(50000)
+                .build();
+        TossPaymentClient.TossConfirmResponse tossResponse = new TossPaymentClient.TossConfirmResponse(
+                "tgen_abc123", "order_001", "Spring Boot 강의", 50000, "카드", "DONE", "2024-01-01T10:00:00+09:00"
+        );
+        Payment inserted = Payment.builder()
+                .id(1L)
+                .enrollmentId(1L)
+                .orderId("order_001")
+                .status("PENDING")
+                .build();
+        Payment done = Payment.builder()
+                .id(1L)
+                .enrollmentId(1L)
+                .paymentKey("tgen_abc123")
+                .orderId("order_001")
+                .orderName("Spring Boot 강의")
+                .amount(50000).method("카드")
+                .status("DONE")
+                .paidAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(null).willReturn(inserted).willReturn(done);
+        willDoNothing().given(paymentMapper).insertPayment(any());
+        given(tossPaymentClient.confirm("tgen_abc123", "order_001", 50000)).willReturn(tossResponse);
+        willDoNothing().given(paymentMapper).updatePaymentDone(any());
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+
+        // when
+        RespPaymentDto result = paymentService.confirmPayment(userId, req);
+
+        // then
+        assertThat(result.getOrderId()).isEqualTo("order_001");
+        assertThat(result.getStatus()).isEqualTo("DONE");
+        assertThat(result.getAmount()).isEqualTo(50000);
+        then(paymentMapper).should().insertPayment(any());
+        then(paymentMapper).should().updatePaymentDone(any());
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 수강 신청 - 결제 승인 실패")
+    void confirmPayment_fail_enrollmentNotFound() {
+        // given
+        Long userId = 4L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(999L, "tgen_abc123", "order_001", "강의명", 50000);
+        given(enrollmentMapper.selectEnrollmentById(999L)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("존재하지 않는 수강 신청입니다.");
+    }
+
+    @Test
+    @DisplayName("본인 신청 아님 - 결제 승인 실패")
+    void confirmPayment_fail_notOwner() {
+        // given
+        Long userId = 99L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(1L, "tgen_abc123", "order_001", "강의명", 50000);
+        Enrollment pending = Enrollment.builder()
+                .id(1L)
+                .userId(4L)
+                .courseId(1L)
+                .status("PENDING")
+                .build();
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("본인의 수강 신청만 결제할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("PENDING 상태 아님 - 결제 승인 실패")
+    void confirmPayment_fail_notPending() {
+        // given
+        Long userId = 4L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(1L, "tgen_abc123", "order_001", "강의명", 50000);
+        Enrollment confirmed = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(1L)
+                .status("CONFIRMED")
+                .build();
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(confirmed);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("PENDING 상태의 수강 신청만 결제할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("금액 불일치 - 결제 승인 실패")
+    void confirmPayment_fail_amountMismatch() {
+        // given
+        Long userId = 4L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(1L, "tgen_abc123", "order_001", "강의명", 30000);
+        Enrollment pending = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(1L)
+                .status("PENDING")
+                .build();
+        Course course = Course.builder()
+                .id(1L)
+                .price(50000)
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("결제 금액이 강의 가격과 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("중복 결제 - 결제 승인 실패")
+    void confirmPayment_fail_duplicate() {
+        // given
+        Long userId = 4L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(1L, "tgen_abc123", "order_001", "강의명", 50000);
+        Enrollment pending = Enrollment.builder()
+                .id(1L)
+                .userId(userId).courseId(1L)
+                .status("PENDING")
+                .build();
+        Course course = Course.builder()
+                .id(1L)
+                .price(50000)
+                .build();
+        Payment existing = Payment.builder()
+                .id(1L)
+                .orderId("order_001")
+                .status("DONE")
+                .build();
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(existing);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 처리된 결제입니다.");
+    }
+
+    @Test
+    @DisplayName("토스 API 실패 - FAILED 업데이트 후 예외 전파")
+    void confirmPayment_fail_tossApiError() {
+        // given
+        Long userId = 4L;
+        ReqPaymentConfirmDto req = new ReqPaymentConfirmDto(1L, "tgen_invalid", "order_001", "강의명", 50000);
+        Enrollment pending = Enrollment.builder()
+                .id(1L)
+                .userId(userId)
+                .courseId(1L)
+                .status("PENDING")
+                .build();
+        Course course = Course.builder()
+                .id(1L)
+                .price(50000)
+                .build();
+        Payment inserted = Payment.builder()
+                .id(1L)
+                .orderId("order_001")
+                .status("PENDING")
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(null).willReturn(inserted);
+        willDoNothing().given(paymentMapper).insertPayment(any());
+        given(tossPaymentClient.confirm("tgen_invalid", "order_001", 50000)).willThrow(new BusinessException(org.springframework.http.HttpStatus.BAD_REQUEST, "결제 승인에 실패했습니다."));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("결제 승인에 실패했습니다.");
+
+        then(paymentMapper).should().insertPayment(any());
+        then(paymentMapper).should().updatePaymentFailed(1L);
+        then(paymentMapper).should(never()).updatePaymentDone(any());
+        then(enrollmentMapper).should(never()).updateEnrollmentStatus(any());
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
@@ -80,7 +80,7 @@ class PaymentServiceTest {
 
         given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
         given(courseMapper.selectCourseById(1L)).willReturn(course);
-        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(null).willReturn(inserted).willReturn(done);
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(inserted).willReturn(done);
         willDoNothing().given(paymentMapper).insertPayment(any());
         given(tossPaymentClient.confirm("tgen_abc123", "order_001", 50000)).willReturn(tossResponse);
         willDoNothing().given(paymentMapper).updatePaymentDone(any());
@@ -201,11 +201,15 @@ class PaymentServiceTest {
         given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
         given(courseMapper.selectCourseById(1L)).willReturn(course);
         given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(existing);
+        willDoNothing().given(paymentMapper).insertPayment(any());
 
-        // when & then
-        assertThatThrownBy(() -> paymentService.confirmPayment(userId, req))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("이미 처리된 결제입니다.");
+        // when — 이미 DONE인 경우 멱등 처리: 기존 결과 반환
+        RespPaymentDto result = paymentService.confirmPayment(userId, req);
+
+        // then
+        assertThat(result.getOrderId()).isEqualTo("order_001");
+        assertThat(result.getStatus()).isEqualTo("DONE");
+        then(tossPaymentClient).should(never()).confirm(any(), any(), anyInt());
     }
 
     @Test
@@ -232,7 +236,7 @@ class PaymentServiceTest {
 
         given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(pending);
         given(courseMapper.selectCourseById(1L)).willReturn(course);
-        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(null).willReturn(inserted);
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(inserted);
         willDoNothing().given(paymentMapper).insertPayment(any());
         given(tossPaymentClient.confirm("tgen_invalid", "order_001", 50000)).willThrow(new BusinessException(org.springframework.http.HttpStatus.BAD_REQUEST, "결제 승인에 실패했습니다."));
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# env files
+.env

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
+
+<head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>frontend</title>
-  </head>
-  <body>
+</head>
+
+<body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-  </body>
+</body>
+
 </html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.4",
+        "@tosspayments/tosspayments-sdk": "^2.7.0",
         "axios": "^1.15.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -1130,6 +1131,12 @@
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.4"
       }
+    },
+    "node_modules/@tosspayments/tosspayments-sdk": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.7.0.tgz",
+      "integrity": "sha512-qpVIMpxdmKNOKwOZuSbkyGO5CpbF3+kqJcHLjGsTdyOsNex8ai+ceQc7zyCJhq+qZf9jglJpx9Q0bGVWwGjcbQ==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.4",
+    "@tosspayments/tosspayments-sdk": "^2.7.0",
     "axios": "^1.15.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,8 @@ import CourseRegisterPage from './pages/CourseRegisterPage'
 import CourseListPage from './pages/CourseListPage'
 import CourseDetailPage from './pages/CourseDetailPage'
 import MyPage from './pages/MyPage'
+import PaymentSuccessPage from './pages/PaymentSuccessPage'
+import PaymentFailPage from './pages/PaymentFailPage'
 
 /* 비회원도 접근 가능한 공개 라우트 */
 const PublicRoute = ({ children }) => <Layout>{children}</Layout>;
@@ -37,6 +39,8 @@ function App() {
                 <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
                 <Route path="/courses/:courseId/edit" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
                 <Route path="/my-page" element={<PrivateRoute><MyPage /></PrivateRoute>} />
+                <Route path="/payment/success" element={<PrivateRoute><PaymentSuccessPage /></PrivateRoute>} />
+                <Route path="/payment/fail" element={<PrivateRoute><PaymentFailPage /></PrivateRoute>} />
                 <Route path="*" element={<Navigate to="/courses" replace />} />
             </Routes>
         </AuthProvider>

--- a/frontend/src/api/payment.js
+++ b/frontend/src/api/payment.js
@@ -1,0 +1,6 @@
+import instance from './axios';
+
+/* 토스페이먼츠 결제 승인 */
+export const confirmPayment = ({ enrollmentId, paymentKey, orderId, orderName, amount }, signal) => {
+    return instance.post('/api/payments/confirm', { enrollmentId, paymentKey, orderId, orderName, amount }, { signal }).then(res => res.data);
+};

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
 import { cancelEnrollment, confirmEnrollment, getMyEnrollments } from '../api/enrollment';
 import { getCourseEnrollments, getMyCourses } from '../api/course';
 import { useAuth } from '../context/AuthContext';
@@ -27,6 +28,8 @@ const MyPage = () => {
     const [courseEnrollmentData, setCourseEnrollmentData] = useState({ content: [], totalCount: 0, totalPages: 0, last: false });
     /* 수강생 목록 페이지 상태 */
     const [studentPage, setStudentPage] = useState(0);
+    /* 결제 진행 중 상태 (이중 클릭 방지) */
+    const [isPaymentLoading, setIsPaymentLoading] = useState(false);
 
     /* 나의 수강목록 조회 */
     const fetchMyEnrollments = async (page = 0) => {
@@ -95,16 +98,43 @@ const MyPage = () => {
         fetchCourseEnrollments(courseId, 0);
     };
 
-    /* 결제 요청 */
-    const handleConfirm = async (enrollmentId) => {
-        if (!window.confirm('결제하시겠습니까?')) return;
+    /* 유료 강의 결제 (토스페이먼츠) */
+    const handlePayment = async (enrollment) => {
+        setIsPaymentLoading(true);
+        try {
+            const tossPayments = await loadTossPayments(import.meta.env.VITE_TOSS_CLIENT_KEY);
+            const payment = tossPayments.payment({ customerKey: `CUSTOMER-${user.id}` });
+
+            await payment.requestPayment({
+                method: 'CARD',
+                amount: { currency: 'KRW', value: enrollment.price },
+                orderId: `ORDER-${enrollment.id}-${Date.now()}`,
+                orderName: enrollment.courseTitle,
+                successUrl: `${window.location.origin}/payment/success?enrollmentId=${enrollment.id}&orderName=${encodeURIComponent(enrollment.courseTitle)}`,
+                failUrl: `${window.location.origin}/payment/fail`,
+                card: {
+                    useEscrow: false,
+                    flowMode: 'DEFAULT',
+                    useCardPoint: false,
+                    useAppCardOnly: false,
+                },
+            });
+        } catch (err) {
+            alert(err.message || '결제 요청에 실패했습니다.');
+            setIsPaymentLoading(false);
+        }
+    };
+
+    /* 무료 강의 수강 확정 */
+    const handleFreeConfirm = async (enrollmentId) => {
+        if (!window.confirm('수강을 확정하시겠습니까?')) return;
 
         try {
             await confirmEnrollment(enrollmentId);
-            alert('결제가 완료되었습니다.');
+            alert('수강이 확정되었습니다.');
             fetchMyEnrollments(enrollmentPage);
         } catch (err) {
-            alert(err.response?.data?.message || '결제에 실패했습니다.');
+            alert(err.response?.data?.message || '수강 확정에 실패했습니다.');
         }
     };
 
@@ -207,10 +237,11 @@ const MyPage = () => {
                                         {enrollment.status === 'PENDING' && (
                                             <>
                                                 <button
-                                                    onClick={() => handleConfirm(enrollment.id)}
-                                                    className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer"
+                                                    onClick={() => enrollment.price > 0 ? handlePayment(enrollment) : handleFreeConfirm(enrollment.id)}
+                                                    disabled={isPaymentLoading}
+                                                    className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                                                 >
-                                                    결제하기
+                                                    {enrollment.price > 0 ? '결제하기' : '수강 확정하기'}
                                                 </button>
                                                 <button
                                                     onClick={() => handleCancel(enrollment.id)}

--- a/frontend/src/pages/PaymentFailPage.jsx
+++ b/frontend/src/pages/PaymentFailPage.jsx
@@ -1,0 +1,46 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+/* 결제 실패 페이지 */
+const PaymentFailPage = () => {
+    /* 페이지 이동을 위한 네비게이트 함수 */
+    const navigate = useNavigate();
+    /* URL 검색 파라미터에서 결제 실패 정보 추출 */
+    const [searchParams] = useSearchParams();
+    /* 결제 실패 정보 (code, message, orderId) */
+    const code = searchParams.get('code');
+    /* 결제 실패 메시지, 주문번호 등은 URL 파라미터로 전달받음 */
+    const message = searchParams.get('message');
+    /* 주문번호는 결제 실패 시에도 URL 파라미터로 전달될 수 있음 */
+    const orderId = searchParams.get('orderId');
+
+    return (
+        <div className="max-w-lg mx-auto mt-20 p-8 text-center">
+            <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg className="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </div>
+
+            <h1 className="text-2xl font-extrabold text-gray-900 mb-3">결제가 취소되었습니다</h1>
+
+            {message && (
+                <p className="text-gray-500 mb-2">{message}</p>
+            )}
+            {code && (
+                <p className="text-xs text-gray-400 mb-6">오류 코드: {code}</p>
+            )}
+            {orderId && (
+                <p className="text-xs text-gray-400 mb-6">주문번호: {orderId}</p>
+            )}
+
+            <button
+                onClick={() => navigate('/my-page', { state: { tab: 'enrollments' } })}
+                className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer"
+            >
+                마이페이지로 돌아가기
+            </button>
+        </div>
+    );
+};
+
+export default PaymentFailPage;

--- a/frontend/src/pages/PaymentSuccessPage.jsx
+++ b/frontend/src/pages/PaymentSuccessPage.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { confirmPayment } from '../api/payment';
+
+/* 결제 성공 처리 페이지 */
+const PaymentSuccessPage = () => {
+    /* 페이지 이동을 위한 네비게이트 함수 */
+    const navigate = useNavigate();
+    /* URL 검색 파라미터에서 결제 정보 추출 */
+    const [searchParams] = useSearchParams();
+    /* 결제 확인 상태 (loading / success / error) */
+    const [status, setStatus] = useState('loading');
+    /* 오류 시 표시할 주문번호 */
+    const [orderId, setOrderId] = useState('');
+
+    /* 마운트 시 URL 파라미터로 백엔드 결제 승인 요청 */
+    useEffect(() => {
+        const controller = new AbortController();
+        const paymentKey = searchParams.get('paymentKey');
+        const rawOrderId = searchParams.get('orderId');
+        const amount = parseInt(searchParams.get('amount'), 10);
+        const enrollmentId = parseInt(searchParams.get('enrollmentId'), 10);
+        const orderName = searchParams.get('orderName');
+
+        setOrderId(rawOrderId);
+
+        confirmPayment({ enrollmentId, paymentKey, orderId: rawOrderId, orderName, amount }, controller.signal)
+            .then(() => setStatus('success'))
+            .catch((err) => {
+                if (err?.code === 'ERR_CANCELED') return;
+                setStatus('error');
+            });
+
+        return () => controller.abort();
+    }, [searchParams]);
+
+    /* 상태에 따른 UI 렌더링 */
+    if (status === 'loading') {
+        return (
+            <div className="max-w-lg mx-auto mt-20 p-8 text-center">
+                <div className="w-12 h-12 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-6" />
+                <p className="text-gray-500 font-medium">결제를 확인하는 중입니다...</p>
+            </div>
+        );
+    }
+
+    if (status === 'error') {
+        return (
+            <div className="max-w-lg mx-auto mt-20 p-8 text-center">
+                <div className="w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center mx-auto mb-6">
+                    <svg className="w-8 h-8 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01M12 3a9 9 0 110 18A9 9 0 0112 3z" />
+                    </svg>
+                </div>
+                <h1 className="text-2xl font-extrabold text-gray-900 mb-3">결제 확인 중 오류가 발생했습니다</h1>
+                <p className="text-gray-500 mb-2">결제는 완료되었으나 시스템 오류가 발생했습니다.</p>
+                <p className="text-sm text-gray-400 mb-6">주문번호 <span className="font-mono font-semibold">{orderId}</span>를 기록하여 관리자에게 문의해주세요.</p>
+                <button
+                    onClick={() => navigate('/my-page', { state: { tab: 'enrollments' } })}
+                    className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer"
+                >
+                    마이페이지로 이동
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-lg mx-auto mt-20 p-8 text-center">
+            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                </svg>
+            </div>
+            <h1 className="text-2xl font-extrabold text-gray-900 mb-3">결제가 완료되었습니다</h1>
+            <p className="text-gray-500 mb-8">수강 신청이 확정되었습니다. 마이페이지에서 확인하세요.</p>
+            <button
+                onClick={() => navigate('/my-page', { state: { tab: 'enrollments' } })}
+                className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer"
+            >
+                마이페이지에서 확인하기
+            </button>
+        </div>
+    );
+};
+
+export default PaymentSuccessPage;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    exclude: ['@tosspayments/tosspayments-sdk'],
+  },
 })


### PR DESCRIPTION
  ## 작업 내용
  - payments 테이블 스키마, Payment 엔티티, PaymentMapper 추가
  - 결제 승인 API 구현 (POST /api/payments/confirm)
  - 토스페이먼츠 SDK 연동 및 결제창 호출 구현 (유료 강의)
  - 무료 강의 수강 확정 버튼 분기 처리 (PENDING → CONFIRMED 즉시 처리)
  - 결제 성공 페이지 구현 (백엔드 승인 요청 → 상태별 UI 렌더링)
  - 결제 실패/취소 페이지 구현 (오류 코드 및 메시지 표시)
  - CONFIRMED 상태 수강 신청 7일 이내 취소 버튼 표시

  ## 구현 시 고려한 점
  - PENDING 선저장 + INSERT IGNORE 처리 (페이지 새로고침 등 재요청 대응)
  - noRollbackFor로 토스 API 실패 시 FAILED 상태 커밋 보장
  - 강의 가격과 요청 금액 서버 교차 검증으로 프론트 조작 방지
  - AbortController로 React StrictMode 이중 호출 방어 (중복 결제 승인 요청 방지)
  - isPaymentLoading으로 결제 진행 중 이중 클릭 방지

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080, TOSS_SECRET_KEY 환경변수 설정 필요)
  - 프론트: `npm run dev` (Port: 5173, VITE_TOSS_CLIENT_KEY 설정 필요)

  ## 연관 이슈
  Closes #29