### PR TITLE
[refactor] React Query 마이그레이션 및 코드 정리

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.2.4",
+        "@tanstack/react-query": "^5.100.9",
         "@tosspayments/tosspayments-sdk": "^2.7.0",
         "axios": "^1.15.2",
         "react": "^19.2.5",
@@ -1130,6 +1131,32 @@
         "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tosspayments/tosspayments-sdk": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.4",
+    "@tanstack/react-query": "^5.100.9",
     "@tosspayments/tosspayments-sdk": "^2.7.0",
     "axios": "^1.15.2",
     "react": "^19.2.5",

--- a/frontend/src/hooks/useCourseDetail.js
+++ b/frontend/src/hooks/useCourseDetail.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCourseDetail } from '../api/course';
+
+/* 강의 상세 정보 조회를 위한 커스텀 훅 */
+export const useCourseDetail = (courseId) => {
+    return useQuery({
+        queryKey: ['courseDetail', courseId],
+        queryFn: () => getCourseDetail(courseId).then(res => res.data),
+        enabled: !!courseId,
+    });
+};

--- a/frontend/src/hooks/useCourseEnrollments.js
+++ b/frontend/src/hooks/useCourseEnrollments.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCourseEnrollments } from '../api/course';
+
+/* 강의 수강생 목록 조회를 위한 커스텀 훅 */
+export const useCourseEnrollments = (courseId, page) => {
+    return useQuery({
+        queryKey: ['courseEnrollments', courseId, page],
+        queryFn: () => getCourseEnrollments(courseId, page).then(res => res.data),
+        enabled: !!courseId,
+    });
+};

--- a/frontend/src/hooks/useCourseList.js
+++ b/frontend/src/hooks/useCourseList.js
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCourseList } from '../api/course';
+
+/* 강의 목록 조회를 위한 커스텀 훅 */
+export const useCourseList = (params) => {
+    return useQuery({
+        queryKey: ['courseList', params],
+        queryFn: () => getCourseList(params).then(res => res.data),
+    });
+};

--- a/frontend/src/hooks/useMyCourses.js
+++ b/frontend/src/hooks/useMyCourses.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyCourses } from '../api/course';
+
+/* 내 강의 목록 조회를 위한 커스텀 훅 */
+export const useMyCourses = (enabled) => {
+    return useQuery({
+        queryKey: ['myCourses'],
+        queryFn: () => getMyCourses().then(res => res.data),
+        enabled,
+    });
+};

--- a/frontend/src/hooks/useMyEnrollments.js
+++ b/frontend/src/hooks/useMyEnrollments.js
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyEnrollments } from '../api/enrollment';
+
+/* 내 수강 신청 목록 조회를 위한 커스텀 훅 */
+export const useMyEnrollments = (page) => {
+    return useQuery({
+        queryKey: ['myEnrollments', page],
+        queryFn: () => getMyEnrollments(page).then(res => res.data),
+    });
+};

--- a/frontend/src/hooks/useUserList.js
+++ b/frontend/src/hooks/useUserList.js
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUserList } from '../api/user';
+
+/* 유저 목록 조회를 위한 커스텀 훅 */
+export const useUserList = () => {
+    return useQuery({
+        queryKey: ['userList'],
+        queryFn: () => getUserList().then(res => res.data),
+    });
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,16 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')).render(
     <StrictMode>
         <BrowserRouter>
-            <App />
+            <QueryClientProvider client={queryClient}>
+                <App />
+            </QueryClientProvider>
         </BrowserRouter>
     </StrictMode>,
 )

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { closeCourse, getCourseDetail, publishCourse } from '../api/course';
+import { useQueryClient } from '@tanstack/react-query';
+import { closeCourse, publishCourse } from '../api/course';
 import { createEnrollment } from '../api/enrollment';
 import { useAuth } from '../context/AuthContext';
 import { COURSE_STATUS_BADGE_STYLE, COURSE_STATUS_LABEL } from '../utils/statusConfig';
+import { useCourseDetail } from '../hooks/useCourseDetail';
 
 /* 강의 상세 페이지 */
 const CourseDetailPage = () => {
@@ -13,33 +15,20 @@ const CourseDetailPage = () => {
     const navigate = useNavigate();
     /* 현재 페이지의 위치 정보 */
     const location = useLocation();
-    /* 강의 상세 정보 상태 */
-    const [course, setCourse] = useState(null);
     /* 인증 정보에서 현재 사용자 정보 추출 */
     const { user } = useAuth();
+    /* React Query의 queryClient 인스턴스 */
+    const queryClient = useQueryClient();
+    /* 강의 상세 조회 */
+    const { data: course, isError } = useCourseDetail(courseId);
 
     /* 현재 로그인한 사용자가 강의 소유자인지 여부 */
     const isOwner = course?.creatorId === user?.id;
 
-    /* 컴포넌트가 마운트될 때 강의 상세 정보를 가져오는 useEffect */
+    /* 강의 조회 실패 시 목록으로 이동 */
     useEffect(() => {
-        let cancelled = false;
-
-        const fetchCourseDetail = async () => {
-            try {
-                const result = await getCourseDetail(courseId);
-                if (cancelled) return;
-                setCourse(result.data);
-            } catch (err) {
-                if (cancelled) return;
-                navigate('/courses', { replace: true });
-            }
-        };
-
-        fetchCourseDetail();
-
-        return () => { cancelled = true; };
-    }, [courseId, navigate]);
+        if (isError) navigate('/courses', { replace: true });
+    }, [isError, navigate]);
 
     /* 목록으로 돌아가기 */
     const handleBackToList = () => {
@@ -57,8 +46,8 @@ const CourseDetailPage = () => {
         if (!window.confirm('강의를 공개하시겠습니까?')) return;
 
         try {
-            const result = await publishCourse(courseId, user?.id);
-            setCourse(result.data);
+            await publishCourse(courseId, user?.id);
+            queryClient.invalidateQueries({ queryKey: ['courseDetail', courseId] });
         } catch (err) {
             alert(err.response?.data?.message || '강의 공개에 실패했습니다.');
         }
@@ -75,9 +64,7 @@ const CourseDetailPage = () => {
             const enrolled = await createEnrollment(Number(courseId));
 
             alert(enrolled.data?.status === 'WAITLIST' ? '정원이 초과되어 대기열에 등록되었습니다.\n마이페이지에서 대기 순번을 확인하세요.' : '수강 신청이 완료되었습니다.');
-            
-            const result = await getCourseDetail(courseId);
-            setCourse(result.data);
+            queryClient.invalidateQueries({ queryKey: ['courseDetail', courseId] });
         } catch (err) {
             alert(err.response?.data?.message || '수강 신청에 실패했습니다.');
         }
@@ -88,8 +75,8 @@ const CourseDetailPage = () => {
         if (!window.confirm('강의를 마감하시겠습니까?')) return;
 
         try {
-            const result = await closeCourse(courseId, user?.id);
-            setCourse(result.data);
+            await closeCourse(courseId, user?.id);
+            queryClient.invalidateQueries({ queryKey: ['courseDetail', courseId] });
         } catch (err) {
             alert(err.response?.data?.message || '강의 마감에 실패했습니다.');
         }
@@ -128,9 +115,9 @@ const CourseDetailPage = () => {
 
                 <div className="flex items-center gap-3">
                     <div className="w-10 h-10 bg-blue-100 rounded-md flex items-center justify-center text-blue-600 font-bold">
-                        {course.creatorName?.charAt(0)}
+                        {course.creatorName.charAt(0)}
                     </div>
-                    <p className="text-sm font-bold text-gray-900">{course?.creatorName}</p>
+                    <p className="text-sm font-bold text-gray-900">{course.creatorName}</p>
                 </div>
             </div>
 

--- a/frontend/src/pages/CourseListPage.jsx
+++ b/frontend/src/pages/CourseListPage.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { getCourseList } from '../api/course';
 import { useAuth } from '../context/AuthContext';
 import { COURSE_STATUS_CARD_STYLE, COURSE_STATUS_LABEL } from '../utils/statusConfig';
+import { useCourseList } from '../hooks/useCourseList';
 
 /* 강의 목록 페이지 */
 const CourseListPage = () => {
@@ -31,27 +31,8 @@ const CourseListPage = () => {
         setTempKeyword(searchParams.get('keyword') || '');
     }, [searchParams]);
 
-    /* 목록 데이터 상태 */
-    const [data, setData] = useState({
-        content: [],
-        totalCount: 0,
-        totalPages: 0,
-        last: false,
-    });
-
-    /* API 호출 (searchParams가 바뀔 때마다 실행) */
-    useEffect(() => {
-        const fetchCourseList = async () => {
-            try {
-                const result = await getCourseList(search);
-                setData(result.data);
-            } catch (err) {
-                console.error(err);
-            }
-        };
-
-        fetchCourseList();
-    }, [searchParams]);
+    /* 강의 목록 조회 (searchParams가 바뀔 때마다 자동 실행) */
+    const { data = { content: [], totalCount: 0, totalPages: 0, last: false } } = useCourseList(search);
 
     /* 검색 실행 */
     const handleSearch = (e) => {
@@ -141,20 +122,20 @@ const CourseListPage = () => {
             </div>
 
             {/* 강의 목록 섹션 */}
-            {data?.content?.length === 0 ? (
+            {data.content.length === 0 ? (
                 <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
                     검색 결과와 일치하는 강의가 없습니다.
                 </div>
             ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-                    {data?.content?.map(course => (
+                    {data.content.map(course => (
                         <div key={course.id} onClick={() => navigate(`/courses/${course.id}`, { state: { fromSearch: location.search } })}
                             className="group flex flex-col bg-white border border-gray-200 rounded-lg overflow-hidden hover:shadow-xl transition-all duration-300 cursor-pointer">
 
                             {/* 카드 상단: 이미지 영역(썸네일 대신 제목 앞글자) */}
                             <div className="relative aspect-video bg-gray-100 flex items-center justify-center overflow-hidden">
                                 <span className="text-gray-300 font-bold text-lg group-hover:scale-110 transition-transform">
-                                    {course?.title?.substring(0, 2)}
+                                    {course.title.substring(0, 2)}
                                 </span>
                                 {/* 상태 배지 */}
                                 <div className="absolute top-2 left-2">
@@ -167,14 +148,14 @@ const CourseListPage = () => {
                             {/* 카드 하단: 상세 정보 */}
                             <div className="p-4 flex flex-col flex-1">
                                 <h2 className="text-sm font-bold text-gray-800 line-clamp-2 h-10 mb-1 group-hover:text-blue-600">
-                                    {course?.title}
+                                    {course.title}
                                 </h2>
                                 <p className="text-xs text-gray-500 mb-3">{course.creatorName}</p>
 
                                 <div className="mt-auto">
                                     {/* 가격 */}
                                     <p className="text-base font-extrabold text-gray-900">
-                                        {course?.price === 0 ? '무료' : `${course.price.toLocaleString()}원`}
+                                        {course.price === 0 ? '무료' : `${course.price.toLocaleString()}원`}
                                     </p>
 
                                     {/* 인원수 바 */}
@@ -198,7 +179,7 @@ const CourseListPage = () => {
             )}
 
             {/* 페이징 섹션 */}
-            {(data?.totalPages ?? 0) > 1 && (
+            {(data.totalPages ?? 0) > 1 && (
                 <div className="flex justify-center items-center gap-4 mt-12">
                     <button disabled={search.page === 0}
                         onClick={() => setSearchParams({ ...Object.fromEntries(searchParams), page: search.page - 1 })}
@@ -209,7 +190,7 @@ const CourseListPage = () => {
                     </button>
 
                     <span className="text-sm font-medium text-gray-700">
-                        <span className="text-blue-600">{search.page + 1}</span> / {data?.totalPages}
+                        <span className="text-blue-600">{search.page + 1}</span> / {data.totalPages}
                     </span>
 
                     <button disabled={data.last}

--- a/frontend/src/pages/CourseRegisterPage.jsx
+++ b/frontend/src/pages/CourseRegisterPage.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
-import { registerCourse, getCourseDetail, updateCourse } from '../api/course';
+import { useQueryClient } from '@tanstack/react-query';
+import { registerCourse, updateCourse } from '../api/course';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useCourseDetail } from '../hooks/useCourseDetail';
 
 /* 강의 등록/수정 페이지 */
 const CourseRegisterPage = () => {
@@ -13,7 +15,6 @@ const CourseRegisterPage = () => {
     const location = useLocation();
     /* 인증 정보에서 현재 사용자 정보 추출 */
     const { user } = useAuth();
-
     /* 수정 모드 여부 */
     const isEdit = !!courseId;
     /* 이전 검색어 유지 */
@@ -33,45 +34,36 @@ const CourseRegisterPage = () => {
     });
     /* 데이터 로딩 상태 */
     const [ready, setReady] = useState(!isEdit);
+    /* 강의 상세 정보 조회 */
+    const { data: courseData, isError: isCourseError } = useCourseDetail(courseId);
+    /* React Query의 쿼리 클라이언트 */
+    const queryClient = useQueryClient();
 
-    /* 수정 모드일 때 기존 데이터 불러오기 */
+    /* 수정 모드일 때 기존 데이터로 폼 초기화 */
     useEffect(() => {
-        if (!isEdit) return;
+        if (!courseData) return;
 
-        let cancelled = false;
+        if (courseData.creatorId !== user.id) {
+            alert('수정 권한이 없습니다.');
+            navigate(`/courses${previousSearch}`, { replace: true });
+            return;
+        }
 
-        const fetchCourseData = async () => {
-            try {
-                const response = await getCourseDetail(courseId);
-                
-                if (cancelled) return;
+        setForm({
+            ...courseData,
+            title: courseData.title ?? '',
+            description: courseData.description ?? '',
+            priceDisplay: courseData.price.toLocaleString()
+        });
+        setReady(true);
+    }, [courseData]);
 
-                const data = response.data;
-
-                if (data.creatorId !== user?.id) {
-                    alert('수정 권한이 없습니다.');
-                    navigate(`/courses${previousSearch}`, { replace: true });
-                    return;
-                }
-
-                setForm({
-                    ...data,
-                    title: data.title ?? '',
-                    description: data.description ?? '',
-                    priceDisplay: data.price.toLocaleString()
-                });
-                setReady(true);
-            } catch (err) {
-                if (cancelled) return;
-                alert('강의 정보를 불러오는데 실패했습니다.');
-                navigate(`/courses${previousSearch}`);
-            }
-        };
-
-        fetchCourseData();
-
-        return () => { cancelled = true; };
-    }, [courseId, isEdit]);
+    /* 강의 정보 조회 실패 시 처리 */
+    useEffect(() => {
+        if (!isCourseError) return;
+        alert('강의 정보를 불러오는데 실패했습니다.');
+        navigate(`/courses${previousSearch}`);
+    }, [isCourseError]);
 
     /* 입력값 변경 핸들러 */
     const handleChange = (e) => {
@@ -114,11 +106,12 @@ const CourseRegisterPage = () => {
 
         try {
             if (isEdit) {
-                await updateCourse(courseId, user?.id, form);
+                await updateCourse(courseId, user.id, form);
+                queryClient.invalidateQueries({ queryKey: ['courseDetail', courseId] });
                 alert('강의 정보가 수정되었습니다!');
                 navigate(`/courses/${courseId}`, { state: { fromSearch: previousSearch, from } });
             } else {
-                const result = await registerCourse(user?.id, form);
+                const result = await registerCourse(user.id, form);
                 alert('강의가 등록되었습니다!');
                 navigate(`/courses/${result.data.id}`, { state: { fromSearch: previousSearch } });
             }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,35 +1,23 @@
-import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { getUserList } from '../api/user';
 import { useAuth } from '../context/AuthContext';
+import { useUserList } from '../hooks/useUserList';
 
 const LoginPage = () => {
+    /* 페이지 이동을 위한 네비게이트 함수 */
     const navigate = useNavigate();
+    /* 현재 위치 정보 */
     const location = useLocation();
+    /* 인증 관련 함수 */
     const { login } = useAuth();
-    /* 유저 목록 상태 */
-    const [users, setUsers] = useState([]);
-    
+    /* 유저 목록 조회 */
+    const { data: users = [] } = useUserList();
+
     /* 로그인 후 리다이렉트할 경로 */
     const redirect = location.state?.redirect || '/courses';
     /* 역할에 따른 라벨 */
     const roleLabel = (role) => role === 'CREATOR' ? '강사' : '수강생';
     /* 역할에 따른 스타일 */
     const roleStyle = (role) => role === 'CREATOR' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700';
-
-    /* 유저 목록 조회 */
-    useEffect(() => {
-        const fetchUserList = async () => {
-            try {
-                const result = await getUserList();
-                setUsers(result.data);
-            } catch (err) {
-                console.error(err);
-            }
-        };
-
-        fetchUserList();
-    }, []);
 
     /* 유저 선택 시 로그인 처리 */
     const handleSelectUser = (user) => {

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
-import { cancelEnrollment, confirmEnrollment, getMyEnrollments } from '../api/enrollment';
-import { getCourseEnrollments, getMyCourses } from '../api/course';
+import { cancelEnrollment, confirmEnrollment } from '../api/enrollment';
 import { useAuth } from '../context/AuthContext';
 import { COURSE_STATUS_BADGE_STYLE, COURSE_STATUS_LABEL, ENROLLMENT_STATUS_BADGE_STYLE, ENROLLMENT_STATUS_LABEL } from '../utils/statusConfig';
+import { useMyEnrollments } from '../hooks/useMyEnrollments';
+import { useMyCourses } from '../hooks/useMyCourses';
+import { useCourseEnrollments } from '../hooks/useCourseEnrollments';
 
 /* 마이페이지 */
 const MyPage = () => {
@@ -16,86 +19,33 @@ const MyPage = () => {
     const { user } = useAuth();
     /* 현재 활성화된 탭 상태 */
     const [activeTab, setActiveTab] = useState(location.state?.tab || 'enrollments');
-    /* 나의 수강목록 상태 */
-    const [enrollmentData, setEnrollmentData] = useState({ content: [], totalCount: 0, totalPages: 0, last: false });
     /* 수강목록 페이지 상태 */
     const [enrollmentPage, setEnrollmentPage] = useState(0);
-    /* 나의 강의 목록 상태 (CREATOR 전용) */
-    const [myCourses, setMyCourses] = useState([]);
     /* 선택한 강의 ID 상태 (강의별 수강생 목록 탭에서) */
     const [selectedCourseId, setSelectedCourseId] = useState('');
-    /* 선택한 강의의 수강생 목록 상태 */
-    const [courseEnrollmentData, setCourseEnrollmentData] = useState({ content: [], totalCount: 0, totalPages: 0, last: false });
     /* 수강생 목록 페이지 상태 */
     const [studentPage, setStudentPage] = useState(0);
     /* 결제 진행 중 상태 (이중 클릭 방지) */
     const [isPaymentLoading, setIsPaymentLoading] = useState(false);
+    /* React Query의 queryClient 인스턴스 */
+    const queryClient = useQueryClient();
 
     /* 나의 수강목록 조회 */
-    const fetchMyEnrollments = async (page = 0) => {
-        try {
-            const result = await getMyEnrollments(page);
-            setEnrollmentData(result.data);
-        } catch (err) {
-            console.error(err);
-            alert('수강 신청 목록을 불러오는데 실패했습니다.');
-        }
-    };
+    const { data: enrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useMyEnrollments(enrollmentPage);
+    /* 내 강의 목록 조회 (CREATOR 권한이 있는 경우) */
+    const { data: myCourses = [] } = useMyCourses(activeTab === 'my-courses' || activeTab === 'students');
+    /* 강의별 수강생 목록 조회 (CREATOR 권한이 있는 경우) */
+    const { data: courseEnrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useCourseEnrollments(selectedCourseId, studentPage);
 
-    /* 페이지 진입 시 나의 수강목록 조회 */
+    /* students 탭 진입 시 강의 선택 초기화 */
     useEffect(() => {
-        fetchMyEnrollments(enrollmentPage);
-    }, [enrollmentPage]);
-
-    /* 수강생 목록 페이지 변경 시 재조회 */
-    useEffect(() => {
-        if (!selectedCourseId) return;
-        fetchCourseEnrollments(selectedCourseId, studentPage);
-    }, [studentPage]);
-
-    /* 내 강의 / 강의별 수강생 목록 탭 진입 시 나의 강의 목록 조회 */
-    useEffect(() => {
-        if (activeTab !== 'my-courses' && activeTab !== 'students') return;
-
-        const fetchMyCourses = async () => {
-            try {
-                const result = await getMyCourses();
-                setMyCourses(result.data);
-                
-                if (activeTab === 'students') {
-                    setSelectedCourseId('');
-                    setCourseEnrollmentData({ content: [], totalCount: 0, totalPages: 0, last: false });
-                }
-            } catch (err) {
-                console.error(err);
-                alert('강의 목록을 불러오는데 실패했습니다.');
-            }
-        };
-
-        fetchMyCourses();
+        if (activeTab === 'students') setSelectedCourseId('');
     }, [activeTab]);
-
-    /* 수강생 목록 조회 */
-    const fetchCourseEnrollments = async (courseId, page = 0) => {
-        try {
-            const result = await getCourseEnrollments(courseId, page);
-            setCourseEnrollmentData(result.data);
-        } catch (err) {
-            alert(err.response?.data?.message || '수강생 목록을 불러오는데 실패했습니다.');
-        }
-    };
 
     /* 강의 선택 시 수강생 목록 조회 */
     const handleCourseSelect = (courseId) => {
         setSelectedCourseId(courseId);
         setStudentPage(0);
-
-        if (!courseId) {
-            setCourseEnrollmentData({ content: [], totalCount: 0, totalPages: 0, last: false });
-            return;
-        }
-
-        fetchCourseEnrollments(courseId, 0);
     };
 
     /* 유료 강의 결제 (토스페이먼츠) */
@@ -132,7 +82,7 @@ const MyPage = () => {
         try {
             await confirmEnrollment(enrollmentId);
             alert('수강이 확정되었습니다.');
-            fetchMyEnrollments(enrollmentPage);
+            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
         } catch (err) {
             alert(err.response?.data?.message || '수강 확정에 실패했습니다.');
         }
@@ -145,7 +95,7 @@ const MyPage = () => {
         try {
             await cancelEnrollment(enrollmentId);
             alert('수강이 취소되었습니다.');
-            fetchMyEnrollments(enrollmentPage);
+            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
         } catch (err) {
             alert(err.response?.data?.message || '수강 취소에 실패했습니다.');
         }
@@ -276,7 +226,7 @@ const MyPage = () => {
                     )}
 
                     {/* 페이징 섹션 */}
-                    {(enrollmentData?.totalPages ?? 0) > 1 && (
+                    {(enrollmentData.totalPages ?? 0) > 1 && (
                         <div className="flex justify-center items-center gap-4 mt-8">
                             <button disabled={enrollmentPage === 0}
                                 onClick={() => setEnrollmentPage(prev => prev - 1)}
@@ -399,7 +349,7 @@ const MyPage = () => {
                     )}
 
                     {/* 페이징 섹션 */}
-                    {(courseEnrollmentData?.totalPages ?? 0) > 1 && (
+                    {(courseEnrollmentData.totalPages ?? 0) > 1 && (
                         <div className="flex justify-center items-center gap-4 mt-8">
                             <button disabled={studentPage === 0}
                                 onClick={() => setStudentPage(prev => prev - 1)}

--- a/frontend/src/pages/PaymentFailPage.jsx
+++ b/frontend/src/pages/PaymentFailPage.jsx
@@ -6,11 +6,11 @@ const PaymentFailPage = () => {
     const navigate = useNavigate();
     /* URL 검색 파라미터에서 결제 실패 정보 추출 */
     const [searchParams] = useSearchParams();
-    /* 결제 실패 정보 (code, message, orderId) */
+    /* 결제 실패 원인을 나타내는 코드 */
     const code = searchParams.get('code');
-    /* 결제 실패 메시지, 주문번호 등은 URL 파라미터로 전달받음 */
+    /* 결제 실패 메시지 */
     const message = searchParams.get('message');
-    /* 주문번호는 결제 실패 시에도 URL 파라미터로 전달될 수 있음 */
+    /* 주문 번호 */
     const orderId = searchParams.get('orderId');
 
     return (


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - @tanstack/react-query v5 설치 및 QueryClientProvider 설정                                                                                                                       
  - 커스텀 훅 6개 추가 (useCourseList, useCourseDetail, useMyEnrollments, useMyCourses, useCourseEnrollments, useUserList)                                                                                          
  - CourseListPage, CourseDetailPage, MyPage, LoginPage, CourseRegisterPage의 useEffect + useState 수동 fetch 로직 제거 후 React       Query 훅으로 교체
  - 수강 취소/확정/강의 수정 후 queryClient.invalidateQueries로 캐시 무효화 처리
  - React Query 기본값이 보장된 곳의 불필요한 옵셔널 체이닝(?.) 제거
  - CourseRegisterPage의 user?.id → user.id (CreatorRoute 보호로 null 불가)

  ## 구현 시 고려한 점
  - 결제 흐름(PaymentSuccessPage), 인증(AuthContext), mutation(취소/확정 API 호출)은 기존 방식 유지 — React Query mutation 전환은 이번 범위에서 제외
  - useCourseDetail의 enabled: !!courseId 옵션으로 CourseRegisterPage 등록 모드에서 불필요한 fetch 방지
  - React Query 기본값(`= { content: [], ... }`)으로 data가 보장되는 곳은 ?.를 제거해 코드 일관성 확보, map() 내부 아이템도 동일하게 정리

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)

  ## 연관 이슈
  Closes #31