### PR TITLE
[feat] 결제 환불 및 마이페이지 결제 내역 탭 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.controller;
 
+import com.yujin.course_enrollment.dto.req.ReqEnrollmentCancelDto;
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentCreateDto;
 import com.yujin.course_enrollment.dto.req.ReqEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
@@ -71,16 +72,18 @@ public class EnrollmentController {
     }
 
     /**
-     * 수강 취소 (PENDING, CONFIRMED → CANCELLED)
+     * 수강 취소 (PENDING, CONFIRMED, WAITLIST → CANCELLED)
      * PATCH /api/enrollments/{enrollmentId}/cancel
      * @param userId 사용자 ID (헤더로 전달)
      * @param enrollmentId 수강 신청 ID
+     * @param reqEnrollmentCancelDto 취소 요청 DTO (CONFIRMED 취소 시 cancelReason 필수)
      */
     @PatchMapping("/{enrollmentId}/cancel")
-    public ResponseEntity<ApiResponse<RespEnrollmentDto>> cancelEnrollment(@RequestHeader("X-User-Id") Long userId, @PathVariable Long enrollmentId) {
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> cancelEnrollment(@RequestHeader("X-User-Id") Long userId, @PathVariable Long enrollmentId, @RequestBody(required = false) ReqEnrollmentCancelDto reqEnrollmentCancelDto) {
         log.debug("[EnrollmentController] 수강 취소 요청 - userId: {}, enrollmentId: {}", userId, enrollmentId);
 
-        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId);
+        String cancelReason = reqEnrollmentCancelDto != null ? reqEnrollmentCancelDto.getCancelReason() : null;
+        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId, cancelReason);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * 결제 컨트롤러
  * 토스페이먼츠 결제 승인 관련 HTTP 요청을 처리
@@ -26,14 +28,29 @@ public class PaymentController {
      * 토스페이먼츠 결제 승인
      * POST /api/payments/confirm
      * @param userId 사용자 ID (헤더로 전달)
-     * @param req 결제 승인 요청 DTO (enrollmentId, paymentKey, orderId, orderName, amount)
+     * @param reqPaymentConfirmDto 결제 승인 요청 DTO (enrollmentId, paymentKey, orderId, orderName, amount)
      * @return 저장된 결제 응답 DTO
      */
     @PostMapping("/confirm")
-    public ResponseEntity<ApiResponse<RespPaymentDto>> confirmPayment(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqPaymentConfirmDto req) {
-        log.debug("[PaymentController] 결제 승인 요청 - userId: {}, enrollmentId: {}", userId, req.getEnrollmentId());
+    public ResponseEntity<ApiResponse<RespPaymentDto>> confirmPayment(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqPaymentConfirmDto reqPaymentConfirmDto) {
+        log.debug("[PaymentController] 결제 승인 요청 - userId: {}, enrollmentId: {}", userId, reqPaymentConfirmDto.getEnrollmentId());
 
-        RespPaymentDto result = paymentService.confirmPayment(userId, req);
+        RespPaymentDto result = paymentService.confirmPayment(userId, reqPaymentConfirmDto);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    /**
+     * 나의 결제 내역 조회
+     * GET /api/payments/my
+     * @param userId 사용자 ID (헤더로 전달)
+     * @return 결제 내역 목록 (DONE, CANCELLED)
+     */
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<RespPaymentDto>>> getMyPayments(@RequestHeader("X-User-Id") Long userId) {
+        log.debug("[PaymentController] 결제 내역 조회 요청 - userId: {}", userId);
+
+        List<RespPaymentDto> result = paymentService.findMyPayments(userId);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentCancelDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqEnrollmentCancelDto.java
@@ -1,0 +1,13 @@
+package com.yujin.course_enrollment.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 수강 취소 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class ReqEnrollmentCancelDto {
+    private String cancelReason;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Payment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Payment.java
@@ -51,4 +51,14 @@ public class Payment {
                 .paidAt(paidAt)
                 .build();
     }
+
+    /* 환불 완료 후 CANCELLED 업데이트용 엔티티 생성 */
+    public static Payment ofCancelled(Long id, String cancelReason) {
+        return Payment.builder()
+                .id(id)
+                .status(PaymentStatus.CANCELLED)
+                .canceledAt(LocalDateTime.now())
+                .cancelReason(cancelReason)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -3,6 +3,8 @@ package com.yujin.course_enrollment.mapper;
 import com.yujin.course_enrollment.entity.Payment;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 /**
  * 결제 Mapper 인터페이스
  * PaymentMapper.xml과 매핑되어 결제 관련 DB 접근을 담당
@@ -20,4 +22,13 @@ public interface PaymentMapper {
 
     /* 주문 ID로 결제 조회 */
     Payment selectPaymentByOrderId(String orderId);
+
+    /* 수강 신청 ID로 DONE 상태 결제 조회 */
+    Payment selectPaymentByEnrollmentId(Long enrollmentId);
+
+    /* 결제 취소 상태 업데이트 */
+    void updatePaymentCancelled(Payment payment);
+
+    /* 사용자 결제 내역 조회 */
+    List<Payment> selectPaymentListByUserId(Long userId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -36,6 +36,7 @@ public class EnrollmentService {
     private final EnrollmentMapper enrollmentMapper;
     private final CourseMapper courseMapper;
     private final UserMapper userMapper;
+    private final PaymentService paymentService;
 
     /**
      * 수강 신청
@@ -178,13 +179,15 @@ public class EnrollmentService {
 
     /**
      * 수강 취소 (PENDING, CONFIRMED, WAITLIST → CANCELLED)
+     * CONFIRMED 유료 강의 취소 시 토스 환불 API 호출 후 상태 변경
      * PENDING/CONFIRMED 취소 시 대기열 첫 번째 사람 자동 PENDING 승격
      * @param userId 사용자 ID
      * @param enrollmentId 수강 신청 ID
-     * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), 이미 취소됨(400), CONFIRMED 7일 초과(400)
+     * @param cancelReason 취소 사유 (CONFIRMED 취소 시 필수)
+     * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), 이미 취소됨(400), CONFIRMED 7일 초과(400), 취소 사유 없음(400)
      */
     @Transactional
-    public RespEnrollmentDto cancelEnrollment(Long userId, Long enrollmentId) {
+    public RespEnrollmentDto cancelEnrollment(Long userId, Long enrollmentId, String cancelReason) {
         log.info("[EnrollmentService] 수강 취소 - userId: {}, enrollmentId: {}", userId, enrollmentId);
 
         // 수강 신청 존재 여부 확인
@@ -206,12 +209,20 @@ public class EnrollmentService {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 취소된 수강 신청입니다.");
         }
 
-        // CONFIRMED 상태 취소 기간 확인 (확정 후 7일 이내)
+        // CONFIRMED 상태 취소 기간 확인 (확정 후 7일 이내) + 환불 처리
         if (EnrollmentStatus.CONFIRMED.equals(enrollment.getStatus())) {
             if (enrollment.getConfirmedAt().plusDays(7).isBefore(LocalDateTime.now())) {
                 log.warn("[EnrollmentService] 취소 기간 초과 - enrollmentId: {}, confirmedAt: {}", enrollmentId, enrollment.getConfirmedAt());
                 throw new BusinessException(HttpStatus.BAD_REQUEST, "수강 확정 후 7일이 지나 취소할 수 없습니다.");
             }
+
+            if (cancelReason == null || cancelReason.isBlank()) {
+                log.warn("[EnrollmentService] 취소 사유 없음 - enrollmentId: {}", enrollmentId);
+                throw new BusinessException(HttpStatus.BAD_REQUEST, "취소 사유를 입력해주세요.");
+            }
+
+            // 토스 환불 API 호출 후 payment CANCELLED 업데이트 (외부 API 먼저 호출)
+            paymentService.refund(enrollmentId, cancelReason);
         }
 
         enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(enrollmentId));
@@ -236,6 +247,7 @@ public class EnrollmentService {
             if (promoted > 0) {
                 courseMapper.updateCourseEnrolledCountPlus(enrollment.getCourseId());
                 log.info("[EnrollmentService] 대기열 승격 - enrollmentId: {}", nextWaitlist.getId());
+
                 break;
             }
         }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -17,6 +17,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * 결제 서비스
  * 토스페이먼츠 결제 승인 및 수강 신청 상태 변경을 처리
@@ -113,5 +116,42 @@ public class PaymentService {
         log.info("[PaymentService] 결제 승인 완료 - enrollmentId: {}, orderId: {}", reqPaymentConfirmDto.getEnrollmentId(), reqPaymentConfirmDto.getOrderId());
 
         return RespPaymentDto.of(paymentMapper.selectPaymentByOrderId(reqPaymentConfirmDto.getOrderId()));
+    }
+
+    /**
+     * 결제 환불
+     * DONE 상태 결제를 찾아 토스 환불 API 호출 후 CANCELLED 업데이트
+     * 무료 강의(결제 내역 없음)는 환불 없이 통과
+     * @param enrollmentId 수강 신청 ID
+     * @param cancelReason 취소 사유
+     */
+    @Transactional
+    public void refund(Long enrollmentId, String cancelReason) {
+        Payment payment = paymentMapper.selectPaymentByEnrollmentId(enrollmentId);
+
+        if (payment == null) {
+            log.info("[PaymentService] 결제 내역 없음 (무료 강의) - enrollmentId: {}", enrollmentId);
+            return;
+        }
+
+        log.info("[PaymentService] 환불 요청 - enrollmentId: {}, paymentKey: {}", enrollmentId, payment.getPaymentKey());
+
+        tossPaymentClient.cancel(payment.getPaymentKey(), cancelReason);
+        paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), cancelReason));
+
+        log.info("[PaymentService] 환불 완료 - enrollmentId: {}, paymentKey: {}", enrollmentId, payment.getPaymentKey());
+    }
+
+    /**
+     * 사용자 결제 내역 조회
+     * @param userId 사용자 ID
+     * @return 결제 내역 목록 (DONE, CANCELLED)
+     */
+    public List<RespPaymentDto> findMyPayments(Long userId) {
+        log.info("[PaymentService] 결제 내역 조회 - userId: {}", userId);
+
+        return paymentMapper.selectPaymentListByUserId(userId).stream()
+                .map(RespPaymentDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/TossPaymentClient.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/TossPaymentClient.java
@@ -35,6 +35,9 @@ public class TossPaymentClient {
     @Value("${toss.confirm-url}")
     private String confirmUrl;
 
+    @Value("${toss.cancel-url-template}")
+    private String cancelUrlTemplate;
+
     private final RestTemplate restTemplate;
 
     /**
@@ -73,6 +76,34 @@ public class TossPaymentClient {
         } catch (RestClientException e) {
             log.error("[TossPaymentClient] 토스 API 통신 오류 - orderId: {}, message: {}", orderId, e.getMessage());
             throw new BusinessException(HttpStatus.BAD_GATEWAY, "결제 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 토스페이먼츠 결제 취소(환불) API 호출
+     * @param paymentKey 결제 키
+     * @param cancelReason 취소 사유
+     * @throws BusinessException 토스 API 취소 실패 시
+     */
+    public void cancel(String paymentKey, String cancelReason) {
+        String url = String.format(cancelUrlTemplate, paymentKey);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Basic " + Base64.getEncoder().encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8)));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("cancelReason", cancelReason);
+
+        try {
+            restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(body, headers), Void.class);
+            log.info("[TossPaymentClient] 결제 취소 성공 - paymentKey: {}", paymentKey);
+        } catch (HttpClientErrorException e) {
+            log.warn("[TossPaymentClient] 결제 취소 실패 - paymentKey: {}, status: {}, body: {}", paymentKey, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "결제 취소에 실패했습니다.");
+        } catch (RestClientException e) {
+            log.error("[TossPaymentClient] 토스 API 통신 오류 (취소) - paymentKey: {}, message: {}", paymentKey, e.getMessage());
+            throw new BusinessException(HttpStatus.BAD_GATEWAY, "결제 취소 처리 중 오류가 발생했습니다.");
         }
     }
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -36,3 +36,4 @@ logging:
 toss:
   secret-key: ${TOSS_SECRET_KEY:}
   confirm-url: https://api.tosspayments.com/v1/payments/confirm
+  cancel-url-template: https://api.tosspayments.com/v1/payments/%s/cancel

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -30,9 +30,9 @@
     <update id="updatePaymentDone" parameterType="Payment">
         UPDATE payments
            SET payment_key = #{paymentKey}
-             , method      = #{method}
-             , status      = #{status}
-             , paid_at     = #{paidAt}
+             , method = #{method}
+             , status = #{status}
+             , paid_at = #{paidAt}
          WHERE id = #{id}
     </update>
 
@@ -60,6 +60,57 @@
              , updated_at
           FROM payments
          WHERE order_id = #{orderId}
+    </select>
+
+    <!-- 수강 신청 ID로 DONE 상태 결제 조회 -->
+    <select id="selectPaymentByEnrollmentId" parameterType="Long" resultType="Payment">
+        SELECT id
+             , enrollment_id
+             , payment_key
+             , order_id
+             , order_name
+             , amount
+             , method
+             , status
+             , paid_at
+             , canceled_at
+             , cancel_reason
+             , created_at
+             , updated_at
+          FROM payments
+         WHERE enrollment_id = #{enrollmentId}
+           AND status = 'DONE'
+    </select>
+
+    <!-- 결제 취소 상태 업데이트 -->
+    <update id="updatePaymentCancelled" parameterType="Payment">
+        UPDATE payments
+           SET status = #{status}
+             , canceled_at = #{canceledAt}
+             , cancel_reason = #{cancelReason}
+         WHERE id = #{id}
+    </update>
+
+    <!-- 사용자 결제 내역 조회 (DONE, CANCELLED) -->
+    <select id="selectPaymentListByUserId" parameterType="Long" resultType="Payment">
+        SELECT p.id
+             , p.enrollment_id
+             , p.payment_key
+             , p.order_id
+             , p.order_name
+             , p.amount
+             , p.method
+             , p.status
+             , p.paid_at
+             , p.canceled_at
+             , p.cancel_reason
+             , p.created_at
+             , p.updated_at
+          FROM payments p
+          JOIN enrollments e ON p.enrollment_id = e.id
+         WHERE e.user_id = #{userId}
+           AND p.status IN ('DONE', 'CANCELLED')
+        ORDER BY p.created_at DESC
     </select>
 
 </mapper>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
@@ -223,7 +223,7 @@ class EnrollmentConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
-                    enrollmentService.cancelEnrollment(target[0], target[1]);
+                    enrollmentService.cancelEnrollment(target[0], target[1], null);
                 } catch (Exception ignored) {
                 } finally {
                     doneLatch.countDown();
@@ -294,7 +294,7 @@ class EnrollmentConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
-                    enrollmentService.cancelEnrollment(target[0], target[1]);
+                    enrollmentService.cancelEnrollment(target[0], target[1], null);
                 } catch (Exception ignored) {
                 } finally {
                     doneLatch.countDown();
@@ -358,7 +358,7 @@ class EnrollmentConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
-                    enrollmentService.cancelEnrollment(target[0], target[1]);
+                    enrollmentService.cancelEnrollment(target[0], target[1], null);
                 } catch (Exception ignored) {
                 } finally {
                     doneLatch.countDown();

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -44,6 +44,9 @@ class EnrollmentServiceTest {
     @Mock
     private UserMapper userMapper;
 
+    @Mock
+    private PaymentService paymentService;
+
     @Test
     @DisplayName("수강 신청 성공")
     void registerEnrollment_success() {
@@ -436,7 +439,7 @@ class EnrollmentServiceTest {
         given(courseMapper.selectCourseById(1L)).willReturn(course);
 
         // when
-        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId);
+        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId, null);
 
         // then
         assertThat(result.getStatus()).isEqualTo("CANCELLED");
@@ -460,7 +463,7 @@ class EnrollmentServiceTest {
         given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(cancelled);
 
         // when & then
-        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId))
+        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("이미 취소된 수강 신청입니다.");
     }
@@ -482,8 +485,72 @@ class EnrollmentServiceTest {
         given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(confirmed);
 
         // when & then
-        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId))
+        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId, null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("수강 확정 후 7일이 지나 취소할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("CONFIRMED 수강 취소 성공 - 환불 처리 포함")
+    void cancelEnrollment_success_confirmed() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Long courseId = 1L;
+        String cancelReason = "단순 변심";
+        Enrollment confirmed = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(courseId)
+                .status("CONFIRMED")
+                .confirmedAt(LocalDateTime.now().minusDays(1))
+                .build();
+        Course course = Course.builder().id(courseId).title("Spring Boot 강의").build();
+        Enrollment cancelled = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(courseId)
+                .status("CANCELLED")
+                .cancelledAt(LocalDateTime.now())
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(confirmed).willReturn(cancelled);
+        willDoNothing().given(paymentService).refund(enrollmentId, cancelReason);
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+        willDoNothing().given(courseMapper).updateCourseEnrolledCountMinus(courseId);
+        given(enrollmentMapper.selectNextWaitlist(courseId)).willReturn(null);
+        given(courseMapper.selectCourseById(courseId)).willReturn(course);
+
+        // when
+        RespEnrollmentDto result = enrollmentService.cancelEnrollment(userId, enrollmentId, cancelReason);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo("CANCELLED");
+        then(paymentService).should().refund(enrollmentId, cancelReason);
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+        then(courseMapper).should().updateCourseEnrolledCountMinus(courseId);
+    }
+
+    @Test
+    @DisplayName("CONFIRMED 취소 사유 없음 - 수강 취소 실패")
+    void cancelEnrollment_fail_noReason() {
+        // given
+        Long userId = 4L;
+        Long enrollmentId = 1L;
+        Enrollment confirmed = Enrollment.builder()
+                .id(enrollmentId)
+                .userId(userId)
+                .courseId(1L)
+                .status("CONFIRMED")
+                .confirmedAt(LocalDateTime.now().minusDays(1))
+                .build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(confirmed);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentService.cancelEnrollment(userId, enrollmentId, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("취소 사유를 입력해주세요.");
+        then(paymentService).should(never()).refund(any(), any());
     }
 }

--- a/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -249,5 +250,88 @@ class PaymentServiceTest {
         then(paymentMapper).should().updatePaymentFailed(1L);
         then(paymentMapper).should(never()).updatePaymentDone(any());
         then(enrollmentMapper).should(never()).updateEnrollmentStatus(any());
+    }
+
+    @Test
+    @DisplayName("환불 성공 - 토스 취소 API 호출 후 CANCELLED 업데이트")
+    void refund_success() {
+        // given
+        Long enrollmentId = 1L;
+        String cancelReason = "단순 변심";
+        Payment done = Payment.builder()
+                .id(1L)
+                .enrollmentId(enrollmentId)
+                .paymentKey("tgen_abc123")
+                .orderId("order_001")
+                .status("DONE")
+                .build();
+
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(done);
+        willDoNothing().given(tossPaymentClient).cancel("tgen_abc123", cancelReason);
+        willDoNothing().given(paymentMapper).updatePaymentCancelled(any());
+
+        // when
+        paymentService.refund(enrollmentId, cancelReason);
+
+        // then
+        then(tossPaymentClient).should().cancel("tgen_abc123", cancelReason);
+        then(paymentMapper).should().updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("환불 스킵 - 무료 강의(결제 내역 없음)")
+    void refund_skip_freeCourse() {
+        // given
+        Long enrollmentId = 2L;
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(null);
+
+        // when
+        paymentService.refund(enrollmentId, "단순 변심");
+
+        // then
+        then(tossPaymentClient).should(never()).cancel(any(), any());
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("결제 내역 조회 성공")
+    void findMyPayments_success() {
+        // given
+        Long userId = 4L;
+        Payment payment1 = Payment.builder()
+                .id(1L)
+                .enrollmentId(1L)
+                .orderId("order_001")
+                .orderName("Spring Boot 강의")
+                .amount(50000)
+                .method("카드")
+                .status("DONE")
+                .paidAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
+                .build();
+        Payment payment2 = Payment.builder()
+                .id(2L)
+                .enrollmentId(2L)
+                .orderId("order_002")
+                .orderName("React 강의")
+                .amount(30000)
+                .method("카드")
+                .status("CANCELLED")
+                .paidAt(LocalDateTime.now().minusDays(3))
+                .createdAt(LocalDateTime.now().minusDays(3))
+                .build();
+
+        given(paymentMapper.selectPaymentListByUserId(userId)).willReturn(java.util.List.of(payment1, payment2));
+
+        // when
+        List<RespPaymentDto> result = paymentService.findMyPayments(userId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getOrderId()).isEqualTo("order_001");
+        assertThat(result.get(0).getStatus()).isEqualTo("DONE");
+        assertThat(result.get(1).getOrderId()).isEqualTo("order_002");
+        assertThat(result.get(1).getStatus()).isEqualTo("CANCELLED");
+        then(paymentMapper).should().selectPaymentListByUserId(userId);
     }
 }

--- a/frontend/src/api/enrollment.js
+++ b/frontend/src/api/enrollment.js
@@ -16,6 +16,6 @@ export const confirmEnrollment = (enrollmentId) => {
 };
 
 /* 수강 취소 */
-export const cancelEnrollment = (enrollmentId) => {
-    return instance.patch(`/api/enrollments/${enrollmentId}/cancel`).then(res => res.data);
+export const cancelEnrollment = (enrollmentId, cancelReason = null) => {
+    return instance.patch(`/api/enrollments/${enrollmentId}/cancel`, cancelReason ? { cancelReason } : undefined).then(res => res.data);
 };

--- a/frontend/src/api/payment.js
+++ b/frontend/src/api/payment.js
@@ -4,3 +4,8 @@ import instance from './axios';
 export const confirmPayment = ({ enrollmentId, paymentKey, orderId, orderName, amount }, signal) => {
     return instance.post('/api/payments/confirm', { enrollmentId, paymentKey, orderId, orderName, amount }, { signal }).then(res => res.data);
 };
+
+/* 나의 결제 내역 조회 */
+export const getMyPayments = () => {
+    return instance.get('/api/payments/my').then(res => res.data);
+};

--- a/frontend/src/components/CancelModal.jsx
+++ b/frontend/src/components/CancelModal.jsx
@@ -1,0 +1,61 @@
+/* CONFIRMED 수강 취소 사유 */
+const CANCEL_REASONS = ['단순 변심', '일정 변경', '강의 내용이 기대와 다름', '기타'];
+
+/* CONFIRMED 수강 취소 사유 모달 */
+const CancelModal = ({ open, onClose, onConfirm, selectedReason, setSelectedReason, customReason, setCustomReason }) => {
+    if (!open) return null;
+
+    return (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+            <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md mx-4">
+                <h2 className="text-lg font-bold text-gray-900 mb-4">수강 취소 사유</h2>
+
+                {/* 사유 선택 라디오 버튼 */}
+                <div className="flex flex-col gap-2 mb-4">
+                    {CANCEL_REASONS.map(reason => (
+                        <label key={reason} className="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="radio"
+                                name="cancelReason"
+                                value={reason}
+                                checked={selectedReason === reason}
+                                onChange={(e) => setSelectedReason(e.target.value)}
+                                className="accent-blue-600"
+                            />
+                            <span className="text-sm text-gray-700">{reason}</span>
+                        </label>
+                    ))}
+                </div>
+
+                {/* 기타 사유 입력 텍스트 영역 (기타 선택 시에만 표시) */}
+                {selectedReason === '기타' && (
+                    <textarea
+                        value={customReason}
+                        onChange={(e) => setCustomReason(e.target.value)}
+                        placeholder="취소 사유를 입력해주세요."
+                        rows={3}
+                        className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-4 resize-none"
+                    />
+                )}
+
+                {/* 액션 버튼 그룹 */}
+                <div className="flex gap-2 justify-end">
+                    <button
+                        onClick={onClose}
+                        className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                    >
+                        닫기
+                    </button>
+                    <button
+                        onClick={onConfirm}
+                        className="px-4 py-2 bg-red-500 text-white text-sm font-semibold rounded-md hover:bg-red-600 transition-colors cursor-pointer"
+                    >
+                        취소 확인
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default CancelModal;

--- a/frontend/src/components/ReceiptModal.jsx
+++ b/frontend/src/components/ReceiptModal.jsx
@@ -1,0 +1,122 @@
+/* 결제 상태에 따른 배지 스타일 */
+const PAYMENT_STATUS_BADGE_STYLE = {
+    DONE: 'bg-green-50 text-green-700 border-green-200',
+    CANCELLED: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+/* 결제 상태 라벨 */
+const PAYMENT_STATUS_LABEL = {
+    DONE: '결제완료',
+    CANCELLED: '환불완료',
+};
+
+/* 결제 영수증 모달 */
+const ReceiptModal = ({ payment, onClose, canCancel = false, onCancel }) => {
+    if (!payment) return null;
+
+    /* 영수증 출력 핸들러 */
+    const handlePrint = () => {
+        const cancelSection = payment.status === 'CANCELLED' ? `
+            <hr style="margin:12px 0;border:none;border-top:1px solid #e5e7eb"/>
+            <div class="row"><span class="label">환불일</span><span class="value">${payment.canceledAt?.substring(0, 10) || '-'}</span></div>
+            ${payment.cancelReason ? `<div class="row"><span class="label">취소 사유</span><span class="value">${payment.cancelReason}</span></div>` : ''}
+        ` : '';
+
+        const win = window.open('', '_blank');
+        win.document.write(`
+            <html><head><title>영수증</title><style>
+                body { font-family: sans-serif; padding: 24px; max-width: 360px; }
+                h1 { font-size: 18px; font-weight: bold; margin-bottom: 16px; }
+                .row { display: flex; justify-content: space-between; margin: 8px 0; font-size: 14px; }
+                .label { color: #6b7280; }
+                .value { font-weight: 600; text-align: right; }
+                .badge { font-size: 11px; font-weight: bold; padding: 2px 8px; border-radius: 4px; border: 1px solid; }
+            </style></head><body>
+                <h1>영수증</h1>
+                <div class="row"><span class="label">주문명</span><span class="value">${payment.orderName}</span></div>
+                <div class="row"><span class="label">주문번호</span><span class="value">${payment.orderId}</span></div>
+                <div class="row"><span class="label">결제 금액</span><span class="value">${payment.amount.toLocaleString()}원</span></div>
+                <div class="row"><span class="label">결제 수단</span><span class="value">${payment.method || '-'}</span></div>
+                <div class="row"><span class="label">결제일</span><span class="value">${payment.paidAt?.substring(0, 10) || '-'}</span></div>
+                ${cancelSection}
+            </body></html>
+        `);
+        win.document.close();
+        win.print();
+    };
+
+    /* 영수증 행 데이터 */
+    const rows = [
+        { label: '주문명', value: payment.orderName },
+        { label: '주문번호', value: payment.orderId },
+        { label: '결제 금액', value: `${payment.amount.toLocaleString()}원` },
+        { label: '결제 수단', value: payment.method || '-' },
+        { label: '결제일', value: payment.paidAt?.substring(0, 10) || '-' },
+    ];
+
+    return (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+            <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm mx-4">
+                <div className="flex items-center justify-between mb-5">
+                    <h2 className="text-lg font-bold text-gray-900">영수증</h2>
+                    <span className={`text-xs font-bold px-2 py-0.5 rounded border ${PAYMENT_STATUS_BADGE_STYLE[payment.status]}`}>
+                        {PAYMENT_STATUS_LABEL[payment.status]}
+                    </span>
+                </div>
+                {/* 영수증 정보 행 */}
+                <dl className="flex flex-col gap-3">
+                    {rows.map(({ label, value }) => (
+                        <div key={label} className="flex justify-between text-sm">
+                            <dt className="text-gray-500">{label}</dt>
+                            <dd className="font-medium text-gray-900 text-right max-w-[60%] break-all">{value}</dd>
+                        </div>
+                    ))}
+                </dl>
+
+                {/* 환불 정보 행 (취소된 결제에 한함) */}
+                {payment.status === 'CANCELLED' && (
+                    <>
+                        <div className="border-t border-gray-100 my-4" />
+                        <dl className="flex flex-col gap-3">
+                            <div className="flex justify-between text-sm">
+                                <dt className="text-gray-500">환불일</dt>
+                                <dd className="font-medium text-gray-900">{payment.canceledAt?.substring(0, 10) || '-'}</dd>
+                            </div>
+                            {payment.cancelReason && (
+                                <div className="flex justify-between text-sm">
+                                    <dt className="text-gray-500">취소 사유</dt>
+                                    <dd className="font-medium text-gray-900 text-right max-w-[60%]">{payment.cancelReason}</dd>
+                                </div>
+                            )}
+                        </dl>
+                    </>
+                )}
+
+                {/* 액션 버튼 그룹 (취소 가능한 경우에만 취소 버튼 표시) */}
+                <div className="flex gap-2 mt-6">
+                    {canCancel && (
+                        <button
+                            onClick={onCancel}
+                            className="flex-1 px-4 py-2 border border-red-300 text-red-500 text-sm font-semibold rounded-md hover:bg-red-50 transition-colors cursor-pointer"
+                        >
+                            결제 취소
+                        </button>
+                    )}
+                    <button
+                        onClick={handlePrint}
+                        className="flex-1 px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                    >
+                        영수증 출력
+                    </button>
+                    <button
+                        onClick={onClose}
+                        className="flex-1 px-4 py-2 bg-gray-100 text-gray-700 text-sm font-semibold rounded-md hover:bg-gray-200 transition-colors cursor-pointer"
+                    >
+                        닫기
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ReceiptModal;

--- a/frontend/src/hooks/useEnrollmentActions.js
+++ b/frontend/src/hooks/useEnrollmentActions.js
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
+import { cancelEnrollment, confirmEnrollment } from '../api/enrollment';
+import { useAuth } from '../context/AuthContext';
+
+/* 수강목록 탭 액션 훅 (결제/취소 로직) */
+export const useEnrollmentActions = () => {
+    /* 인증 정보 */
+    const { user } = useAuth();
+    /* React Query 클라이언트 */
+    const queryClient = useQueryClient();
+
+    /* 수강목록 페이지네이션 상태 */
+    const [enrollmentPage, setEnrollmentPage] = useState(0);
+    /* 결제 로딩 상태 */
+    const [isPaymentLoading, setIsPaymentLoading] = useState(false);
+    /* CONFIRMED 취소 모달 상태 */
+    const [cancelModal, setCancelModal] = useState({ open: false, enrollmentId: null });
+    /* 취소 사유 상태 */
+    const [selectedReason, setSelectedReason] = useState('');
+    /* 기타 사유 입력 상태 */
+    const [customReason, setCustomReason] = useState('');
+
+    /* 유료 강의 결제 (토스페이먼츠) */
+    const handlePayment = async (enrollment) => {
+        setIsPaymentLoading(true);
+        
+        try {
+            const tossPayments = await loadTossPayments(import.meta.env.VITE_TOSS_CLIENT_KEY);
+            const payment = tossPayments.payment({ customerKey: `CUSTOMER-${user.id}` });
+
+            await payment.requestPayment({
+                method: 'CARD',
+                amount: { currency: 'KRW', value: enrollment.price },
+                orderId: `ORDER-${enrollment.id}-${Date.now()}`,
+                orderName: enrollment.courseTitle,
+                successUrl: `${window.location.origin}/payment/success?enrollmentId=${enrollment.id}&orderName=${encodeURIComponent(enrollment.courseTitle)}`,
+                failUrl: `${window.location.origin}/payment/fail`,
+                card: {
+                    useEscrow: false,
+                    flowMode: 'DEFAULT',
+                    useCardPoint: false,
+                    useAppCardOnly: false,
+                },
+            });
+        } catch (err) {
+            alert(err.message || '결제 요청에 실패했습니다.');
+            setIsPaymentLoading(false);
+        }
+    };
+
+    /* 무료 강의 수강 확정 */
+    const handleFreeConfirm = async (enrollmentId) => {
+        if (!window.confirm('수강을 확정하시겠습니까?')) return;
+
+        try {
+            await confirmEnrollment(enrollmentId);
+            alert('수강이 확정되었습니다.');
+            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
+        } catch (err) {
+            alert(err.response?.data?.message || '수강 확정에 실패했습니다.');
+        }
+    };
+
+    /* PENDING/WAITLIST 취소 (사유 불필요) */
+    const handleCancel = async (enrollmentId) => {
+        if (!window.confirm('수강을 취소하시겠습니까?')) return;
+
+        try {
+            await cancelEnrollment(enrollmentId);
+            alert('수강이 취소되었습니다.');
+            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
+        } catch (err) {
+            alert(err.response?.data?.message || '수강 취소에 실패했습니다.');
+        }
+    };
+
+    /* CONFIRMED 취소 모달 열기 */
+    const handleCancelClick = (enrollmentId) => {
+        setSelectedReason('');
+        setCustomReason('');
+        setCancelModal({ open: true, enrollmentId });
+    };
+
+    /* CONFIRMED 취소 모달 확인 */
+    const handleCancelConfirm = async () => {
+        const reason = selectedReason === '기타' ? customReason.trim() : selectedReason;
+
+        if (!reason) {
+            alert('취소 사유를 선택하거나 입력해주세요.');
+            return;
+        }
+
+        try {
+            await cancelEnrollment(cancelModal.enrollmentId, reason);
+            alert('수강이 취소되었습니다.');
+            setCancelModal({ open: false, enrollmentId: null });
+            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
+            queryClient.invalidateQueries({ queryKey: ['myPayments'] });
+        } catch (err) {
+            alert(err.response?.data?.message || '수강 취소에 실패했습니다.');
+        }
+    };
+
+    return {
+        enrollmentPage,
+        setEnrollmentPage,
+        isPaymentLoading,
+        cancelModal,
+        setCancelModal,
+        selectedReason,
+        setSelectedReason,
+        customReason,
+        setCustomReason,
+        handlePayment,
+        handleFreeConfirm,
+        handleCancel,
+        handleCancelClick,
+        handleCancelConfirm,
+    };
+};

--- a/frontend/src/hooks/useMyPayments.js
+++ b/frontend/src/hooks/useMyPayments.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyPayments } from '../api/payment';
+
+/* 내 결제 내역 조회를 위한 커스텀 훅 */
+export const useMyPayments = (enabled = true) => {
+    return useQuery({
+        queryKey: ['myPayments'],
+        queryFn: () => getMyPayments().then(res => res.data),
+        enabled,
+    });
+};

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,109 +1,24 @@
-import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
-import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
-import { cancelEnrollment, confirmEnrollment } from '../api/enrollment';
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { COURSE_STATUS_BADGE_STYLE, COURSE_STATUS_LABEL, ENROLLMENT_STATUS_BADGE_STYLE, ENROLLMENT_STATUS_LABEL } from '../utils/statusConfig';
-import { useMyEnrollments } from '../hooks/useMyEnrollments';
-import { useMyCourses } from '../hooks/useMyCourses';
-import { useCourseEnrollments } from '../hooks/useCourseEnrollments';
+import EnrollmentTab from './mypage/EnrollmentTab';
+import PaymentTab from './mypage/PaymentTab';
+import MyCourseTab from './mypage/MyCourseTab';
+import StudentTab from './mypage/StudentTab';
 
 /* 마이페이지 */
 const MyPage = () => {
-    /* 페이지 이동을 위한 navigate 함수 */
-    const navigate = useNavigate();
-    /* 현재 페이지의 위치 정보 */
+    /* 라우터 location에서 탭 정보 가져오기 */
     const location = useLocation();
-    /* 인증 정보에서 현재 사용자 정보 추출 */
+    /* 인증 정보 */
     const { user } = useAuth();
     /* 현재 활성화된 탭 상태 */
     const [activeTab, setActiveTab] = useState(location.state?.tab || 'enrollments');
-    /* 수강목록 페이지 상태 */
-    const [enrollmentPage, setEnrollmentPage] = useState(0);
-    /* 선택한 강의 ID 상태 (강의별 수강생 목록 탭에서) */
-    const [selectedCourseId, setSelectedCourseId] = useState('');
-    /* 수강생 목록 페이지 상태 */
-    const [studentPage, setStudentPage] = useState(0);
-    /* 결제 진행 중 상태 (이중 클릭 방지) */
-    const [isPaymentLoading, setIsPaymentLoading] = useState(false);
-    /* React Query의 queryClient 인스턴스 */
-    const queryClient = useQueryClient();
 
-    /* 나의 수강목록 조회 */
-    const { data: enrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useMyEnrollments(enrollmentPage);
-    /* 내 강의 목록 조회 (CREATOR 권한이 있는 경우) */
-    const { data: myCourses = [] } = useMyCourses(activeTab === 'my-courses' || activeTab === 'students');
-    /* 강의별 수강생 목록 조회 (CREATOR 권한이 있는 경우) */
-    const { data: courseEnrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useCourseEnrollments(selectedCourseId, studentPage);
-
-    /* students 탭 진입 시 강의 선택 초기화 */
-    useEffect(() => {
-        if (activeTab === 'students') setSelectedCourseId('');
-    }, [activeTab]);
-
-    /* 강의 선택 시 수강생 목록 조회 */
-    const handleCourseSelect = (courseId) => {
-        setSelectedCourseId(courseId);
-        setStudentPage(0);
-    };
-
-    /* 유료 강의 결제 (토스페이먼츠) */
-    const handlePayment = async (enrollment) => {
-        setIsPaymentLoading(true);
-        try {
-            const tossPayments = await loadTossPayments(import.meta.env.VITE_TOSS_CLIENT_KEY);
-            const payment = tossPayments.payment({ customerKey: `CUSTOMER-${user.id}` });
-
-            await payment.requestPayment({
-                method: 'CARD',
-                amount: { currency: 'KRW', value: enrollment.price },
-                orderId: `ORDER-${enrollment.id}-${Date.now()}`,
-                orderName: enrollment.courseTitle,
-                successUrl: `${window.location.origin}/payment/success?enrollmentId=${enrollment.id}&orderName=${encodeURIComponent(enrollment.courseTitle)}`,
-                failUrl: `${window.location.origin}/payment/fail`,
-                card: {
-                    useEscrow: false,
-                    flowMode: 'DEFAULT',
-                    useCardPoint: false,
-                    useAppCardOnly: false,
-                },
-            });
-        } catch (err) {
-            alert(err.message || '결제 요청에 실패했습니다.');
-            setIsPaymentLoading(false);
-        }
-    };
-
-    /* 무료 강의 수강 확정 */
-    const handleFreeConfirm = async (enrollmentId) => {
-        if (!window.confirm('수강을 확정하시겠습니까?')) return;
-
-        try {
-            await confirmEnrollment(enrollmentId);
-            alert('수강이 확정되었습니다.');
-            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
-        } catch (err) {
-            alert(err.response?.data?.message || '수강 확정에 실패했습니다.');
-        }
-    };
-
-    /* 수강 취소 */
-    const handleCancel = async (enrollmentId) => {
-        if (!window.confirm('수강을 취소하시겠습니까?')) return;
-
-        try {
-            await cancelEnrollment(enrollmentId);
-            alert('수강이 취소되었습니다.');
-            queryClient.invalidateQueries({ queryKey: ['myEnrollments', enrollmentPage] });
-        } catch (err) {
-            alert(err.response?.data?.message || '수강 취소에 실패했습니다.');
-        }
-    };
-
-    /* 탭 구성 - CREATOR 권한이 있는 경우 내 강의와 강의별 수강생 목록 탭 추가 */
+    /* 탭 목록 - CREATOR는 추가 탭 노출 */
     const tabs = [
         { key: 'enrollments', label: '나의 수강목록' },
+        { key: 'payments', label: '결제 내역' },
         ...(user?.role === 'CREATOR' ? [
             { key: 'my-courses', label: '내 강의' },
             { key: 'students', label: '강의별 수강생 목록' },
@@ -114,7 +29,7 @@ const MyPage = () => {
         <div className="max-w-4xl mx-auto mt-10 p-6">
             <h1 className="text-3xl font-extrabold text-gray-900 mb-8">마이페이지</h1>
 
-            {/* 탭 */}
+            {/* 탭 버튼들 */}
             <div className="flex gap-1 border-b border-gray-200 mb-8">
                 {tabs.map(tab => (
                     <button
@@ -130,248 +45,11 @@ const MyPage = () => {
                 ))}
             </div>
 
-            {/* 나의 수강목록 */}
-            {activeTab === 'enrollments' && (
-                <>
-                    {enrollmentData.content.length === 0 ? (
-                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                            수강 신청 내역이 없습니다.
-                        </div>
-                    ) : (
-                        <div className="flex flex-col gap-4">
-                            {enrollmentData.content.map(enrollment => (
-                                <div key={enrollment.id}
-                                    className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-
-                                    {/* 강의 정보 */}
-                                    <div className="flex-1 min-w-0">
-                                        <div className="flex items-center gap-2 mb-1">
-                                            <span
-                                                onClick={() => navigate(`/courses/${enrollment.courseId}`, { state: { from: 'my-page', tab: 'enrollments' } })}
-                                                className="text-base font-bold text-gray-900 truncate cursor-pointer hover:text-blue-600 transition-colors"
-                                            >
-                                                {enrollment.courseTitle}
-                                            </span>
-                                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ENROLLMENT_STATUS_BADGE_STYLE[enrollment.status]}`}>
-                                                {ENROLLMENT_STATUS_LABEL[enrollment.status]}
-                                            </span>
-                                        </div>
-
-                                        <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
-                                            <span>{enrollment.price === 0 ? '무료' : `${enrollment.price.toLocaleString()}원`}</span>
-                                            <span className="text-gray-300">|</span>
-                                            <span>{enrollment.startDate} ~ {enrollment.endDate}</span>
-                                            <span className="text-gray-300">|</span>
-                                            <span>신청일 {enrollment.createdAt?.substring(0, 10)}</span>
-                                        </div>
-
-                                        {enrollment.status === 'CONFIRMED' && enrollment.confirmedAt && (
-                                            <p className="text-xs text-green-600 mt-1">
-                                                결제일 {enrollment.confirmedAt.substring(0, 10)}
-                                            </p>
-                                        )}
-                                        {enrollment.status === 'CANCELLED' && enrollment.cancelledAt && (
-                                            <p className="text-xs text-gray-400 mt-1">
-                                                취소일 {enrollment.cancelledAt.substring(0, 10)}
-                                            </p>
-                                        )}
-                                        {enrollment.status === 'WAITLIST' && enrollment.waitlistPosition && (
-                                            <p className="text-xs text-purple-600 mt-1">
-                                                대기 순번 {enrollment.waitlistPosition}번
-                                            </p>
-                                        )}
-                                    </div>
-
-                                    {/* 액션 버튼 */}
-                                    <div className="flex gap-2 shrink-0">
-                                        {enrollment.status === 'PENDING' && (
-                                            <>
-                                                <button
-                                                    onClick={() => enrollment.price > 0 ? handlePayment(enrollment) : handleFreeConfirm(enrollment.id)}
-                                                    disabled={isPaymentLoading}
-                                                    className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                                                >
-                                                    {enrollment.price > 0 ? '결제하기' : '수강 확정하기'}
-                                                </button>
-                                                <button
-                                                    onClick={() => handleCancel(enrollment.id)}
-                                                    className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
-                                                >
-                                                    취소하기
-                                                </button>
-                                            </>
-                                        )}
-                                        {enrollment.status === 'CONFIRMED' &&
-                                            enrollment.confirmedAt &&
-                                            new Date(enrollment.confirmedAt) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) && (
-                                            <button
-                                                onClick={() => handleCancel(enrollment.id)}
-                                                className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
-                                            >
-                                                취소하기
-                                            </button>
-                                        )}
-                                        {enrollment.status === 'WAITLIST' && (
-                                            <button
-                                                onClick={() => handleCancel(enrollment.id)}
-                                                className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
-                                            >
-                                                대기 취소
-                                            </button>
-                                        )}
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-                    )}
-
-                    {/* 페이징 섹션 */}
-                    {(enrollmentData.totalPages ?? 0) > 1 && (
-                        <div className="flex justify-center items-center gap-4 mt-8">
-                            <button disabled={enrollmentPage === 0}
-                                onClick={() => setEnrollmentPage(prev => prev - 1)}
-                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
-                                </svg>
-                            </button>
-                            <span className="text-sm font-medium text-gray-700">
-                                <span className="text-blue-600">{enrollmentPage + 1}</span> / {enrollmentData.totalPages}
-                            </span>
-                            <button disabled={enrollmentData.last}
-                                onClick={() => setEnrollmentPage(prev => prev + 1)}
-                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
-                                </svg>
-                            </button>
-                        </div>
-                    )}
-                </>
-            )}
-
-            {/* 내 강의 목록 (CREATOR 전용) */}
-            {activeTab === 'my-courses' && (
-                <>
-                    {myCourses.length === 0 ? (
-                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                            등록한 강의가 없습니다.
-                        </div>
-                    ) : (
-                        <div className="flex flex-col gap-4">
-                            {myCourses.map(course => (
-                                <div key={course.id}
-                                    onClick={() => navigate(`/courses/${course.id}`, { state: { from: 'my-page' } })}
-                                    className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4 cursor-pointer hover:shadow-md transition-shadow">
-                                    <div className="flex-1 min-w-0">
-                                        <div className="flex items-center gap-2 mb-1">
-                                            <span className="text-base font-bold text-gray-900 truncate">{course.title}</span>
-                                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>
-                                                {COURSE_STATUS_LABEL[course.status]}
-                                            </span>
-                                        </div>
-                                        <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
-                                            <span>{course.price === 0 ? '무료' : `${course.price.toLocaleString()}원`}</span>
-                                            <span className="text-gray-300">|</span>
-                                            <span>수강 {course.enrolledCount} / {course.capacity}명</span>
-                                            <span className="text-gray-300">|</span>
-                                            <span>{course.startDate} ~ {course.endDate}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                </>
-            )}
-
-            {/* 강의별 수강생 목록 (CREATOR 전용) */}
-            {activeTab === 'students' && (
-                <>
-                    {/* 강의 선택 */}
-                    <div className="mb-6">
-                        <select
-                            value={selectedCourseId}
-                            onChange={(e) => handleCourseSelect(e.target.value)}
-                            className="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        >
-                            <option value="">강의를 선택하세요</option>
-                            {myCourses.map(course => (
-                                <option key={course.id} value={course.id}>
-                                    {course.title}
-                                </option>
-                            ))}
-                        </select>
-                    </div>
-
-                    {/* 수강생 목록 */}
-                    {!selectedCourseId ? (
-                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                            강의를 선택하면 수강생 목록이 표시됩니다.
-                        </div>
-                    ) : courseEnrollmentData.content.length === 0 ? (
-                        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                            수강생이 없습니다.
-                        </div>
-                    ) : (
-                        <div className="overflow-x-auto">
-                            <table className="w-full text-sm text-left">
-                                <thead>
-                                    <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
-                                        <th className="pb-3 pr-6 font-semibold">수강생</th>
-                                        <th className="pb-3 pr-6 font-semibold">상태</th>
-                                        <th className="pb-3 pr-6 font-semibold">신청일</th>
-                                        <th className="pb-3 font-semibold">결제일 / 취소일</th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-gray-100">
-                                    {courseEnrollmentData.content.map(enrollment => (
-                                        <tr key={enrollment.id} className="hover:bg-gray-50">
-                                            <td className="py-4 pr-6 font-medium text-gray-900">{enrollment.userName}</td>
-                                            <td className="py-4 pr-6">
-                                                <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ENROLLMENT_STATUS_BADGE_STYLE[enrollment.status]}`}>
-                                                    {ENROLLMENT_STATUS_LABEL[enrollment.status]}
-                                                </span>
-                                            </td>
-                                            <td className="py-4 pr-6 text-gray-500">{enrollment.createdAt?.substring(0, 10)}</td>
-                                            <td className="py-4 text-gray-500">
-                                                {enrollment.status === 'CONFIRMED' && enrollment.confirmedAt
-                                                    ? enrollment.confirmedAt.substring(0, 10)
-                                                    : enrollment.status === 'CANCELLED' && enrollment.cancelledAt
-                                                        ? enrollment.cancelledAt.substring(0, 10)
-                                                        : '-'}
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
-                    )}
-
-                    {/* 페이징 섹션 */}
-                    {(courseEnrollmentData.totalPages ?? 0) > 1 && (
-                        <div className="flex justify-center items-center gap-4 mt-8">
-                            <button disabled={studentPage === 0}
-                                onClick={() => setStudentPage(prev => prev - 1)}
-                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
-                                </svg>
-                            </button>
-                            <span className="text-sm font-medium text-gray-700">
-                                <span className="text-blue-600">{studentPage + 1}</span> / {courseEnrollmentData.totalPages}
-                            </span>
-                            <button disabled={courseEnrollmentData.last}
-                                onClick={() => setStudentPage(prev => prev + 1)}
-                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
-                                </svg>
-                            </button>
-                        </div>
-                    )}
-                </>
-            )}
+            {/* 탭 콘텐츠 */}
+            {activeTab === 'enrollments' && <EnrollmentTab />}
+            {activeTab === 'payments' && <PaymentTab />}
+            {activeTab === 'my-courses' && <MyCourseTab />}
+            {activeTab === 'students' && <StudentTab />}
         </div>
     );
 };

--- a/frontend/src/pages/mypage/EnrollmentTab.jsx
+++ b/frontend/src/pages/mypage/EnrollmentTab.jsx
@@ -1,0 +1,163 @@
+import { useNavigate } from 'react-router-dom';
+import { ENROLLMENT_STATUS_BADGE_STYLE, ENROLLMENT_STATUS_LABEL } from '../../utils/statusConfig';
+import { useMyEnrollments } from '../../hooks/useMyEnrollments';
+import { useEnrollmentActions } from '../../hooks/useEnrollmentActions';
+import CancelModal from '../../components/CancelModal';
+
+/* 나의 수강목록 탭 */
+const EnrollmentTab = () => {
+    /* 페이지 이동 훅 */
+    const navigate = useNavigate();
+    /* 수강목록 액션 훅 */
+    const {
+        enrollmentPage,
+        setEnrollmentPage,
+        isPaymentLoading,
+        cancelModal,
+        setCancelModal,
+        selectedReason,
+        setSelectedReason,
+        customReason,
+        setCustomReason,
+        handlePayment,
+        handleFreeConfirm,
+        handleCancel,
+        handleCancelClick,
+        handleCancelConfirm,
+    } = useEnrollmentActions();
+    
+    /* 수강목록 데이터 */
+    const { data: enrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useMyEnrollments(enrollmentPage);
+
+    return (
+        <>
+            {enrollmentData.content.length === 0 ? (
+                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                    수강 신청 내역이 없습니다.
+                </div>
+            ) : (
+                <div className="flex flex-col gap-4">
+                    {enrollmentData.content.map(enrollment => (
+                        <div key={enrollment.id}
+                            className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+
+                            {/* 강의 정보 */}
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 mb-1">
+                                    <span
+                                        onClick={() => navigate(`/courses/${enrollment.courseId}`, { state: { from: 'my-page', tab: 'enrollments' } })}
+                                        className="text-base font-bold text-gray-900 truncate cursor-pointer hover:text-blue-600 transition-colors"
+                                    >
+                                        {enrollment.courseTitle}
+                                    </span>
+                                    <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ENROLLMENT_STATUS_BADGE_STYLE[enrollment.status]}`}>
+                                        {ENROLLMENT_STATUS_LABEL[enrollment.status]}
+                                    </span>
+                                </div>
+
+                                <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
+                                    <span>{enrollment.price === 0 ? '무료' : `${enrollment.price.toLocaleString()}원`}</span>
+                                    <span className="text-gray-300">|</span>
+                                    <span>{enrollment.startDate} ~ {enrollment.endDate}</span>
+                                    <span className="text-gray-300">|</span>
+                                    <span>신청일 {enrollment.createdAt?.substring(0, 10)}</span>
+                                </div>
+
+                                {enrollment.status === 'CONFIRMED' && enrollment.confirmedAt && (
+                                    <p className="text-xs text-green-600 mt-1">
+                                        결제일 {enrollment.confirmedAt.substring(0, 10)}
+                                    </p>
+                                )}
+                                {enrollment.status === 'CANCELLED' && enrollment.cancelledAt && (
+                                    <p className="text-xs text-gray-400 mt-1">
+                                        취소일 {enrollment.cancelledAt.substring(0, 10)}
+                                    </p>
+                                )}
+                                {enrollment.status === 'WAITLIST' && enrollment.waitlistPosition && (
+                                    <p className="text-xs text-purple-600 mt-1">
+                                        대기 순번 {enrollment.waitlistPosition}번
+                                    </p>
+                                )}
+                            </div>
+
+                            {/* 액션 버튼 */}
+                            <div className="flex gap-2 shrink-0">
+                                {enrollment.status === 'PENDING' && (
+                                    <>
+                                        <button
+                                            onClick={() => enrollment.price > 0 ? handlePayment(enrollment) : handleFreeConfirm(enrollment.id)}
+                                            disabled={isPaymentLoading}
+                                            className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                                        >
+                                            {enrollment.price > 0 ? '결제하기' : '수강 확정하기'}
+                                        </button>
+                                        <button
+                                            onClick={() => handleCancel(enrollment.id)}
+                                            className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                                        >
+                                            취소하기
+                                        </button>
+                                    </>
+                                )}
+                                {enrollment.status === 'CONFIRMED' &&
+                                    enrollment.confirmedAt &&
+                                    new Date(enrollment.confirmedAt) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) && (
+                                    <button
+                                        onClick={() => handleCancelClick(enrollment.id)}
+                                        className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                                    >
+                                        수강 취소
+                                    </button>
+                                )}
+                                {enrollment.status === 'WAITLIST' && (
+                                    <button
+                                        onClick={() => handleCancel(enrollment.id)}
+                                        className="px-4 py-2 border border-gray-300 text-gray-600 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors cursor-pointer"
+                                    >
+                                        대기 취소
+                                    </button>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* 페이징 */}
+            {(enrollmentData.totalPages ?? 0) > 1 && (
+                <div className="flex justify-center items-center gap-4 mt-8">
+                    <button disabled={enrollmentPage === 0}
+                        onClick={() => setEnrollmentPage(prev => prev - 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                        </svg>
+                    </button>
+                    <span className="text-sm font-medium text-gray-700">
+                        <span className="text-blue-600">{enrollmentPage + 1}</span> / {enrollmentData.totalPages}
+                    </span>
+                    <button disabled={enrollmentData.last}
+                        onClick={() => setEnrollmentPage(prev => prev + 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </button>
+                </div>
+            )}
+
+            {/* CONFIRMED 취소 모달 */}
+            <CancelModal
+                open={cancelModal.open}
+                onClose={() => setCancelModal({ open: false, enrollmentId: null })}
+                onConfirm={handleCancelConfirm}
+                selectedReason={selectedReason}
+                setSelectedReason={setSelectedReason}
+                customReason={customReason}
+                setCustomReason={setCustomReason}
+            />
+        </>
+    );
+};
+
+export default EnrollmentTab;

--- a/frontend/src/pages/mypage/MyCourseTab.jsx
+++ b/frontend/src/pages/mypage/MyCourseTab.jsx
@@ -1,0 +1,51 @@
+import { useNavigate } from 'react-router-dom';
+import { COURSE_STATUS_BADGE_STYLE, COURSE_STATUS_LABEL } from '../../utils/statusConfig';
+import { useMyCourses } from '../../hooks/useMyCourses';
+
+/* 내 강의 목록 탭 (CREATOR 전용) */
+const MyCourseTab = () => {
+    /* 페이지 이동 함수 */
+    const navigate = useNavigate();
+    /* 내 강의 데이터 */
+    const { data: myCourses = [] } = useMyCourses(true);
+
+    /* 등록한 강의가 없는 경우 */
+    if (myCourses.length === 0) {
+        return (
+            <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                등록한 강의가 없습니다.
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            {myCourses.map(course => (
+                <div key={course.id}
+                    onClick={() => navigate(`/courses/${course.id}`, { state: { from: 'my-page' } })}
+                    className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4 cursor-pointer hover:shadow-md transition-shadow">
+                    <div className="flex-1 min-w-0">
+                        {/* 강의 제목과 상태 배지 */}
+                        <div className="flex items-center gap-2 mb-1">
+                            <span className="text-base font-bold text-gray-900 truncate">{course.title}</span>
+                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>
+                                {COURSE_STATUS_LABEL[course.status]}
+                            </span>
+                        </div>
+                        
+                        {/* 강의 정보 */}
+                        <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
+                            <span>{course.price === 0 ? '무료' : `${course.price.toLocaleString()}원`}</span>
+                            <span className="text-gray-300">|</span>
+                            <span>수강 {course.enrolledCount} / {course.capacity}명</span>
+                            <span className="text-gray-300">|</span>
+                            <span>{course.startDate} ~ {course.endDate}</span>
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default MyCourseTab;

--- a/frontend/src/pages/mypage/PaymentTab.jsx
+++ b/frontend/src/pages/mypage/PaymentTab.jsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { cancelEnrollment } from '../../api/enrollment';
+import { useMyPayments } from '../../hooks/useMyPayments';
+import CancelModal from '../../components/CancelModal';
+import ReceiptModal from '../../components/ReceiptModal';
+
+/* 결제 상태 배지 스타일 */
+const PAYMENT_STATUS_BADGE_STYLE = {
+    DONE: 'bg-green-50 text-green-700 border-green-200',
+    CANCELLED: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+/* 결제 상태 라벨 */
+const PAYMENT_STATUS_LABEL = {
+    DONE: '결제완료',
+    CANCELLED: '환불완료',
+};
+
+/* 결제 취소 가능 여부 (결제일로부터 7일 이내) */
+const isWithin7Days = (paidAt) =>
+    paidAt && new Date(paidAt) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+/* 결제 내역 탭 */
+const PaymentTab = () => {
+    /* 결제 데이터 */
+    const { data: myPayments = [] } = useMyPayments();
+    /* 결제 영수증 모달 상태 */
+    const [receiptPayment, setReceiptPayment] = useState(null);
+    /* CONFIRMED 취소 모달 상태 */
+    const [cancelModal, setCancelModal] = useState({ open: false, enrollmentId: null });
+    /* 취소 사유 상태 */
+    const [selectedReason, setSelectedReason] = useState('');
+    /* 기타 사유 입력 상태 */
+    const [customReason, setCustomReason] = useState('');
+    /* React Query 클라이언트 */
+    const queryClient = useQueryClient();
+
+    /* 결제 취소 클릭 핸들러 */
+    const handleCancelClick = (e, payment) => {
+        e.stopPropagation();
+
+        if (!window.confirm('결제를 취소하시겠습니까?')) return;
+
+        setSelectedReason('');
+        setCustomReason('');
+        setCancelModal({ open: true, enrollmentId: payment.enrollmentId });
+    };
+
+    /* 영수증 모달에서 결제 취소 핸들러 */
+    const handleCancelFromReceipt = () => {
+        if (!window.confirm('결제를 취소하시겠습니까?')) return;
+        
+        setSelectedReason('');
+        setCustomReason('');
+        setCancelModal({ open: true, enrollmentId: receiptPayment.enrollmentId });
+    };
+
+    /* CONFIRMED 취소 모달 확인 핸들러 */
+    const handleCancelConfirm = async () => {
+        const reason = selectedReason === '기타' ? customReason.trim() : selectedReason;
+
+        if (!reason) {
+            alert('취소 사유를 선택하거나 입력해주세요.');
+            return;
+        }
+
+        try {
+            await cancelEnrollment(cancelModal.enrollmentId, reason);
+            alert('결제가 취소되었습니다.');
+            setCancelModal({ open: false, enrollmentId: null });
+            setReceiptPayment(null);
+
+            queryClient.invalidateQueries({ queryKey: ['myPayments'] });
+            queryClient.invalidateQueries({ queryKey: ['myEnrollments'] });
+        } catch (err) {
+            alert(err.response?.data?.message || '결제 취소에 실패했습니다.');
+        }
+    };
+
+    /* 결제 내역이 없는 경우 */
+    if (myPayments.length === 0) {
+        return (
+            <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                결제 내역이 없습니다.
+            </div>
+        );
+    }
+
+    return (
+        <>
+            <div className="flex flex-col gap-4">
+                {myPayments.map(payment => (
+                    <div key={payment.id}
+                        onClick={() => setReceiptPayment(payment)}
+                        className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm cursor-pointer hover:shadow-md transition-shadow">
+                        <div className="flex items-start justify-between gap-4">
+                            {/* 결제 정보 */}
+                            <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-2 mb-1">
+                                    <span className="text-base font-bold text-gray-900 truncate">{payment.orderName}</span>
+                                    <span className={`text-xs font-bold px-2 py-0.5 rounded border shrink-0 ${PAYMENT_STATUS_BADGE_STYLE[payment.status]}`}>
+                                        {PAYMENT_STATUS_LABEL[payment.status]}
+                                    </span>
+                                </div>
+                                <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
+                                    <span className="font-semibold text-gray-700">{payment.amount.toLocaleString()}원</span>
+                                    {payment.method && (
+                                        <>
+                                            <span className="text-gray-300">|</span>
+                                            <span>{payment.method}</span>
+                                        </>
+                                    )}
+                                    <span className="text-gray-300">|</span>
+                                    <span>결제일 {payment.paidAt?.substring(0, 10)}</span>
+                                </div>
+                                {payment.status === 'CANCELLED' && (
+                                    <p className="text-xs text-gray-400 mt-1">
+                                        환불일 {payment.canceledAt?.substring(0, 10)}
+                                        {payment.cancelReason && <span className="ml-2">· {payment.cancelReason}</span>}
+                                    </p>
+                                )}
+                            </div>
+
+                            {/* CONFIRMED 결제이면서 결제일로부터 7일 이내인 경우에만 취소 버튼 표시 */}
+                            {payment.status === 'DONE' && isWithin7Days(payment.paidAt) && (
+                                <button
+                                    onClick={(e) => handleCancelClick(e, payment)}
+                                    className="shrink-0 px-4 py-2 border border-red-200 text-red-400 text-sm font-semibold rounded-md hover:bg-red-50 transition-colors cursor-pointer"
+                                >
+                                    결제 취소
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {/* 영수증 모달 */}
+            <ReceiptModal
+                payment={receiptPayment}
+                onClose={() => setReceiptPayment(null)}
+                canCancel={receiptPayment?.status === 'DONE' && isWithin7Days(receiptPayment?.paidAt)}
+                onCancel={handleCancelFromReceipt}
+            />
+
+            {/* CONFIRMED 취소 모달 */}
+            <CancelModal
+                open={cancelModal.open}
+                onClose={() => setCancelModal({ open: false, enrollmentId: null })}
+                onConfirm={handleCancelConfirm}
+                selectedReason={selectedReason}
+                setSelectedReason={setSelectedReason}
+                customReason={customReason}
+                setCustomReason={setCustomReason}
+            />
+        </>
+    );
+};
+
+export default PaymentTab;

--- a/frontend/src/pages/mypage/StudentTab.jsx
+++ b/frontend/src/pages/mypage/StudentTab.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { ENROLLMENT_STATUS_BADGE_STYLE, ENROLLMENT_STATUS_LABEL } from '../../utils/statusConfig';
+import { useMyCourses } from '../../hooks/useMyCourses';
+import { useCourseEnrollments } from '../../hooks/useCourseEnrollments';
+
+/* 강의별 수강생 목록 탭 (CREATOR 전용) */
+const StudentTab = () => {
+    /* 선택한 강의 ID */
+    const [selectedCourseId, setSelectedCourseId] = useState('');
+    /* 수강생 목록 페이지 */
+    const [studentPage, setStudentPage] = useState(0);
+
+    /* 내 강의 데이터 */
+    const { data: myCourses = [] } = useMyCourses(true);
+    /* 선택한 강의의 수강 신청 데이터 */
+    const { data: courseEnrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useCourseEnrollments(selectedCourseId, studentPage);
+
+    /* 강의가 변경될 때마다 수강생 페이지 초기화 */
+    useEffect(() => {
+        setSelectedCourseId('');
+    }, []);
+
+    /* 강의 선택 핸들러 */
+    const handleCourseSelect = (courseId) => {
+        setSelectedCourseId(courseId);
+        setStudentPage(0);
+    };
+
+    return (
+        <>
+            {/* 강의 선택 */}
+            <div className="mb-6">
+                <select
+                    value={selectedCourseId}
+                    onChange={(e) => handleCourseSelect(e.target.value)}
+                    className="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                    <option value="">강의를 선택하세요</option>
+                    {myCourses.map(course => (
+                        <option key={course.id} value={course.id}>{course.title}</option>
+                    ))}
+                </select>
+            </div>
+
+            {/* 수강생 목록 */}
+            {!selectedCourseId ? (
+                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                    강의를 선택하면 수강생 목록이 표시됩니다.
+                </div>
+            ) : courseEnrollmentData.content.length === 0 ? (
+                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                    수강생이 없습니다.
+                </div>
+            ) : (
+                <div className="overflow-x-auto">
+                    <table className="w-full text-sm text-left">
+                        <thead>
+                            <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
+                                <th className="pb-3 pr-6 font-semibold">수강생</th>
+                                <th className="pb-3 pr-6 font-semibold">상태</th>
+                                <th className="pb-3 pr-6 font-semibold">신청일</th>
+                                <th className="pb-3 font-semibold">결제일 / 취소일</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-100">
+                            {courseEnrollmentData.content.map(enrollment => (
+                                <tr key={enrollment.id} className="hover:bg-gray-50">
+                                    <td className="py-4 pr-6 font-medium text-gray-900">{enrollment.userName}</td>
+                                    <td className="py-4 pr-6">
+                                        <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ENROLLMENT_STATUS_BADGE_STYLE[enrollment.status]}`}>
+                                            {ENROLLMENT_STATUS_LABEL[enrollment.status]}
+                                        </span>
+                                    </td>
+                                    <td className="py-4 pr-6 text-gray-500">{enrollment.createdAt?.substring(0, 10)}</td>
+                                    <td className="py-4 text-gray-500">
+                                        {enrollment.status === 'CONFIRMED' && enrollment.confirmedAt
+                                            ? enrollment.confirmedAt.substring(0, 10)
+                                            : enrollment.status === 'CANCELLED' && enrollment.cancelledAt
+                                                ? enrollment.cancelledAt.substring(0, 10)
+                                                : '-'}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {/* 페이징 */}
+            {(courseEnrollmentData.totalPages ?? 0) > 1 && (
+                <div className="flex justify-center items-center gap-4 mt-8">
+                    <button disabled={studentPage === 0}
+                        onClick={() => setStudentPage(prev => prev - 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                        </svg>
+                    </button>
+                    <span className="text-sm font-medium text-gray-700">
+                        <span className="text-blue-600">{studentPage + 1}</span> / {courseEnrollmentData.totalPages}
+                    </span>
+                    <button disabled={courseEnrollmentData.last}
+                        onClick={() => setStudentPage(prev => prev + 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </button>
+                </div>
+            )}
+        </>
+    );
+};
+
+export default StudentTab;


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - CONFIRMED 수강 취소 시 토스페이먼츠 환불 API 연동 및 취소 사유 수신 처리
  - GET /api/payments/my 결제 내역 조회 엔드포인트 추가
  - 마이페이지 탭 컴포넌트 분리 리팩토링 (MyPage 단일 파일 → 탭별 컴포넌트)
  - 결제 내역 탭 구현 (영수증 조회, 결제 취소, 영수증 출력)
  - PaymentService, EnrollmentService 단위 테스트 추가
  
  ## 구현 시 고려한 점
  - CONFIRMED 취소 흐름: 7일 이내 검증 → 취소 사유 필수 검증 → 토스 환불 API → DB CANCELLED 업데이트 순서로 외부 API를 DB 쓰기보다 먼저 호출해 부분 실패 방지
  - 무료 강의는 결제 내역이 없으므로 refund() 내부에서 결제 조회 결과가 null이면 조기 반환
  - 결제 취소 버튼은 DONE 상태이면서 결제일로부터 7일 이내인 경우에만 노출 (프론트/백엔드 동일 조건)
  - PENDING/WAITLIST 취소는 사유 불필요, CONFIRMED 취소만 CancelModal을 통해 사유 필수 입력
  - 영수증 출력은 window.open + window.print()로 현재 페이지 영향 없이 별도 창 출력
  
  ## 테스트 방법
  - 백엔드: IDE에서 CourseEnrollmentApplication 실행 (Port: 8080)
  - 프론트: npm run dev (Port: 5173)
  - http://localhost:5173/my-page 에서 결제 내역 탭 확인
  - CONFIRMED 수강 취소: 수강목록 탭 → 수강 취소 클릭 → 사유 선택 → 결제 내역 탭에서 CANCELLED 반영 확인
  - 영수증: 결제 내역 카드 클릭 → 영수증 모달 → 영수증 출력 클릭
  
 ## 연관 이슈
 Closes #33