### PR TITLE
[refactor] Javadoc 누락 태그 보완 및 프론트엔드 로딩 상태 패턴 통일

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -45,6 +45,7 @@ public class CourseService {
      * 강의 등록
      * @param creatorId 강의를 등록하는 크리에이터 ID
      * @param reqCourseCreateDto 강의 등록 요청 DTO
+     * @return 등록된 강의 응답 DTO
      * @throws BusinessException 사용자 없음(400), 등록 권한 없음(403), 날짜 유효성 오류(400), 등록 실패(500)
      */
     @Transactional
@@ -99,6 +100,7 @@ public class CourseService {
     /**
      * 강의 목록 조회
      * @param reqCourseSearchDto 검색 조건 DTO
+     * @return 페이징된 강의 목록
      */
     public RespPageDto<RespCourseListDto> findCourseList(ReqCourseSearchDto reqCourseSearchDto) {
         log.info("[CourseService] 강의 목록 조회 - status: {}, keyword: {}", reqCourseSearchDto.getStatus(), reqCourseSearchDto.getKeyword());
@@ -115,7 +117,8 @@ public class CourseService {
      * 강의 상세 조회
      * @param courseId 강의 ID
      * @param userId 조회하는 사용자 ID (수강 신청 여부 확인용)
-     * @throws BusinessException 강의 없음(400)
+     * @return 강의 상세 응답 DTO
+     * @throws BusinessException 강의 없음(400), DRAFT 강의 접근 권한 없음(403)
      */
     public RespCourseDetailDto findCourseById(Long courseId, Long userId) {
         log.info("[CourseService] 강의 상세 조회 - courseId: {}", courseId);
@@ -146,6 +149,7 @@ public class CourseService {
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
      * @param reqCourseUpdateDto 강의 수정 요청 DTO
+     * @return 수정된 강의 상세 응답 DTO
      * @throws BusinessException 강의 없음(400), 수정 권한 없음(403), DRAFT 상태 아님(400), 날짜 유효성 오류(400)
      */
     @Transactional
@@ -188,6 +192,7 @@ public class CourseService {
      * 강의 공개 (DRAFT → OPEN)
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
+     * @return 공개된 강의 상세 응답 DTO
      * @throws BusinessException 강의 없음(400), 공개 권한 없음(403), DRAFT 상태 아님(400)
      */
     @Transactional
@@ -221,6 +226,7 @@ public class CourseService {
      * 강의 마감 (OPEN → CLOSED)
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
+     * @return 마감된 강의 상세 응답 DTO
      * @throws BusinessException 강의 없음(400), 마감 권한 없음(403), OPEN 상태 아님(400)
      */
     @Transactional
@@ -253,6 +259,7 @@ public class CourseService {
     /**
      * 강의 목록 조회 (CREATOR 전용)
      * @param creatorId 크리에이터 ID
+     * @return 강의 목록
      */
     public List<RespCourseListDto> findMyCourses(Long creatorId) {
         log.info("[CourseService] 나의 강의 목록 조회 - creatorId: {}", creatorId);
@@ -265,6 +272,7 @@ public class CourseService {
      * @param creatorId 크리에이터 ID
      * @param courseId 강의 ID
      * @param reqCourseEnrollmentPageDto 페이징 조건 DTO
+     * @return 페이징된 수강생 목록
      * @throws BusinessException 강의 없음(400), 조회 권한 없음(403)
      */
     public RespPageDto<RespEnrollmentCreatorDto> findCourseEnrollments(Long creatorId, Long courseId, ReqCourseEnrollmentPageDto reqCourseEnrollmentPageDto) {

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -43,6 +43,7 @@ public class EnrollmentService {
      * 정원이 남아있으면 PENDING, 초과 시 WAITLIST로 등록
      * @param userId 신청하는 사용자 ID
      * @param reqEnrollmentCreateDto 수강 신청 요청 DTO
+     * @return 수강 신청 응답 DTO
      * @throws BusinessException 사용자 없음(400), 강의 없음(400), 본인 강의 신청(403), 모집 중 아님(400), 중복 신청(400)
      */
     @Transactional
@@ -124,6 +125,7 @@ public class EnrollmentService {
      * 나의 수강 신청 목록 조회
      * @param userId 사용자 ID
      * @param reqEnrollmentPageDto 페이징 조건 DTO
+     * @return 페이징된 수강 신청 목록
      */
     public RespPageDto<RespEnrollmentStudentDto> findMyEnrollments(Long userId, ReqEnrollmentPageDto reqEnrollmentPageDto) {
         log.info("[EnrollmentService] 나의 수강 신청 목록 조회 - userId: {}, page: {}, size: {}", userId, reqEnrollmentPageDto.getPage(), reqEnrollmentPageDto.getSize());
@@ -141,6 +143,7 @@ public class EnrollmentService {
      * 결제 요청 (PENDING → CONFIRMED)
      * @param userId 사용자 ID
      * @param enrollmentId 수강 신청 ID
+     * @return 수강 신청 응답 DTO
      * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), PENDING 상태 아님(400)
      */
     @Transactional
@@ -184,6 +187,7 @@ public class EnrollmentService {
      * @param userId 사용자 ID
      * @param enrollmentId 수강 신청 ID
      * @param cancelReason 취소 사유 (CONFIRMED 취소 시 필수)
+     * @return 취소된 수강 신청 응답 DTO
      * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), 이미 취소됨(400), CONFIRMED 7일 초과(400), 취소 사유 없음(400)
      */
     @Transactional

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -124,6 +124,7 @@ public class PaymentService {
      * 무료 강의(결제 내역 없음)는 환불 없이 통과
      * @param enrollmentId 수강 신청 ID
      * @param cancelReason 취소 사유
+     * @throws BusinessException 토스 환불 API 호출 실패(400)
      */
     @Transactional
     public void refund(Long enrollmentId, String cancelReason) {

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -20,7 +20,7 @@ const CourseDetailPage = () => {
     /* React Query의 queryClient 인스턴스 */
     const queryClient = useQueryClient();
     /* 강의 상세 조회 */
-    const { data: course, isError } = useCourseDetail(courseId);
+    const { data: course, isLoading, isError } = useCourseDetail(courseId);
 
     /* 현재 로그인한 사용자가 강의 소유자인지 여부 */
     const isOwner = course?.creatorId === user?.id;
@@ -82,7 +82,7 @@ const CourseDetailPage = () => {
         }
     };
 
-    if (!course) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     return (
         <div className="max-w-7xl mx-auto mt-10 p-6">

--- a/frontend/src/pages/CourseListPage.jsx
+++ b/frontend/src/pages/CourseListPage.jsx
@@ -32,7 +32,7 @@ const CourseListPage = () => {
     }, [searchParams]);
 
     /* 강의 목록 조회 (searchParams가 바뀔 때마다 자동 실행) */
-    const { data = { content: [], totalCount: 0, totalPages: 0, last: false } } = useCourseList(search);
+    const { data = { content: [], totalCount: 0, totalPages: 0, last: false }, isLoading } = useCourseList(search);
 
     /* 검색 실행 */
     const handleSearch = (e) => {
@@ -64,6 +64,8 @@ const CourseListPage = () => {
             page: 0
         });
     };
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     return (
         <div className="max-w-7xl mx-auto mt-10 p-6">

--- a/frontend/src/pages/mypage/EnrollmentTab.jsx
+++ b/frontend/src/pages/mypage/EnrollmentTab.jsx
@@ -27,16 +27,19 @@ const EnrollmentTab = () => {
     } = useEnrollmentActions();
     
     /* 수강목록 데이터 */
-    const { data: enrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useMyEnrollments(enrollmentPage);
+    const { data: enrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false }, isLoading } = useMyEnrollments(enrollmentPage);
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
+
+    if (enrollmentData.content.length === 0) return (
+        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+            수강 신청 내역이 없습니다.
+        </div>
+    );
 
     return (
         <>
-            {enrollmentData.content.length === 0 ? (
-                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                    수강 신청 내역이 없습니다.
-                </div>
-            ) : (
-                <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4">
                     {enrollmentData.content.map(enrollment => (
                         <div key={enrollment.id}
                             className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4">
@@ -121,7 +124,6 @@ const EnrollmentTab = () => {
                         </div>
                     ))}
                 </div>
-            )}
 
             {/* 페이징 */}
             {(enrollmentData.totalPages ?? 0) > 1 && (

--- a/frontend/src/pages/mypage/MyCourseTab.jsx
+++ b/frontend/src/pages/mypage/MyCourseTab.jsx
@@ -7,7 +7,9 @@ const MyCourseTab = () => {
     /* 페이지 이동 함수 */
     const navigate = useNavigate();
     /* 내 강의 데이터 */
-    const { data: myCourses = [] } = useMyCourses(true);
+    const { data: myCourses = [], isLoading } = useMyCourses(true);
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     /* 등록한 강의가 없는 경우 */
     if (myCourses.length === 0) {

--- a/frontend/src/pages/mypage/PaymentTab.jsx
+++ b/frontend/src/pages/mypage/PaymentTab.jsx
@@ -23,7 +23,7 @@ const isWithin7Days = (paidAt) =>
 /* 결제 내역 탭 */
 const PaymentTab = () => {
     /* 결제 데이터 */
-    const { data: myPayments = [] } = useMyPayments();
+    const { data: myPayments = [], isLoading } = useMyPayments();
     /* 결제 영수증 모달 상태 */
     const [receiptPayment, setReceiptPayment] = useState(null);
     /* CONFIRMED 취소 모달 상태 */
@@ -76,6 +76,8 @@ const PaymentTab = () => {
             alert(err.response?.data?.message || '결제 취소에 실패했습니다.');
         }
     };
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     /* 결제 내역이 없는 경우 */
     if (myPayments.length === 0) {

--- a/frontend/src/pages/mypage/StudentTab.jsx
+++ b/frontend/src/pages/mypage/StudentTab.jsx
@@ -11,9 +11,9 @@ const StudentTab = () => {
     const [studentPage, setStudentPage] = useState(0);
 
     /* 내 강의 데이터 */
-    const { data: myCourses = [] } = useMyCourses(true);
+    const { data: myCourses = [], isLoading: isCoursesLoading } = useMyCourses(true);
     /* 선택한 강의의 수강 신청 데이터 */
-    const { data: courseEnrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false } } = useCourseEnrollments(selectedCourseId, studentPage);
+    const { data: courseEnrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false }, isLoading: isEnrollmentsLoading } = useCourseEnrollments(selectedCourseId, studentPage);
 
     /* 강의가 변경될 때마다 수강생 페이지 초기화 */
     useEffect(() => {
@@ -25,6 +25,8 @@ const StudentTab = () => {
         setSelectedCourseId(courseId);
         setStudentPage(0);
     };
+
+    if (isCoursesLoading || isEnrollmentsLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     return (
         <>


### PR DESCRIPTION
  ## 작업 내용
  - 백엔드 서비스 Javadoc @return 태그 누락 보완 (EnrollmentService, CourseService, PaymentService)
  - PaymentService.refund, CourseService.findCourseById @throws 태그 누락 보완
  - 프론트엔드 커스텀 훅에서 isLoading 구조분해 추가
  - 전 페이지/탭 isLoading early return 패턴으로 통일 (CourseDetailPage, CourseListPage, EnrollmentTab, MyCourseTab, PaymentTab, StudentTab)
  - EnrollmentTab 인라인 삼항 연산자 → early return 방식으로 변환

  ## 구현 시 고려한 점
  - isLoading early return은 훅 자체를 수정하지 않고 컴포넌트에서 구조분해 시 추가하는 방식 적용 — useQuery 반환값을 그대로 활용
  - EnrollmentTab empty early return 시 CancelModal 미렌더링 문제 검토 → content가 비어있으면 CONFIRMED 취소 모달이 열릴 수 없으므로 안전
  - StudentTab은 myCourses와 courseEnrollments 두 훅 모두 로딩 중일 때 로딩 UI 표시

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - 마이페이지 각 탭 진입 시 로딩 UI 노출 확인
  - 수강 신청/결제/취소 기능 정상 동작 확인 (로직 변경 없음)

  ## 연관 이슈
  Closes #36