### PR TITLE
[feat] 마이페이지 MyCourse·Payment 탭 페이지네이션 추가 및 page size 통일

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
@@ -4,6 +4,7 @@ import com.yujin.course_enrollment.dto.req.ReqCourseCreateDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseSearchDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseUpdateDto;
+import com.yujin.course_enrollment.dto.req.ReqMyCoursePageDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
@@ -16,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 /**
@@ -126,12 +125,13 @@ public class CourseController {
      * 나의 강의 목록 조회 (CREATOR 전용)
      * GET /api/courses/my
      * @param creatorId 크리에이터 ID (헤더로 전달)
+     * @param reqMyCoursePageDto 페이징 조건 DTO
      */
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<List<RespCourseListDto>>> getMyCourses(@RequestHeader("X-User-Id") Long creatorId) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespCourseListDto>>> getMyCourses(@RequestHeader("X-User-Id") Long creatorId, ReqMyCoursePageDto reqMyCoursePageDto) {
         log.debug("[CourseController] 나의 강의 목록 조회 요청 - creatorId: {}", creatorId);
 
-        List<RespCourseListDto> result = courseService.findMyCourses(creatorId);
+        RespPageDto<RespCourseListDto> result = courseService.findMyCourses(creatorId, reqMyCoursePageDto);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
@@ -1,6 +1,8 @@
 package com.yujin.course_enrollment.controller;
 
+import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.PaymentService;
@@ -9,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 /**
  * 결제 컨트롤러
@@ -44,13 +44,14 @@ public class PaymentController {
      * 나의 결제 내역 조회
      * GET /api/payments/my
      * @param userId 사용자 ID (헤더로 전달)
-     * @return 결제 내역 목록 (DONE, CANCELLED)
+     * @param reqMyPaymentPageDto 페이징 조건 DTO
+     * @return 페이징된 결제 내역 목록 (DONE, CANCELLED)
      */
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<List<RespPaymentDto>>> getMyPayments(@RequestHeader("X-User-Id") Long userId) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespPaymentDto>>> getMyPayments(@RequestHeader("X-User-Id") Long userId, ReqMyPaymentPageDto reqMyPaymentPageDto) {
         log.debug("[PaymentController] 결제 내역 조회 요청 - userId: {}", userId);
 
-        List<RespPaymentDto> result = paymentService.findMyPayments(userId);
+        RespPageDto<RespPaymentDto> result = paymentService.findMyPayments(userId, reqMyPaymentPageDto);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqMyCoursePageDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqMyCoursePageDto.java
@@ -5,13 +5,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * 수강 신청 목록 페이징 조건 DTO
+ * 나의 강의 목록 페이징 조건 DTO
  */
 @Getter
 @Setter
 @NoArgsConstructor
-public class ReqEnrollmentPageDto {
-    private Long userId;
+public class ReqMyCoursePageDto {
+    private Long creatorId;
     private int page = 0;
     private int size = 10;
 

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqMyPaymentPageDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqMyPaymentPageDto.java
@@ -5,12 +5,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * 수강 신청 목록 페이징 조건 DTO
+ * 나의 결제 내역 페이징 조건 DTO
  */
 @Getter
 @Setter
 @NoArgsConstructor
-public class ReqEnrollmentPageDto {
+public class ReqMyPaymentPageDto {
     private Long userId;
     private int page = 0;
     private int size = 10;

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -1,6 +1,7 @@
 package com.yujin.course_enrollment.mapper;
 
 import com.yujin.course_enrollment.dto.req.ReqCourseSearchDto;
+import com.yujin.course_enrollment.dto.req.ReqMyCoursePageDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.entity.Course;
@@ -42,5 +43,8 @@ public interface CourseMapper {
     void updateCourseEnrolledCountMinus(Long courseId);
 
     /* 나의 강의 목록 조회 (CREATOR 전용) */
-    List<RespCourseListDto> selectCourseListByCreatorId(Long creatorId);
+    List<RespCourseListDto> selectCourseListByCreatorId(ReqMyCoursePageDto reqMyCoursePageDto);
+
+    /* 나의 강의 목록 전체 수 조회 (페이징용) */
+    int selectCourseListByCreatorIdCount(Long creatorId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
 import com.yujin.course_enrollment.entity.Payment;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -30,5 +31,8 @@ public interface PaymentMapper {
     void updatePaymentCancelled(Payment payment);
 
     /* 사용자 결제 내역 조회 */
-    List<Payment> selectPaymentListByUserId(Long userId);
+    List<Payment> selectPaymentListByUserId(ReqMyPaymentPageDto reqMyPaymentPageDto);
+
+    /* 사용자 결제 내역 전체 수 조회 (페이징용) */
+    int selectPaymentListByUserIdCount(Long userId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -4,6 +4,7 @@ import com.yujin.course_enrollment.dto.req.ReqCourseCreateDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseEnrollmentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseSearchDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseUpdateDto;
+import com.yujin.course_enrollment.dto.req.ReqMyCoursePageDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseCreateDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
@@ -259,12 +260,18 @@ public class CourseService {
     /**
      * 강의 목록 조회 (CREATOR 전용)
      * @param creatorId 크리에이터 ID
-     * @return 강의 목록
+     * @param reqMyCoursePageDto 페이징 조건 DTO
+     * @return 페이징된 강의 목록
      */
-    public List<RespCourseListDto> findMyCourses(Long creatorId) {
-        log.info("[CourseService] 나의 강의 목록 조회 - creatorId: {}", creatorId);
+    public RespPageDto<RespCourseListDto> findMyCourses(Long creatorId, ReqMyCoursePageDto reqMyCoursePageDto) {
+        log.info("[CourseService] 나의 강의 목록 조회 - creatorId: {}, page: {}, size: {}", creatorId, reqMyCoursePageDto.getPage(), reqMyCoursePageDto.getSize());
 
-        return courseMapper.selectCourseListByCreatorId(creatorId);
+        reqMyCoursePageDto.setCreatorId(creatorId);
+
+        List<RespCourseListDto> content = courseMapper.selectCourseListByCreatorId(reqMyCoursePageDto);
+        int totalCount = courseMapper.selectCourseListByCreatorIdCount(creatorId);
+
+        return RespPageDto.of(content, reqMyCoursePageDto.getPage(), reqMyCoursePageDto.getSize(), totalCount);
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -1,6 +1,8 @@
 package com.yujin.course_enrollment.service;
 
+import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
@@ -146,13 +148,19 @@ public class PaymentService {
     /**
      * 사용자 결제 내역 조회
      * @param userId 사용자 ID
-     * @return 결제 내역 목록 (DONE, CANCELLED)
+     * @param reqMyPaymentPageDto 페이징 조건 DTO
+     * @return 페이징된 결제 내역 목록 (DONE, CANCELLED)
      */
-    public List<RespPaymentDto> findMyPayments(Long userId) {
-        log.info("[PaymentService] 결제 내역 조회 - userId: {}", userId);
+    public RespPageDto<RespPaymentDto> findMyPayments(Long userId, ReqMyPaymentPageDto reqMyPaymentPageDto) {
+        log.info("[PaymentService] 결제 내역 조회 - userId: {}, page: {}, size: {}", userId, reqMyPaymentPageDto.getPage(), reqMyPaymentPageDto.getSize());
 
-        return paymentMapper.selectPaymentListByUserId(userId).stream()
+        reqMyPaymentPageDto.setUserId(userId);
+
+        List<RespPaymentDto> content = paymentMapper.selectPaymentListByUserId(reqMyPaymentPageDto).stream()
                 .map(RespPaymentDto::of)
                 .collect(Collectors.toList());
+        int totalCount = paymentMapper.selectPaymentListByUserIdCount(userId);
+
+        return RespPageDto.of(content, reqMyPaymentPageDto.getPage(), reqMyPaymentPageDto.getSize(), totalCount);
     }
 }

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -166,7 +166,7 @@
     </update>
 
     <!-- 나의 강의 목록 조회 (CREATOR 전용) -->
-    <select id="selectCourseListByCreatorId" parameterType="Long" resultType="RespCourseListDto">
+    <select id="selectCourseListByCreatorId" parameterType="ReqMyCoursePageDto" resultType="RespCourseListDto">
         SELECT c.id
              , c.creator_id
              , u.name AS creatorName
@@ -184,6 +184,14 @@
           JOIN users u ON c.creator_id = u.id
          WHERE c.creator_id = #{creatorId}
         ORDER BY c.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 나의 강의 목록 전체 수 조회 (페이징용) -->
+    <select id="selectCourseListByCreatorIdCount" parameterType="Long" resultType="int">
+        SELECT COUNT(*)
+          FROM courses
+         WHERE creator_id = #{creatorId}
     </select>
 
     <!-- 수강 인원 감소 -->

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -92,7 +92,7 @@
     </update>
 
     <!-- 사용자 결제 내역 조회 (DONE, CANCELLED) -->
-    <select id="selectPaymentListByUserId" parameterType="Long" resultType="Payment">
+    <select id="selectPaymentListByUserId" parameterType="ReqMyPaymentPageDto" resultType="Payment">
         SELECT p.id
              , p.enrollment_id
              , p.payment_key
@@ -111,6 +111,16 @@
          WHERE e.user_id = #{userId}
            AND p.status IN ('DONE', 'CANCELLED')
         ORDER BY p.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 사용자 결제 내역 전체 수 조회 (페이징용) -->
+    <select id="selectPaymentListByUserIdCount" parameterType="Long" resultType="int">
+        SELECT COUNT(*)
+          FROM payments p
+          JOIN enrollments e ON p.enrollment_id = e.id
+         WHERE e.user_id = #{userId}
+           AND p.status IN ('DONE', 'CANCELLED')
     </select>
 
 </mapper>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
@@ -1,6 +1,8 @@
 package com.yujin.course_enrollment.service;
 
+import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
@@ -321,17 +323,20 @@ class PaymentServiceTest {
                 .createdAt(LocalDateTime.now().minusDays(3))
                 .build();
 
-        given(paymentMapper.selectPaymentListByUserId(userId)).willReturn(java.util.List.of(payment1, payment2));
+        ReqMyPaymentPageDto reqMyPaymentPageDto = new ReqMyPaymentPageDto();
+        given(paymentMapper.selectPaymentListByUserId(reqMyPaymentPageDto)).willReturn(java.util.List.of(payment1, payment2));
+        given(paymentMapper.selectPaymentListByUserIdCount(userId)).willReturn(2);
 
         // when
-        List<RespPaymentDto> result = paymentService.findMyPayments(userId);
+        RespPageDto<RespPaymentDto> result = paymentService.findMyPayments(userId, reqMyPaymentPageDto);
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getOrderId()).isEqualTo("order_001");
-        assertThat(result.get(0).getStatus()).isEqualTo("DONE");
-        assertThat(result.get(1).getOrderId()).isEqualTo("order_002");
-        assertThat(result.get(1).getStatus()).isEqualTo("CANCELLED");
-        then(paymentMapper).should().selectPaymentListByUserId(userId);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getOrderId()).isEqualTo("order_001");
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo("DONE");
+        assertThat(result.getContent().get(1).getOrderId()).isEqualTo("order_002");
+        assertThat(result.getContent().get(1).getStatus()).isEqualTo("CANCELLED");
+        then(paymentMapper).should().selectPaymentListByUserId(reqMyPaymentPageDto);
+        then(paymentMapper).should().selectPaymentListByUserIdCount(userId);
     }
 }

--- a/frontend/src/api/course.js
+++ b/frontend/src/api/course.js
@@ -39,8 +39,8 @@ export const closeCourse = (courseId, creatorId) => {
 };
 
 /* 나의 강의 목록 조회 (CREATOR 전용) */
-export const getMyCourses = () => {
-    return instance.get('/api/courses/my').then(res => res.data);
+export const getMyCourses = (page = 0, size = 10) => {
+    return instance.get('/api/courses/my', { params: { page, size } }).then(res => res.data);
 };
 
 /* 강의별 수강생 목록 조회 (CREATOR 전용) */

--- a/frontend/src/api/enrollment.js
+++ b/frontend/src/api/enrollment.js
@@ -6,7 +6,7 @@ export const createEnrollment = (courseId) => {
 };
 
 /* 나의 수강 신청 목록 조회 */
-export const getMyEnrollments = (page = 0, size = 5) => {
+export const getMyEnrollments = (page = 0, size = 10) => {
     return instance.get('/api/enrollments/me', { params: { page, size } }).then(res => res.data);
 };
 

--- a/frontend/src/api/payment.js
+++ b/frontend/src/api/payment.js
@@ -6,6 +6,6 @@ export const confirmPayment = ({ enrollmentId, paymentKey, orderId, orderName, a
 };
 
 /* 나의 결제 내역 조회 */
-export const getMyPayments = () => {
-    return instance.get('/api/payments/my').then(res => res.data);
+export const getMyPayments = (page = 0, size = 10) => {
+    return instance.get('/api/payments/my', { params: { page, size } }).then(res => res.data);
 };

--- a/frontend/src/hooks/useMyCourses.js
+++ b/frontend/src/hooks/useMyCourses.js
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { getMyCourses } from '../api/course';
 
 /* 내 강의 목록 조회를 위한 커스텀 훅 */
-export const useMyCourses = (enabled) => {
+export const useMyCourses = (page = 0, size = 10, enabled = true) => {
     return useQuery({
-        queryKey: ['myCourses'],
-        queryFn: () => getMyCourses().then(res => res.data),
+        queryKey: ['myCourses', page, size],
+        queryFn: () => getMyCourses(page, size).then(res => res.data),
         enabled,
     });
 };

--- a/frontend/src/hooks/useMyPayments.js
+++ b/frontend/src/hooks/useMyPayments.js
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { getMyPayments } from '../api/payment';
 
 /* 내 결제 내역 조회를 위한 커스텀 훅 */
-export const useMyPayments = (enabled = true) => {
+export const useMyPayments = (page = 0, enabled = true) => {
     return useQuery({
-        queryKey: ['myPayments'],
-        queryFn: () => getMyPayments().then(res => res.data),
+        queryKey: ['myPayments', page],
+        queryFn: () => getMyPayments(page).then(res => res.data),
         enabled,
     });
 };

--- a/frontend/src/pages/mypage/MyCourseTab.jsx
+++ b/frontend/src/pages/mypage/MyCourseTab.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { COURSE_STATUS_BADGE_STYLE, COURSE_STATUS_LABEL } from '../../utils/statusConfig';
 import { useMyCourses } from '../../hooks/useMyCourses';
@@ -6,13 +7,15 @@ import { useMyCourses } from '../../hooks/useMyCourses';
 const MyCourseTab = () => {
     /* 페이지 이동 함수 */
     const navigate = useNavigate();
+    /* 페이지 상태 */
+    const [myCoursePage, setMyCoursePage] = useState(0);
     /* 내 강의 데이터 */
-    const { data: myCourses = [], isLoading } = useMyCourses(true);
+    const { data: myCourseData = { content: [], totalCount: 0, totalPages: 0, last: false }, isLoading } = useMyCourses(myCoursePage);
 
     if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     /* 등록한 강의가 없는 경우 */
-    if (myCourses.length === 0) {
+    if (myCourseData.content.length === 0) {
         return (
             <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
                 등록한 강의가 없습니다.
@@ -21,32 +24,57 @@ const MyCourseTab = () => {
     }
 
     return (
-        <div className="flex flex-col gap-4">
-            {myCourses.map(course => (
-                <div key={course.id}
-                    onClick={() => navigate(`/courses/${course.id}`, { state: { from: 'my-page' } })}
-                    className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4 cursor-pointer hover:shadow-md transition-shadow">
-                    <div className="flex-1 min-w-0">
-                        {/* 강의 제목과 상태 배지 */}
-                        <div className="flex items-center gap-2 mb-1">
-                            <span className="text-base font-bold text-gray-900 truncate">{course.title}</span>
-                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>
-                                {COURSE_STATUS_LABEL[course.status]}
-                            </span>
-                        </div>
-                        
-                        {/* 강의 정보 */}
-                        <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
-                            <span>{course.price === 0 ? '무료' : `${course.price.toLocaleString()}원`}</span>
-                            <span className="text-gray-300">|</span>
-                            <span>수강 {course.enrolledCount} / {course.capacity}명</span>
-                            <span className="text-gray-300">|</span>
-                            <span>{course.startDate} ~ {course.endDate}</span>
+        <>
+            <div className="flex flex-col gap-4">
+                {myCourseData.content.map(course => (
+                    <div key={course.id}
+                        onClick={() => navigate(`/courses/${course.id}`, { state: { from: 'my-page' } })}
+                        className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4 cursor-pointer hover:shadow-md transition-shadow">
+                        <div className="flex-1 min-w-0">
+                            {/* 강의 제목과 상태 배지 */}
+                            <div className="flex items-center gap-2 mb-1">
+                                <span className="text-base font-bold text-gray-900 truncate">{course.title}</span>
+                                <span className={`text-xs font-bold px-2 py-0.5 rounded border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>
+                                    {COURSE_STATUS_LABEL[course.status]}
+                                </span>
+                            </div>
+
+                            {/* 강의 정보 */}
+                            <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 mt-1">
+                                <span>{course.price === 0 ? '무료' : `${course.price.toLocaleString()}원`}</span>
+                                <span className="text-gray-300">|</span>
+                                <span>수강 {course.enrolledCount} / {course.capacity}명</span>
+                                <span className="text-gray-300">|</span>
+                                <span>{course.startDate} ~ {course.endDate}</span>
+                            </div>
                         </div>
                     </div>
+                ))}
+            </div>
+
+            {/* 페이징 */}
+            {(myCourseData.totalPages ?? 0) > 1 && (
+                <div className="flex justify-center items-center gap-4 mt-8">
+                    <button disabled={myCoursePage === 0}
+                        onClick={() => setMyCoursePage(prev => prev - 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                        </svg>
+                    </button>
+                    <span className="text-sm font-medium text-gray-700">
+                        <span className="text-blue-600">{myCoursePage + 1}</span> / {myCourseData.totalPages}
+                    </span>
+                    <button disabled={myCourseData.last}
+                        onClick={() => setMyCoursePage(prev => prev + 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </button>
                 </div>
-            ))}
-        </div>
+            )}
+        </>
     );
 };
 

--- a/frontend/src/pages/mypage/PaymentTab.jsx
+++ b/frontend/src/pages/mypage/PaymentTab.jsx
@@ -22,8 +22,10 @@ const isWithin7Days = (paidAt) =>
 
 /* 결제 내역 탭 */
 const PaymentTab = () => {
+    /* 페이지 상태 */
+    const [paymentPage, setPaymentPage] = useState(0);
     /* 결제 데이터 */
-    const { data: myPayments = [], isLoading } = useMyPayments();
+    const { data: paymentData = { content: [], totalCount: 0, totalPages: 0, last: false }, isLoading } = useMyPayments(paymentPage);
     /* 결제 영수증 모달 상태 */
     const [receiptPayment, setReceiptPayment] = useState(null);
     /* CONFIRMED 취소 모달 상태 */
@@ -80,7 +82,7 @@ const PaymentTab = () => {
     if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     /* 결제 내역이 없는 경우 */
-    if (myPayments.length === 0) {
+    if (paymentData.content.length === 0) {
         return (
             <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
                 결제 내역이 없습니다.
@@ -91,7 +93,7 @@ const PaymentTab = () => {
     return (
         <>
             <div className="flex flex-col gap-4">
-                {myPayments.map(payment => (
+                {paymentData.content.map(payment => (
                     <div key={payment.id}
                         onClick={() => setReceiptPayment(payment)}
                         className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm cursor-pointer hover:shadow-md transition-shadow">
@@ -136,6 +138,29 @@ const PaymentTab = () => {
                     </div>
                 ))}
             </div>
+
+            {/* 페이징 */}
+            {(paymentData.totalPages ?? 0) > 1 && (
+                <div className="flex justify-center items-center gap-4 mt-8">
+                    <button disabled={paymentPage === 0}
+                        onClick={() => setPaymentPage(prev => prev - 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                        </svg>
+                    </button>
+                    <span className="text-sm font-medium text-gray-700">
+                        <span className="text-blue-600">{paymentPage + 1}</span> / {paymentData.totalPages}
+                    </span>
+                    <button disabled={paymentData.last}
+                        onClick={() => setPaymentPage(prev => prev + 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </button>
+                </div>
+            )}
 
             {/* 영수증 모달 */}
             <ReceiptModal

--- a/frontend/src/pages/mypage/StudentTab.jsx
+++ b/frontend/src/pages/mypage/StudentTab.jsx
@@ -10,8 +10,8 @@ const StudentTab = () => {
     /* 수강생 목록 페이지 */
     const [studentPage, setStudentPage] = useState(0);
 
-    /* 내 강의 데이터 */
-    const { data: myCourses = [], isLoading: isCoursesLoading } = useMyCourses(true);
+    /* 내 강의 데이터 (드롭다운용 전체 목록) */
+    const { data: myCourseData = { content: [] }, isLoading: isCoursesLoading } = useMyCourses(0, 100);
     /* 선택한 강의의 수강 신청 데이터 */
     const { data: courseEnrollmentData = { content: [], totalCount: 0, totalPages: 0, last: false }, isLoading: isEnrollmentsLoading } = useCourseEnrollments(selectedCourseId, studentPage);
 
@@ -38,7 +38,7 @@ const StudentTab = () => {
                     className="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                     <option value="">강의를 선택하세요</option>
-                    {myCourses.map(course => (
+                    {myCourseData.content.map(course => (
                         <option key={course.id} value={course.id}>{course.title}</option>
                     ))}
                 </select>


### PR DESCRIPTION
  ## 작업 내용
  - 내 강의 목록·결제 내역 조회 API 페이지네이션 적용 (GET /api/courses/my?page=0&size=10, GET /api/payments/my?page=0&size=10)
  page size 5 → 10 통일
  - ReqMyCoursePageDto, ReqMyPaymentPageDto 추가 (page, size, offset 계산)
  - MyCourseTab, PaymentTab 페이지네이션 UI 구현 (이전/다음 버튼)
  - 전체 기본 page size 5 → 10 통일, useMyCourses·useMyPayments 훅 시그니처 변경
  
  ## 구현 시 고려한 점
  - RespPageDto로 반환 (content, totalCount, totalPages, last 포함) - EnrollmentTab·StudentTab과 동일한 패턴으로 통일
  - StudentTab 드롭다운은 전체 목록이 필요하므로 size=100으로 호출 -별도 전체 조회 API 추가 없이 기존 페이징 API 재활용

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - http://localhost:5173/my-page 에서 내 강의 탭, 결제 내역 탭 10건 초과 시 페이징 버튼 노출 확인

  ## 연관 이슈
  Closes #38