### PR TITLE
[feat] 회원가입 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.security:spring-security-crypto'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JacksonConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JacksonConfig.java
@@ -1,0 +1,31 @@
+package com.yujin.course_enrollment.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+/**
+ * Jackson 전역 설정
+ * 모든 @RequestBody String 필드에 앞뒤 공백 자동 제거 적용
+ */
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public SimpleModule stringTrimModule() {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(String.class, new StdDeserializer<>(String.class) {
+            @Override
+            public String deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+                String value = p.getValueAsString();
+                return value != null ? value.trim() : null;
+            }
+        });
+        return module;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
@@ -1,0 +1,72 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 인증 컨트롤러
+ * 회원가입 등 인증 관련 HTTP 요청을 처리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    /**
+     * 아이디 중복 확인
+     * GET /api/auth/check-username?value=xxx
+     * @param value 확인할 아이디
+     * @return { available: true/false }
+     */
+    @GetMapping("/check-username")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkUsername(@RequestParam String value) {
+        log.debug("[AuthController] 아이디 중복 확인 - username: {}", value);
+
+        return ResponseEntity.ok(ApiResponse.success(Map.of("available", userService.isUsernameAvailable(value))));
+    }
+
+    /**
+     * 이메일 중복 확인
+     * GET /api/auth/check-email?value=xxx
+     * @param value 확인할 이메일
+     * @return { available: true/false }
+     */
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkEmail(@RequestParam String value) {
+        log.debug("[AuthController] 이메일 중복 확인 - email: {}", value);
+
+        return ResponseEntity.ok(ApiResponse.success(Map.of("available", userService.isEmailAvailable(value))));
+    }
+
+    /**
+     * 회원가입
+     * POST /api/auth/signup
+     * @param user 회원가입 요청 (username, name, email, password)
+     * @return 201 Created
+     */
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody User user) {
+        log.debug("[AuthController] 회원가입 요청 - username: {}", user.getUsername());
+
+        userService.signup(user);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created());
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
@@ -15,6 +15,7 @@ import com.yujin.course_enrollment.service.CourseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +44,7 @@ public class CourseController {
 
         RespCourseCreateDto respCourseCreateDto = courseService.registerCourse(creatorId, reqCourseCreateDto);
 
-        return ResponseEntity.ok(ApiResponse.success(respCourseCreateDto));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(respCourseCreateDto));
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -11,6 +11,7 @@ import com.yujin.course_enrollment.service.EnrollmentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,7 +39,7 @@ public class EnrollmentController {
 
         RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, reqEnrollmentCreateDto);
 
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(result));
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
@@ -9,6 +9,7 @@ import com.yujin.course_enrollment.service.PaymentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,7 +38,7 @@ public class PaymentController {
 
         RespPaymentDto result = paymentService.confirmPayment(userId, reqPaymentConfirmDto);
 
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(result));
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/User.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/User.java
@@ -1,18 +1,61 @@
 package com.yujin.course_enrollment.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 /**
  * 사용자 엔티티
  * 크리에이터(CREATOR)와 수강생(STUDENT)을 구분하는 객체
  */
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class User {
     private Long id;
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    @Size(min = 4, max = 20, message = "아이디는 4~20자여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "아이디는 영문, 숫자, 밑줄(_)만 사용 가능합니다.")
+    private String username;
+
+    @NotBlank(message = "이름을 입력해주세요.")
     private String name;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 16, message = "비밀번호는 8~16자여야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?])\\S{8,16}$",
+        message = "비밀번호는 영문, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+    )
+    private String password;
+
     private String role;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /* 회원가입용 신규 사용자 엔티티 생성 */
+    public static User ofSignup(String username, String name, String email, String encodedPassword) {
+        return User.builder()
+                .username(username)
+                .name(name)
+                .email(email)
+                .password(encodedPassword)
+                .role("STUDENT")
+                .build();
+    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/response/ApiResponse.java
@@ -29,6 +29,16 @@ public class ApiResponse<T> {
         return new ApiResponse<>(200, "success", null);
     }
 
+    /* 생성 성공 응답 (데이터 있음) */
+    public static <T> ApiResponse<T> created(T data) {
+        return new ApiResponse<>(201, "created", data);
+    }
+
+    /* 생성 성공 응답 (데이터 없음) */
+    public static <T> ApiResponse<T> created() {
+        return new ApiResponse<>(201, "created", null);
+    }
+
     /* 실패 응답 */
     public static <T> ApiResponse<T> fail(int code, String message) {
         return new ApiResponse<>(code, message, null);

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
@@ -16,4 +16,13 @@ public interface UserMapper {
 
     /* 전체 사용자 목록 조회 */
     List<User> selectUserList();
+
+    /* 이메일로 사용자 조회 */
+    User selectUserByEmail(String email);
+
+    /* 아이디로 사용자 조회 */
+    User selectUserByUsername(String username);
+
+    /* 사용자 등록 */
+    void insertUser(User user);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
@@ -1,9 +1,12 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,13 +23,57 @@ import java.util.List;
 public class UserService {
 
     private final UserMapper userMapper;
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     /**
      * 전체 사용자 목록 조회
+     * @return 전체 사용자 목록
      */
     public List<User> findUserList() {
         log.info("[UserService] 전체 사용자 목록 조회");
 
         return userMapper.selectUserList();
+    }
+
+    /**
+     * 아이디 사용 가능 여부 확인
+     * @param username 확인할 아이디
+     * @return 사용 가능 여부
+     */
+    public boolean isUsernameAvailable(String username) {
+        log.debug("[UserService] 아이디 중복 확인 - username: {}", username);
+
+        return userMapper.selectUserByUsername(username) == null;
+    }
+
+    /**
+     * 이메일 사용 가능 여부 확인
+     * @param email 확인할 이메일
+     * @return 사용 가능 여부
+     */
+    public boolean isEmailAvailable(String email) {
+        log.debug("[UserService] 이메일 중복 확인 - email: {}", email);
+
+        return userMapper.selectUserByEmail(email) == null;
+    }
+
+    /**
+     * 회원가입
+     * @param user 회원가입 요청 (username, name, email, password)
+     * @throws BusinessException 아이디 또는 이메일 중복 (409)
+     */
+    @Transactional
+    public void signup(User user) {
+        log.info("[UserService] 회원가입 - username: {}, email: {}", user.getUsername(), user.getEmail());
+
+        if (userMapper.selectUserByUsername(user.getUsername()) != null) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다.");
+        }
+
+        if (userMapper.selectUserByEmail(user.getEmail()) != null) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+        }
+
+        userMapper.insertUser(User.ofSignup(user.getUsername(), user.getName(), user.getEmail(), passwordEncoder.encode(user.getPassword())));
     }
 }

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -6,8 +6,12 @@
     <!-- 사용자 단건 조회 -->
     <select id="selectUserById" parameterType="Long" resultType="User">
         SELECT id
+             , username
              , name
+             , email
              , role
+             , created_at
+             , updated_at
           FROM users
          WHERE id = #{id}
     </select>
@@ -15,10 +19,59 @@
     <!-- 전체 사용자 목록 조회 -->
     <select id="selectUserList" resultType="User">
         SELECT id
+             , username
              , name
+             , email
              , role
+             , created_at
+             , updated_at
           FROM users
         ORDER BY id
     </select>
+
+    <!-- 이메일로 사용자 조회 -->
+    <select id="selectUserByEmail" parameterType="String" resultType="User">
+        SELECT id
+             , username
+             , name
+             , email
+             , password
+             , role
+             , created_at
+             , updated_at
+          FROM users
+         WHERE email = #{email}
+    </select>
+
+    <!-- 아이디로 사용자 조회 -->
+    <select id="selectUserByUsername" parameterType="String" resultType="User">
+        SELECT id
+             , username
+             , name
+             , email
+             , password
+             , role
+             , created_at
+             , updated_at
+          FROM users
+         WHERE username = #{username}
+    </select>
+
+    <!-- 사용자 등록 -->
+    <insert id="insertUser" parameterType="User" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO users (
+                username
+              , name
+              , email
+              , password
+              , role
+        ) VALUES (
+                #{username}
+              , #{name}
+              , #{email}
+              , #{password}
+              , #{role}
+        )
+    </insert>
 
 </mapper>

--- a/backend/src/main/resources/sql/data.sql
+++ b/backend/src/main/resources/sql/data.sql
@@ -1,12 +1,12 @@
--- 사용자
-INSERT INTO users (name, role)
+-- 사용자 (password: Test1234!)
+INSERT INTO users (username, name, email, password, role)
 VALUES
-    ('강사A',  'CREATOR'),
-    ('강사B',  'CREATOR'),
-    ('강사C',  'CREATOR'),
-    ('수강생A', 'STUDENT'),
-    ('수강생B', 'STUDENT'),
-    ('수강생C', 'STUDENT');
+    ('creator_a', '강사A',  'creator_a@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'CREATOR'),
+    ('creator_b', '강사B',  'creator_b@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'CREATOR'),
+    ('creator_c', '강사C',  'creator_c@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'CREATOR'),
+    ('student_a', '수강생A', 'student_a@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT'),
+    ('student_b', '수강생B', 'student_b@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT'),
+    ('student_c', '수강생C', 'student_c@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT');
 
 
 

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -4,9 +4,14 @@ DROP TABLE IF EXISTS courses;
 DROP TABLE IF EXISTS users;
 
 CREATE TABLE users (
-                       id    BIGINT AUTO_INCREMENT PRIMARY KEY,
-                       name  VARCHAR(50)  NOT NULL,
-                       role  VARCHAR(20)  NOT NULL
+                       id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+                       username   VARCHAR(50)  NOT NULL UNIQUE,
+                       name       VARCHAR(50)  NOT NULL,
+                       email      VARCHAR(100) NOT NULL UNIQUE,
+                       password   VARCHAR(200) NOT NULL,
+                       role       VARCHAR(20)  NOT NULL,
+                       created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                       updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE courses (

--- a/backend/src/test/java/com/yujin/course_enrollment/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/CourseServiceTest.java
@@ -51,7 +51,11 @@ class CourseServiceTest {
     void registerCourse_success() {
         // given
         Long creatorId = 1L;
-        User creator = new User(1L, "강사A", "CREATOR");
+        User creator = User.builder()
+                .id(1L)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
         ReqCourseCreateDto req = new ReqCourseCreateDto(
                 "Spring Boot 강의", "설명", 50000, 30,
                 LocalDate.now().plusDays(1),
@@ -107,7 +111,11 @@ class CourseServiceTest {
     void registerCourse_notCreator() {
         // given
         Long creatorId = 3L;
-        User student = new User(3L, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(3L)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         given(userMapper.selectUserById(creatorId)).willReturn(student);
 
         ReqCourseCreateDto req = new ReqCourseCreateDto(
@@ -127,7 +135,11 @@ class CourseServiceTest {
     void registerCourse_invalidDate() {
         // given
         Long creatorId = 1L;
-        User creator = new User(1L, "강사A", "CREATOR");
+        User creator = User.builder()
+                .id(1L)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
         given(userMapper.selectUserById(creatorId)).willReturn(creator);
 
         ReqCourseCreateDto req = new ReqCourseCreateDto(
@@ -147,7 +159,11 @@ class CourseServiceTest {
     void registerCourse_sameDate_success() {
         // given
         Long creatorId = 1L;
-        User creator = new User(1L, "강사A", "CREATOR");
+        User creator = User.builder()
+                .id(1L)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
         LocalDate futureDate = LocalDate.now().plusDays(10);
 
         ReqCourseCreateDto req = new ReqCourseCreateDto(
@@ -186,7 +202,11 @@ class CourseServiceTest {
     void registerCourse_pastStartDate() {
         // given
         Long creatorId = 1L;
-        User creator = new User(1L, "강사A", "CREATOR");
+        User creator = User.builder()
+                .id(1L)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
         given(userMapper.selectUserById(creatorId)).willReturn(creator);
 
         ReqCourseCreateDto req = new ReqCourseCreateDto(
@@ -206,7 +226,11 @@ class CourseServiceTest {
     void registerCourse_pastEndDate() {
         // given
         Long creatorId = 1L;
-        User creator = new User(1L, "강사A", "CREATOR");
+        User creator = User.builder()
+                .id(1L)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
         given(userMapper.selectUserById(creatorId)).willReturn(creator);
 
         ReqCourseCreateDto req = new ReqCourseCreateDto(

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
@@ -48,16 +48,17 @@ class EnrollmentConcurrencyTest {
     /** 테스트용 STUDENT 유저 n명을 DB에 삽입하고 생성된 ID 목록 반환 */
     private List<Long> insertStudents(int count) {
         List<Long> ids = new ArrayList<>();
+        String prefix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
 
         for (int i = 0; i < count; i++) {
             final int idx = i;
             KeyHolder holder = new GeneratedKeyHolder();
 
             jdbcTemplate.update(con -> {
-                PreparedStatement ps = con.prepareStatement(
-                        "INSERT INTO users (name, role) VALUES (?, 'STUDENT')",
-                        Statement.RETURN_GENERATED_KEYS);
-                ps.setString(1, "동시성테스트유저" + idx);
+                PreparedStatement ps = con.prepareStatement("INSERT INTO users (username, name, email, password, role) VALUES (?, ?, ?, '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT')", new String[]{"id"});
+                ps.setString(1, prefix + "_" + idx);
+                ps.setString(2, "동시성테스트유저" + idx);
+                ps.setString(3, prefix + "_" + idx + "@test.com");
 
                 return ps;
             }, holder);

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -53,7 +53,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 1L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         Course openCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
@@ -107,7 +111,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 999L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         ReqEnrollmentCreateDto req = new ReqEnrollmentCreateDto(courseId);
 
         given(userMapper.selectUserById(userId)).willReturn(student);
@@ -125,7 +133,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 1L;
         Long courseId = 1L;
-        User creator = new User(userId, "강사A", "CREATOR");
+        User creator = User.builder()
+                .id(userId)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
         Course ownCourse = Course.builder()
                 .id(courseId)
                 .creatorId(userId)
@@ -148,7 +160,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 1L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         Course closedCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
@@ -171,7 +187,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 1L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         Course openCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
@@ -201,7 +221,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 1L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         Course openCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
@@ -246,7 +270,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 1L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         Course openCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)
@@ -285,7 +313,11 @@ class EnrollmentServiceTest {
         // given
         Long userId = 4L;
         Long courseId = 1L;
-        User student = new User(userId, "수강생A", "STUDENT");
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
         Course fullCourse = Course.builder()
                 .id(courseId)
                 .creatorId(1L)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import Layout from './components/Layout'
 import LoginPage from './pages/LoginPage'
+import SignupPage from './pages/SignupPage'
 import CourseRegisterPage from './pages/CourseRegisterPage'
 import CourseListPage from './pages/CourseListPage'
 import CourseDetailPage from './pages/CourseDetailPage'
@@ -34,6 +35,7 @@ function App() {
         <AuthProvider>
             <Routes>
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/signup" element={<SignupPage />} />
                 <Route path="/courses" element={<PublicRoute><CourseListPage /></PublicRoute>} />
                 <Route path="/courses/:courseId" element={<PublicRoute><CourseDetailPage /></PublicRoute>} />
                 <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,16 @@
+import instance from './axios';
+
+/* 회원가입 */
+export const signup = (data) => {
+    return instance.post('/api/auth/signup', data).then(res => res.data);
+};
+
+/* 아이디 중복 확인 */
+export const checkUsername = (value) => {
+    return instance.get('/api/auth/check-username', { params: { value } }).then(res => res.data);
+};
+
+/* 이메일 중복 확인 */
+export const checkEmail = (value) => {
+    return instance.get('/api/auth/check-email', { params: { value } }).then(res => res.data);
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -13,7 +13,7 @@ const Header = () => {
     /* 로그아웃 처리 */
     const handleLogout = () => {
         logout();
-        navigate('/login');
+        navigate('/signup');
     };
 
     return (
@@ -50,10 +50,10 @@ const Header = () => {
                         </>
                     ) : (
                         <button
-                            onClick={() => navigate('/login')}
+                            onClick={() => navigate('/signup')}
                             className="text-sm px-3 py-1.5 rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors cursor-pointer"
                         >
-                            로그인
+                            회원가입
                         </button>
                     )}
                 </div>

--- a/frontend/src/pages/CourseRegisterPage.jsx
+++ b/frontend/src/pages/CourseRegisterPage.jsx
@@ -61,6 +61,7 @@ const CourseRegisterPage = () => {
     /* 강의 정보 조회 실패 시 처리 */
     useEffect(() => {
         if (!isCourseError) return;
+        
         alert('강의 정보를 불러오는데 실패했습니다.');
         navigate(`/courses${previousSearch}`);
     }, [isCourseError]);

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useUserList } from '../hooks/useUserList';
 
@@ -59,6 +59,11 @@ const LoginPage = () => {
                 >
                     비회원으로 계속 보기
                 </button>
+
+                <p className="text-center mt-2 text-sm text-gray-500">
+                    계정이 없으신가요?{' '}
+                    <Link to="/signup" className="text-blue-600 font-medium hover:underline">회원가입</Link>
+                </p>
             </div>
         </div>
     );

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { signup, checkUsername, checkEmail } from '../api/auth';
+
+/* 필드별 유효성 검사 함수 */
+const validateField = (name, value) => {
+    switch (name) {
+        case 'username':
+            if (!value) return '아이디를 입력해주세요.';
+            if (value.length < 4 || value.length > 20) return '아이디는 4~20자여야 합니다.';
+            if (!/^[a-zA-Z0-9_]+$/.test(value)) return '영문, 숫자, 밑줄(_)만 사용 가능합니다.';
+            return '';
+
+        case 'name':
+            if (!value) return '이름을 입력해주세요.';
+            return '';
+
+        case 'email':
+            if (!value) return '이메일을 입력해주세요.';
+            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return '올바른 이메일 형식이 아닙니다.';
+            return '';
+
+        case 'password':
+            if (!value) return '비밀번호를 입력해주세요.';
+            if (/\s/.test(value)) return '비밀번호에 공백을 사용할 수 없습니다.';
+            if (value.length < 8 || value.length > 16) return '비밀번호는 8~16자여야 합니다.';
+            if (!/(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?])/.test(value))
+                return '영문, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다.';
+            return '';
+
+        default:
+            return '';
+    }
+};
+
+/* 회원가입 페이지 */
+const SignupPage = () => {
+    /* 페이지 이동을 위한 navigate 함수 */
+    const navigate = useNavigate();
+    /* 폼 상태 */
+    const [form, setForm] = useState({ username: '', name: '', email: '', password: '' });
+    /* 필드별 에러 메시지 */
+    const [errors, setErrors] = useState({});
+    /* 필드 방문 여부 (blur 발생 기준) */
+    const [touched, setTouched] = useState({});
+    /* 서버 중복 확인 중 여부 */
+    const [checking, setChecking] = useState({ username: false, email: false });
+    /* 전체 폼 유효성 여부 */
+    const isFormValid =
+        Object.keys(form).every(name => !validateField(name, form[name])) &&
+        !errors.username && !errors.email &&
+        !checking.username && !checking.email;
+
+    /* 회원가입 뮤테이션 */
+    const { mutate: signupMutate, isPending } = useMutation({
+        mutationFn: signup,
+        onSuccess: () => {
+            alert('회원가입이 완료되었습니다.');
+            navigate('/login');
+        },
+        onError: (err) => {
+            alert(err.response?.data?.message || '회원가입에 실패했습니다.');
+        },
+    });
+
+    /* 입력값 변경 핸들러 - 방문한 필드만 실시간 검사 */
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setForm(prev => ({ ...prev, [name]: value }));
+
+        if (touched[name]) {
+            setErrors(prev => ({ ...prev, [name]: validateField(name, value) }));
+        }
+    };
+
+    /* 포커스 아웃 핸들러 - 앞뒤 공백 제거, 유효성 검사 시작, 중복 확인 */
+    const handleBlur = async (e) => {
+        const { name, value } = e.target;
+        const trimmed = value.trim();
+
+        setForm(prev => ({ ...prev, [name]: trimmed }));
+        setTouched(prev => ({ ...prev, [name]: true }));
+
+        const localError = validateField(name, trimmed);
+        setErrors(prev => ({ ...prev, [name]: localError }));
+
+        if (!localError && (name === 'username' || name === 'email')) {
+            setChecking(prev => ({ ...prev, [name]: true }));
+            try {
+                const checkFn = name === 'username' ? checkUsername : checkEmail;
+                const result = await checkFn(trimmed);
+                if (!result.data.available) {
+                    setErrors(prev => ({ ...prev, [name]: name === 'username' ? '이미 사용 중인 아이디입니다.' : '이미 사용 중인 이메일입니다.' }));
+                }
+            } catch {
+                /* 서버 오류 시 무시 */
+            } finally {
+                setChecking(prev => ({ ...prev, [name]: false }));
+            }
+        }
+    };
+
+    /* 회원가입 요청 */
+    const handleSubmit = (e) => {
+        e.preventDefault();
+
+        const trimmedForm = Object.fromEntries(
+            Object.entries(form).map(([k, v]) => [k, v.trim()])
+        );
+        const allTouched = { username: true, name: true, email: true, password: true };
+        const newErrors = Object.fromEntries(
+            Object.keys(trimmedForm).map(name => [name, validateField(name, trimmedForm[name])])
+        );
+
+        setForm(trimmedForm);
+        setTouched(allTouched);
+        setErrors(newErrors);
+
+        if (Object.values(newErrors).some(msg => msg)) return;
+
+        signupMutate(trimmedForm);
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
+            <div className="w-full max-w-md">
+                <div className="text-center mb-8">
+                    <h1 className="text-3xl font-extrabold text-gray-900 mb-2">회원가입</h1>
+                </div>
+
+                {/* 회원가입 폼 */}
+                <form onSubmit={handleSubmit} noValidate className="bg-white rounded-xl border border-gray-200 shadow-sm p-6 space-y-4">
+
+                    {/* 아이디 입력 필드 */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">아이디</label>
+                        <input
+                            type="text"
+                            name="username"
+                            value={form.username}
+                            onChange={handleChange}
+                            onBlur={handleBlur}
+                            placeholder="4~20자, 영문/숫자/밑줄(_)"
+                            required
+                            className={`w-full border py-2.5 px-3 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none ${errors.username && touched.username ? 'border-red-400' : 'border-gray-300'}`}
+                        />
+                        {checking.username && <p className="mt-1 text-xs text-gray-400">확인 중...</p>}
+                        {!checking.username && errors.username && touched.username && (
+                            <p className="mt-1 text-xs text-red-500">{errors.username}</p>
+                        )}
+                    </div>
+
+                    {/* 이름 입력 필드 */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">이름</label>
+                        <input
+                            type="text"
+                            name="name"
+                            value={form.name}
+                            onChange={handleChange}
+                            onBlur={handleBlur}
+                            placeholder="이름을 입력하세요"
+                            required
+                            className={`w-full border py-2.5 px-3 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none ${errors.name && touched.name ? 'border-red-400' : 'border-gray-300'}`}
+                        />
+                        {errors.name && touched.name && (
+                            <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+                        )}
+                    </div>
+
+                    {/* 이메일 입력 필드 */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">이메일</label>
+                        <input
+                            type="email"
+                            name="email"
+                            value={form.email}
+                            onChange={handleChange}
+                            onBlur={handleBlur}
+                            placeholder="example@email.com"
+                            required
+                            className={`w-full border py-2.5 px-3 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none ${errors.email && touched.email ? 'border-red-400' : 'border-gray-300'}`}
+                        />
+                        {checking.email && <p className="mt-1 text-xs text-gray-400">확인 중...</p>}
+                        {!checking.email && errors.email && touched.email && (
+                            <p className="mt-1 text-xs text-red-500">{errors.email}</p>
+                        )}
+                    </div>
+
+                    {/* 비밀번호 입력 필드 */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">비밀번호</label>
+                        <input
+                            type="password"
+                            name="password"
+                            value={form.password}
+                            onChange={handleChange}
+                            onBlur={handleBlur}
+                            placeholder="영문+숫자+특수문자 8~16자"
+                            required
+                            className={`w-full border py-2.5 px-3 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none ${errors.password && touched.password ? 'border-red-400' : 'border-gray-300'}`}
+                        />
+                        {errors.password && touched.password && (
+                            <p className="mt-1 text-xs text-red-500">{errors.password}</p>
+                        )}
+                    </div>
+
+                    {/* 제출 버튼 - 처리 중이거나 폼이 유효하지 않으면 비활성화 */}
+                    <button
+                        type="submit"
+                        disabled={isPending || !isFormValid}
+                        className="w-full py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        {isPending ? '처리 중...' : '가입하기'}
+                    </button>
+                </form>
+
+                {/* 로그인 페이지로 이동하는 링크 */}
+                <p className="text-center mt-4 text-sm text-gray-500">
+                    이미 계정이 있으신가요?{' '}
+                    <Link to="/login" className="text-blue-600 font-medium hover:underline">로그인</Link>
+                </p>
+            </div>
+        </div>
+    );
+};
+
+export default SignupPage;


### PR DESCRIPTION
  ## 작업 내용
  - POST /api/auth/signup 회원가입 엔드포인트 추가 (아이디·이메일 중복 검사, BCrypt 해시 저장)
  - GET /api/auth/check-username, GET /api/auth/check-email 실시간 중복 확인 엔드포인트 추가
  - JacksonConfig: @RequestBody 전역 String trim 적용
  - ApiResponse: created() 추가, 생성 관련 POST 엔드포인트 응답 201 통일
  - SignupPage: 필드별 실시간 유효성 검사(blur/change), blur 시 서버 중복 확인, 확인 중 상태 표시
  - Header: 비로그인 시 회원가입 버튼으로 변경, 로그아웃 후 /signup 이동

  ## 구현 시 고려한 점
  - 비밀번호는 @JsonProperty WRITE_ONLY로 역직렬화는 허용하되 응답 직렬화에서 제외 (@JsonIgnore는 역직렬화도 막아 password가 항상 null로 수신되는 문제)
  - 앞뒤 공백 처리는 서비스가 아닌 Jackson 전역 trim으로 처리해 컨트롤러 진입 시점에 정리
  - 비밀번호 중간 공백은 백엔드 @Pattern(\\S{8,16}), 프론트 /\s/ 검사로 이중 차단
  - 실시간 중복 확인은 로컬 유효성 검사 통과 후에만 서버 요청 (불필요한 API 호출 방지), 확인 중에는 제출 버튼 비활성화
  - 회원가입 시 역할은 STUDENT로 고정, 강사(CREATOR) 계정 생성은 별도 이슈에서 처리 예정

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - http://localhost:5173/signup 에서 회원가입 후 /login 이동 확인
  - 중복 아이디·이메일 입력 시 blur 시점에 실시간 에러 표시 확인

  ## 연관 이슈
  Closes #40