### PR TITLE
[feat] CREATOR 신청 및 관리자 승인 기능 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CreatorRequestController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CreatorRequestController.java
@@ -1,6 +1,8 @@
 package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqCreatorRequestDto;
+import com.yujin.course_enrollment.dto.req.ReqCreatorRequestRejectDto;
+import com.yujin.course_enrollment.dto.resp.RespCreatorRequestDto;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.CreatorRequestService;
 import jakarta.validation.Valid;
@@ -8,11 +10,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * 강사 신청 컨트롤러
@@ -40,5 +47,48 @@ public class CreatorRequestController {
         creatorRequestService.requestCreator(userId, reqCreatorRequestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created());
+    }
+
+    /**
+     * 강사 신청 목록 조회 (관리자)
+     * GET /api/admin/creator-requests
+     * @return 전체 강사 신청 목록
+     */
+    @GetMapping("/admin/creator-requests")
+    public ResponseEntity<ApiResponse<List<RespCreatorRequestDto>>> getCreatorRequestList() {
+        log.debug("[CreatorRequestController] 강사 신청 목록 조회");
+
+        return ResponseEntity.ok(ApiResponse.success(creatorRequestService.findCreatorRequestList()));
+    }
+
+    /**
+     * 강사 신청 승인 (관리자)
+     * PATCH /api/admin/creator-requests/{id}/approve
+     * @param id 신청 ID
+     * @return 200 OK
+     */
+    @PatchMapping("/admin/creator-requests/{id}/approve")
+    public ResponseEntity<ApiResponse<Void>> approveCreatorRequest(@PathVariable Long id) {
+        log.debug("[CreatorRequestController] 강사 신청 승인 - requestId: {}", id);
+
+        creatorRequestService.approveCreatorRequest(id);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 강사 신청 거절 (관리자)
+     * PATCH /api/admin/creator-requests/{id}/reject
+     * @param id 신청 ID
+     * @param reqCreatorRequestRejectDto 거절 사유
+     * @return 200 OK
+     */
+    @PatchMapping("/admin/creator-requests/{id}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectCreatorRequest(@PathVariable Long id, @Valid @RequestBody ReqCreatorRequestRejectDto reqCreatorRequestRejectDto) {
+        log.debug("[CreatorRequestController] 강사 신청 거절 - requestId: {}", id);
+
+        creatorRequestService.rejectCreatorRequest(id, reqCreatorRequestRejectDto.getRejectReason());
+
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CreatorRequestController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CreatorRequestController.java
@@ -1,0 +1,44 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.dto.req.ReqCreatorRequestDto;
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.CreatorRequestService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 강사 신청 컨트롤러
+ * 강사 신청 및 관리자 승인/거절 HTTP 요청을 처리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CreatorRequestController {
+
+    private final CreatorRequestService creatorRequestService;
+
+    /**
+     * 강사 신청
+     * POST /api/creator-requests
+     * @param userId 신청자 ID (헤더로 전달)
+     * @param reqCreatorRequestDto 신청 정보 (reason)
+     * @return 201 Created
+     */
+    @PostMapping("/creator-requests")
+    public ResponseEntity<ApiResponse<Void>> requestCreator(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqCreatorRequestDto reqCreatorRequestDto) {
+        log.debug("[CreatorRequestController] 강사 신청 요청 - userId: {}", userId);
+
+        creatorRequestService.requestCreator(userId, reqCreatorRequestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created());
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqCreatorRequestDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqCreatorRequestDto.java
@@ -1,0 +1,17 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 강사 신청 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqCreatorRequestDto {
+    @NotBlank(message = "신청 사유를 입력해주세요.")
+    private String reason;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqCreatorRequestRejectDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqCreatorRequestRejectDto.java
@@ -1,0 +1,17 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 강사 신청 거절 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqCreatorRequestRejectDto {
+    @NotBlank(message = "거절 사유를 입력해주세요.")
+    private String rejectReason;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespCreatorRequestDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespCreatorRequestDto.java
@@ -1,0 +1,25 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 강사 신청 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespCreatorRequestDto {
+    private Long id;
+    private Long userId;
+    private String username;
+    private String name;
+    private String status;
+    private String reason;
+    private String rejectReason;
+    private LocalDateTime requestedAt;
+    private LocalDateTime processedAt;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/CreatorRequest.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/CreatorRequest.java
@@ -1,0 +1,56 @@
+package com.yujin.course_enrollment.entity;
+
+import com.yujin.course_enrollment.global.CreatorRequestStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 강사 신청 엔티티
+ * 수강생이 강사 계정을 신청하는 정보를 담는 객체
+ * 상태: PENDING(신청 중) → APPROVED(승인) / REJECTED(거절)
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatorRequest {
+    private Long id;
+    private Long userId;
+    private String status;
+    private String reason;
+    private String rejectReason;
+    private LocalDateTime requestedAt;
+    private LocalDateTime processedAt;
+
+    /* 강사 신청 생성 */
+    public static CreatorRequest ofCreate(Long userId, String reason) {
+        return CreatorRequest.builder()
+                .userId(userId)
+                .status(CreatorRequestStatus.PENDING)
+                .reason(reason)
+                .build();
+    }
+
+    /* 승인 상태로 변경할 엔티티 생성 */
+    public static CreatorRequest ofApprove(Long id) {
+        return CreatorRequest.builder()
+                .id(id)
+                .status(CreatorRequestStatus.APPROVED)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    /* 거절 상태로 변경할 엔티티 생성 */
+    public static CreatorRequest ofReject(Long id, String rejectReason) {
+        return CreatorRequest.builder()
+                .id(id)
+                .status(CreatorRequestStatus.REJECTED)
+                .rejectReason(rejectReason)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/global/CreatorRequestStatus.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/CreatorRequestStatus.java
@@ -1,0 +1,12 @@
+package com.yujin.course_enrollment.global;
+
+/**
+ * 강사 신청 상태 관리 클래스
+ */
+public class CreatorRequestStatus {
+    public static final String PENDING  = "PENDING";
+    public static final String APPROVED = "APPROVED";
+    public static final String REJECTED = "REJECTED";
+
+    private CreatorRequestStatus() {}
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CreatorRequestMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CreatorRequestMapper.java
@@ -1,7 +1,10 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.resp.RespCreatorRequestDto;
 import com.yujin.course_enrollment.entity.CreatorRequest;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 /**
  * 강사 신청 Mapper 인터페이스
@@ -12,6 +15,15 @@ public interface CreatorRequestMapper {
 
     /* 강사 신청 등록 */
     void insertCreatorRequest(CreatorRequest creatorRequest);
+
+    /* 강사 신청 단건 조회 */
+    RespCreatorRequestDto selectCreatorRequestById(Long id);
+
+    /* 전체 강사 신청 목록 조회 (관리자용) */
+    List<RespCreatorRequestDto> selectCreatorRequestList();
+
+    /* 강사 신청 상태 업데이트 */
+    void updateCreatorRequestStatus(CreatorRequest creatorRequest);
 
     /* 사용자의 PENDING 상태 신청 조회 */
     CreatorRequest selectPendingRequestByUserId(Long userId);

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CreatorRequestMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CreatorRequestMapper.java
@@ -1,0 +1,18 @@
+package com.yujin.course_enrollment.mapper;
+
+import com.yujin.course_enrollment.entity.CreatorRequest;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 강사 신청 Mapper 인터페이스
+ * CreatorRequestMapper.xml과 매핑되어 강사 신청 관련 DB 접근을 담당
+ */
+@Mapper
+public interface CreatorRequestMapper {
+
+    /* 강사 신청 등록 */
+    void insertCreatorRequest(CreatorRequest creatorRequest);
+
+    /* 사용자의 PENDING 상태 신청 조회 */
+    CreatorRequest selectPendingRequestByUserId(Long userId);
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.mapper;
 
 import com.yujin.course_enrollment.entity.User;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -25,4 +26,7 @@ public interface UserMapper {
 
     /* 사용자 등록 */
     void insertUser(User user);
+
+    /* 사용자 역할 변경 */
+    void updateUserRole(@Param("id") Long id, @Param("role") String role);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CreatorRequestService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CreatorRequestService.java
@@ -1,8 +1,10 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqCreatorRequestDto;
+import com.yujin.course_enrollment.dto.resp.RespCreatorRequestDto;
 import com.yujin.course_enrollment.entity.CreatorRequest;
 import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.CreatorRequestStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CreatorRequestMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
@@ -11,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 강사 신청 서비스
@@ -49,5 +53,59 @@ public class CreatorRequestService {
         }
 
         creatorRequestMapper.insertCreatorRequest(CreatorRequest.ofCreate(userId, reqCreatorRequestDto.getReason()));
+    }
+
+    /**
+     * 강사 신청 목록 조회 (관리자)
+     * @return 전체 강사 신청 목록
+     */
+    public List<RespCreatorRequestDto> findCreatorRequestList() {
+        log.info("[CreatorRequestService] 강사 신청 목록 조회");
+
+        return creatorRequestMapper.selectCreatorRequestList();
+    }
+
+    /**
+     * 강사 신청 승인
+     * @param requestId 신청 ID
+     * @throws BusinessException 신청 없음(404), 이미 처리된 신청(409)
+     */
+    @Transactional
+    public void approveCreatorRequest(Long requestId) {
+        log.info("[CreatorRequestService] 강사 신청 승인 - requestId: {}", requestId);
+
+        RespCreatorRequestDto request = creatorRequestMapper.selectCreatorRequestById(requestId);
+        if (request == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "강사 신청을 찾을 수 없습니다.");
+        }
+
+        if (!CreatorRequestStatus.PENDING.equals(request.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT, "처리 완료된 신청입니다.");
+        }
+
+        creatorRequestMapper.updateCreatorRequestStatus(CreatorRequest.ofApprove(requestId));
+        userMapper.updateUserRole(request.getUserId(), "CREATOR");
+    }
+
+    /**
+     * 강사 신청 거절
+     * @param requestId 신청 ID
+     * @param rejectReason 거절 사유
+     * @throws BusinessException 신청 없음(404), 이미 처리된 신청(409)
+     */
+    @Transactional
+    public void rejectCreatorRequest(Long requestId, String rejectReason) {
+        log.info("[CreatorRequestService] 강사 신청 거절 - requestId: {}", requestId);
+
+        RespCreatorRequestDto request = creatorRequestMapper.selectCreatorRequestById(requestId);
+        if (request == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "강사 신청을 찾을 수 없습니다.");
+        }
+
+        if (!CreatorRequestStatus.PENDING.equals(request.getStatus())) {
+            throw new BusinessException(HttpStatus.CONFLICT, "처리 완료된 신청입니다.");
+        }
+
+        creatorRequestMapper.updateCreatorRequestStatus(CreatorRequest.ofReject(requestId, rejectReason));
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CreatorRequestService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CreatorRequestService.java
@@ -1,0 +1,53 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.req.ReqCreatorRequestDto;
+import com.yujin.course_enrollment.entity.CreatorRequest;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CreatorRequestMapper;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 강사 신청 서비스
+ * 강사 신청 관련 비즈니스 로직을 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CreatorRequestService {
+
+    private final CreatorRequestMapper creatorRequestMapper;
+    private final UserMapper userMapper;
+
+    /**
+     * 강사 신청
+     * @param userId 신청자 ID
+     * @param reqCreatorRequestDto 신청 정보 (reason)
+     * @throws BusinessException 사용자 없음(404), 이미 강사(409), 신청 중복(409)
+     */
+    @Transactional
+    public void requestCreator(Long userId, ReqCreatorRequestDto reqCreatorRequestDto) {
+        log.info("[CreatorRequestService] 강사 신청 - userId: {}", userId);
+
+        User user = userMapper.selectUserById(userId);
+        if (user == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+        }
+
+        if ("CREATOR".equals(user.getRole())) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 강사 계정입니다.");
+        }
+
+        if (creatorRequestMapper.selectPendingRequestByUserId(userId) != null) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 강사 신청 중입니다.");
+        }
+
+        creatorRequestMapper.insertCreatorRequest(CreatorRequest.ofCreate(userId, reqCreatorRequestDto.getReason()));
+    }
+}

--- a/backend/src/main/resources/mapper/CreatorRequestMapper.xml
+++ b/backend/src/main/resources/mapper/CreatorRequestMapper.xml
@@ -16,6 +16,47 @@
         )
     </insert>
 
+    <!-- 강사 신청 단건 조회 -->
+    <select id="selectCreatorRequestById" parameterType="Long" resultType="RespCreatorRequestDto">
+        SELECT cr.id
+             , cr.user_id
+             , u.username
+             , u.name
+             , cr.status
+             , cr.reason
+             , cr.reject_reason
+             , cr.requested_at
+             , cr.processed_at
+          FROM creator_requests cr
+          JOIN users u ON u.id = cr.user_id
+         WHERE cr.id = #{id}
+    </select>
+
+    <!-- 전체 강사 신청 목록 조회 -->
+    <select id="selectCreatorRequestList" resultType="RespCreatorRequestDto">
+        SELECT cr.id
+             , cr.user_id
+             , u.username
+             , u.name
+             , cr.status
+             , cr.reason
+             , cr.reject_reason
+             , cr.requested_at
+             , cr.processed_at
+          FROM creator_requests cr
+          JOIN users u ON u.id = cr.user_id
+        ORDER BY cr.requested_at DESC
+    </select>
+
+    <!-- 강사 신청 상태 업데이트 -->
+    <update id="updateCreatorRequestStatus" parameterType="CreatorRequest">
+        UPDATE creator_requests
+           SET status = #{status}
+             , reject_reason = #{rejectReason}
+             , processed_at = #{processedAt}
+         WHERE id = #{id}
+    </update>
+
     <!-- 사용자의 PENDING 상태 신청 조회 -->
     <select id="selectPendingRequestByUserId" parameterType="Long" resultType="CreatorRequest">
         SELECT id

--- a/backend/src/main/resources/mapper/CreatorRequestMapper.xml
+++ b/backend/src/main/resources/mapper/CreatorRequestMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yujin.course_enrollment.mapper.CreatorRequestMapper">
+
+    <!-- 강사 신청 등록 -->
+    <insert id="insertCreatorRequest" parameterType="CreatorRequest" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO creator_requests (
+                user_id
+              , status
+              , reason
+        ) VALUES (
+                #{userId}
+              , #{status}
+              , #{reason}
+        )
+    </insert>
+
+    <!-- 사용자의 PENDING 상태 신청 조회 -->
+    <select id="selectPendingRequestByUserId" parameterType="Long" resultType="CreatorRequest">
+        SELECT id
+             , user_id
+             , status
+             , reason
+             , reject_reason
+             , requested_at
+             , processed_at
+          FROM creator_requests
+         WHERE user_id = #{userId}
+           AND status = 'PENDING'
+        LIMIT 1
+    </select>
+
+</mapper>

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -74,4 +74,11 @@
         )
     </insert>
 
+    <!-- 사용자 역할 변경 -->
+    <update id="updateUserRole">
+        UPDATE users
+           SET role = #{role}
+         WHERE id = #{id}
+    </update>
+
 </mapper>

--- a/backend/src/main/resources/sql/data.sql
+++ b/backend/src/main/resources/sql/data.sql
@@ -6,7 +6,8 @@ VALUES
     ('creator_c', '강사C',  'creator_c@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'CREATOR'),
     ('student_a', '수강생A', 'student_a@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT'),
     ('student_b', '수강생B', 'student_b@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT'),
-    ('student_c', '수강생C', 'student_c@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT');
+    ('student_c', '수강생C', 'student_c@test.com', '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'STUDENT'),
+    ('admin',     '관리자',  'admin@test.com',     '$2a$10$N/1FjmE1Nxvz24gnJ4A.I.3zw7QlQdAgKn8TVvuUfkCRJq0gMUioK', 'ADMIN');
 
 
 

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS creator_requests;
 DROP TABLE IF EXISTS payments;
 DROP TABLE IF EXISTS enrollments;
 DROP TABLE IF EXISTS courses;
@@ -45,6 +46,17 @@ CREATE TABLE enrollments (
 
 CREATE UNIQUE INDEX idx_enrollment_user_course ON enrollments(user_id, course_id);
 CREATE INDEX idx_enrollment_course             ON enrollments(course_id);
+
+CREATE TABLE creator_requests (
+                                  id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                  user_id       BIGINT      NOT NULL,
+                                  status        VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+                                  reason        TEXT        NOT NULL,
+                                  reject_reason TEXT,
+                                  requested_at  DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                  processed_at  DATETIME,
+                                  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
 
 CREATE TABLE payments (
                           id            BIGINT       AUTO_INCREMENT PRIMARY KEY,

--- a/backend/src/test/java/com/yujin/course_enrollment/service/CreatorRequestServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/CreatorRequestServiceTest.java
@@ -1,0 +1,121 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.req.ReqCreatorRequestDto;
+import com.yujin.course_enrollment.entity.CreatorRequest;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CreatorRequestMapper;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * 강사 신청 서비스 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class CreatorRequestServiceTest {
+
+    @InjectMocks
+    private CreatorRequestService creatorRequestService;
+
+    @Mock
+    private CreatorRequestMapper creatorRequestMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Test
+    @DisplayName("강사 신청 성공")
+    void requestCreator_success() {
+        // given
+        Long userId = 4L;
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
+        ReqCreatorRequestDto dto = new ReqCreatorRequestDto("강의를 만들고 싶습니다.");
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(creatorRequestMapper.selectPendingRequestByUserId(userId)).willReturn(null);
+        willDoNothing().given(creatorRequestMapper).insertCreatorRequest(any());
+
+        // when
+        creatorRequestService.requestCreator(userId, dto);
+
+        // then
+        then(creatorRequestMapper).should().insertCreatorRequest(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 - 강사 신청 실패")
+    void requestCreator_userNotFound() {
+        // given
+        Long userId = 999L;
+        ReqCreatorRequestDto dto = new ReqCreatorRequestDto("강의를 만들고 싶습니다.");
+
+        given(userMapper.selectUserById(userId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.requestCreator(userId, dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("사용자를 찾을 수 없습니다.");
+        then(creatorRequestMapper).should(never()).insertCreatorRequest(any());
+    }
+
+    @Test
+    @DisplayName("이미 강사 계정 - 강사 신청 실패")
+    void requestCreator_alreadyCreator() {
+        // given
+        Long userId = 1L;
+        User creator = User.builder()
+                .id(userId)
+                .name("강사A")
+                .role("CREATOR")
+                .build();
+        ReqCreatorRequestDto dto = new ReqCreatorRequestDto("더 많은 강의를 만들고 싶습니다.");
+
+        given(userMapper.selectUserById(userId)).willReturn(creator);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.requestCreator(userId, dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 강사 계정입니다.");
+        then(creatorRequestMapper).should(never()).insertCreatorRequest(any());
+    }
+
+    @Test
+    @DisplayName("이미 신청 중 - 강사 신청 실패")
+    void requestCreator_alreadyPending() {
+        // given
+        Long userId = 4L;
+        User student = User.builder()
+                .id(userId)
+                .name("수강생A")
+                .role("STUDENT")
+                .build();
+        CreatorRequest pending = CreatorRequest.builder()
+                .id(1L)
+                .userId(userId)
+                .status("PENDING")
+                .reason("강의를 만들고 싶습니다.")
+                .build();
+        ReqCreatorRequestDto dto = new ReqCreatorRequestDto("다시 신청합니다.");
+
+        given(userMapper.selectUserById(userId)).willReturn(student);
+        given(creatorRequestMapper.selectPendingRequestByUserId(userId)).willReturn(pending);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.requestCreator(userId, dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 강사 신청 중입니다.");
+        then(creatorRequestMapper).should(never()).insertCreatorRequest(any());
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/service/CreatorRequestServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/CreatorRequestServiceTest.java
@@ -1,6 +1,7 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqCreatorRequestDto;
+import com.yujin.course_enrollment.dto.resp.RespCreatorRequestDto;
 import com.yujin.course_enrollment.entity.CreatorRequest;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.exception.BusinessException;
@@ -15,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.never;
 
 /**
  * 강사 신청 서비스 단위 테스트
@@ -117,5 +119,102 @@ class CreatorRequestServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("이미 강사 신청 중입니다.");
         then(creatorRequestMapper).should(never()).insertCreatorRequest(any());
+    }
+
+    @Test
+    @DisplayName("강사 신청 승인 성공")
+    void approveCreatorRequest_success() {
+        // given
+        Long requestId = 1L;
+        Long userId = 4L;
+        RespCreatorRequestDto request = new RespCreatorRequestDto(requestId, userId, "student_a", "수강생A", "PENDING", "강의를 만들고 싶습니다.", null, null, null);
+
+        given(creatorRequestMapper.selectCreatorRequestById(requestId)).willReturn(request);
+        willDoNothing().given(creatorRequestMapper).updateCreatorRequestStatus(any());
+        willDoNothing().given(userMapper).updateUserRole(userId, "CREATOR");
+
+        // when
+        creatorRequestService.approveCreatorRequest(requestId);
+
+        // then
+        then(creatorRequestMapper).should().updateCreatorRequestStatus(any());
+        then(userMapper).should().updateUserRole(userId, "CREATOR");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 신청 - 승인 실패")
+    void approveCreatorRequest_notFound() {
+        // given
+        Long requestId = 999L;
+        given(creatorRequestMapper.selectCreatorRequestById(requestId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.approveCreatorRequest(requestId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("강사 신청을 찾을 수 없습니다.");
+        then(userMapper).should(never()).updateUserRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 처리된 신청 - 승인 실패")
+    void approveCreatorRequest_alreadyProcessed() {
+        // given
+        Long requestId = 1L;
+        RespCreatorRequestDto request = new RespCreatorRequestDto(requestId, 4L, "student_a", "수강생A", "APPROVED", "강의를 만들고 싶습니다.", null, null, null);
+
+        given(creatorRequestMapper.selectCreatorRequestById(requestId)).willReturn(request);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.approveCreatorRequest(requestId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("처리 완료된 신청입니다.");
+        then(userMapper).should(never()).updateUserRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("강사 신청 거절 성공")
+    void rejectCreatorRequest_success() {
+        // given
+        Long requestId = 1L;
+        String rejectReason = "경력 정보가 부족합니다.";
+        RespCreatorRequestDto request = new RespCreatorRequestDto(requestId, 4L, "student_a", "수강생A", "PENDING", "강의를 만들고 싶습니다.", null, null, null);
+
+        given(creatorRequestMapper.selectCreatorRequestById(requestId)).willReturn(request);
+        willDoNothing().given(creatorRequestMapper).updateCreatorRequestStatus(any());
+
+        // when
+        creatorRequestService.rejectCreatorRequest(requestId, rejectReason);
+
+        // then
+        then(creatorRequestMapper).should().updateCreatorRequestStatus(any());
+        then(userMapper).should(never()).updateUserRole(any(), any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 신청 - 거절 실패")
+    void rejectCreatorRequest_notFound() {
+        // given
+        Long requestId = 999L;
+        given(creatorRequestMapper.selectCreatorRequestById(requestId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.rejectCreatorRequest(requestId, "사유"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("강사 신청을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("이미 처리된 신청 - 거절 실패")
+    void rejectCreatorRequest_alreadyProcessed() {
+        // given
+        Long requestId = 1L;
+        RespCreatorRequestDto request = new RespCreatorRequestDto(requestId, 4L, "student_a", "수강생A", "REJECTED", "강의를 만들고 싶습니다.", "경력 정보가 부족합니다.", null, null);
+
+        given(creatorRequestMapper.selectCreatorRequestById(requestId)).willReturn(request);
+
+        // when & then
+        assertThatThrownBy(() -> creatorRequestService.rejectCreatorRequest(requestId, "다른 사유"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("처리 완료된 신청입니다.");
     }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import CourseRegisterPage from './pages/CourseRegisterPage'
 import CourseListPage from './pages/CourseListPage'
 import CourseDetailPage from './pages/CourseDetailPage'
 import MyPage from './pages/MyPage'
+import AdminPage from './pages/AdminPage'
 import PaymentSuccessPage from './pages/PaymentSuccessPage'
 import PaymentFailPage from './pages/PaymentFailPage'
 
@@ -30,6 +31,16 @@ const CreatorRoute = ({ children }) => {
     return <Layout>{children}</Layout>;
 };
 
+/* ADMIN 권한 전용 라우트 */
+const AdminRoute = ({ children }) => {
+    const { user } = useAuth();
+
+    if (!user) return <Navigate to="/login" replace />;
+    if (user.role !== 'ADMIN') return <Navigate to="/courses" replace />;
+
+    return <Layout>{children}</Layout>;
+};
+
 function App() {
     return (
         <AuthProvider>
@@ -41,6 +52,7 @@ function App() {
                 <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
                 <Route path="/courses/:courseId/edit" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
                 <Route path="/my-page" element={<PrivateRoute><MyPage /></PrivateRoute>} />
+                <Route path="/admin" element={<AdminRoute><AdminPage /></AdminRoute>} />
                 <Route path="/payment/success" element={<PrivateRoute><PaymentSuccessPage /></PrivateRoute>} />
                 <Route path="/payment/fail" element={<PrivateRoute><PaymentFailPage /></PrivateRoute>} />
                 <Route path="*" element={<Navigate to="/courses" replace />} />

--- a/frontend/src/api/creatorRequest.js
+++ b/frontend/src/api/creatorRequest.js
@@ -4,3 +4,18 @@ import instance from './axios';
 export const requestCreator = (reason) => {
     return instance.post('/api/creator-requests', { reason }).then(res => res.data);
 };
+
+/* 강사 신청 목록 조회 (관리자) */
+export const getCreatorRequestList = () => {
+    return instance.get('/api/admin/creator-requests').then(res => res.data);
+};
+
+/* 강사 신청 승인 (관리자) */
+export const approveCreatorRequest = (id) => {
+    return instance.patch(`/api/admin/creator-requests/${id}/approve`).then(res => res.data);
+};
+
+/* 강사 신청 거절 (관리자) */
+export const rejectCreatorRequest = (id, rejectReason) => {
+    return instance.patch(`/api/admin/creator-requests/${id}/reject`, { rejectReason }).then(res => res.data);
+};

--- a/frontend/src/api/creatorRequest.js
+++ b/frontend/src/api/creatorRequest.js
@@ -1,0 +1,6 @@
+import instance from './axios';
+
+/* 강사 신청 */
+export const requestCreator = (reason) => {
+    return instance.post('/api/creator-requests', { reason }).then(res => res.data);
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -35,12 +35,21 @@ const Header = () => {
                                     {roleLabel(user.role)}
                                 </span>
                             </div>
-                            <button
-                                onClick={() => navigate('/my-page')}
-                                className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
-                            >
-                                마이페이지
-                            </button>
+                            {user.role === 'ADMIN' ? (
+                                <button
+                                    onClick={() => navigate('/admin')}
+                                    className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+                                >
+                                    관리자 페이지
+                                </button>
+                            ) : (
+                                <button
+                                    onClick={() => navigate('/my-page')}
+                                    className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+                                >
+                                    마이페이지
+                                </button>
+                            )}
                             <button
                                 onClick={handleLogout}
                                 className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -8,7 +8,7 @@ const Header = () => {
     const { user, logout } = useAuth();
 
     /* 역할에 따른 라벨 */
-    const roleLabel = (role) => role === 'CREATOR' ? '강사' : '수강생';
+    const roleLabel = (role) => role === 'CREATOR' ? '강사' : role === 'ADMIN' ? '관리자' : '수강생';
 
     /* 로그아웃 처리 */
     const handleLogout = () => {

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCreatorRequestList, approveCreatorRequest, rejectCreatorRequest } from '../api/creatorRequest';
+
+/* 상태 라벨/스타일 */
+const statusLabel = (status) => status === 'PENDING' ? '검토 중' : status === 'APPROVED' ? '승인' : '거절';
+const statusStyle = (status) =>
+    status === 'PENDING' ? 'bg-yellow-100 text-yellow-700' :
+    status === 'APPROVED' ? 'bg-green-100 text-green-700' :
+    'bg-red-100 text-red-700';
+
+/* 관리자 페이지 - 강사 신청 목록 */
+const AdminPage = () => {
+    /* React Query 클라이언트 */
+    const queryClient = useQueryClient();
+    /* 거절 모달 상태: { id, rejectReason } */
+    const [rejectModal, setRejectModal] = useState(null);
+
+    /* 강사 신청 목록 조회 */
+    const { data: requests = [], isLoading } = useQuery({
+        queryKey: ['creatorRequests'],
+        queryFn: () => getCreatorRequestList().then(res => res.data),
+    });
+
+    /* 승인 */
+    const handleApprove = async (id) => {
+        if (!window.confirm('강사 신청을 승인하시겠습니까?')) return;
+        try {
+            await approveCreatorRequest(id);
+            alert('승인되었습니다.');
+            queryClient.invalidateQueries({ queryKey: ['creatorRequests'] });
+        } catch (err) {
+            alert(err.response?.data?.message || '승인에 실패했습니다.');
+        }
+    };
+
+    /* 거절 */
+    const handleReject = async () => {
+        if (!rejectModal.rejectReason.trim()) {
+            alert('거절 사유를 입력해주세요.');
+            return;
+        }
+        try {
+            await rejectCreatorRequest(rejectModal.id, rejectModal.rejectReason.trim());
+            alert('거절되었습니다.');
+            setRejectModal(null);
+            queryClient.invalidateQueries({ queryKey: ['creatorRequests'] });
+        } catch (err) {
+            alert(err.response?.data?.message || '거절에 실패했습니다.');
+        }
+    };
+
+    if (isLoading) return <div className="max-w-4xl mx-auto mt-10 p-6 text-gray-500">로딩 중...</div>;
+
+    return (
+        <div className="max-w-4xl mx-auto mt-10 p-6">
+            <h1 className="text-3xl font-extrabold text-gray-900 mb-8">강사 신청 관리</h1>
+
+            {requests.length === 0 ? (
+                <div className="text-center py-16 text-gray-400">강사 신청 내역이 없습니다.</div>
+            ) : (
+                <div className="flex flex-col gap-4">
+                    {requests.map(req => (
+                        <div key={req.id} className="border border-gray-200 rounded-xl p-5 bg-white shadow-sm">
+                            <div className="flex items-start justify-between gap-4">
+
+                                {/* 신청자 정보 및 사유 */}
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <span className="font-semibold text-gray-900">{req.name}</span>
+                                        <span className="text-sm text-gray-400">@{req.username}</span>
+                                        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusStyle(req.status)}`}>
+                                            {statusLabel(req.status)}
+                                        </span>
+                                    </div>
+                                    <p className="text-sm text-gray-600 mt-2">
+                                        <span className="font-medium text-gray-700">신청 사유</span>
+                                        <span className="mx-2 text-gray-300">|</span>
+                                        {req.reason}
+                                    </p>
+                                    {req.rejectReason && (
+                                        <p className="text-sm text-red-500 mt-1">
+                                            <span className="font-medium">거절 사유</span>
+                                            <span className="mx-2 text-red-300">|</span>
+                                            {req.rejectReason}
+                                        </p>
+                                    )}
+                                    <p className="text-xs text-gray-400 mt-2">
+                                        {new Date(req.requestedAt).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
+                                    </p>
+                                </div>
+
+                                {/* 승인/거절 버튼 */}
+                                {req.status === 'PENDING' && (
+                                    <div className="flex gap-2 shrink-0">
+                                        <button
+                                            onClick={() => handleApprove(req.id)}
+                                            className="px-4 py-1.5 text-sm font-semibold bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors cursor-pointer"
+                                        >
+                                            승인
+                                        </button>
+                                        <button
+                                            onClick={() => setRejectModal({ id: req.id, rejectReason: '' })}
+                                            className="px-4 py-1.5 text-sm font-semibold bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors cursor-pointer"
+                                        >
+                                            거절
+                                        </button>
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* 거절 사유 입력 */}
+                            {rejectModal?.id === req.id && (
+                                <div className="mt-4 pt-4 border-t border-gray-100">
+                                    <textarea
+                                        value={rejectModal.rejectReason}
+                                        onChange={(e) => setRejectModal(prev => ({ ...prev, rejectReason: e.target.value }))}
+                                        placeholder="거절 사유를 입력해주세요."
+                                        rows={2}
+                                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-red-400 resize-none"
+                                    />
+                                    <div className="flex justify-end gap-2 mt-2">
+                                        <button
+                                            onClick={() => setRejectModal(null)}
+                                            className="px-4 py-1.5 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                                        >
+                                            취소
+                                        </button>
+                                        <button
+                                            onClick={handleReject}
+                                            className="px-4 py-1.5 text-sm font-semibold bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors cursor-pointer"
+                                        >
+                                            거절하기
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AdminPage;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -15,9 +15,9 @@ const LoginPage = () => {
     /* 로그인 후 리다이렉트할 경로 */
     const redirect = location.state?.redirect || '/courses';
     /* 역할에 따른 라벨 */
-    const roleLabel = (role) => role === 'CREATOR' ? '강사' : '수강생';
+    const roleLabel = (role) => role === 'CREATOR' ? '강사' : role === 'ADMIN' ? '관리자' : '수강생';
     /* 역할에 따른 스타일 */
-    const roleStyle = (role) => role === 'CREATOR' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700';
+    const roleStyle = (role) => role === 'CREATOR' ? 'bg-blue-100 text-blue-700' : role === 'ADMIN' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700';
 
     /* 유저 선택 시 로그인 처리 */
     const handleSelectUser = (user) => {

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { requestCreator } from '../api/creatorRequest';
 import EnrollmentTab from './mypage/EnrollmentTab';
 import PaymentTab from './mypage/PaymentTab';
 import MyCourseTab from './mypage/MyCourseTab';
@@ -14,6 +15,10 @@ const MyPage = () => {
     const { user } = useAuth();
     /* 현재 활성화된 탭 상태 */
     const [activeTab, setActiveTab] = useState(location.state?.tab || 'enrollments');
+    /* 강사 신청 폼 표시 상태 */
+    const [showCreatorForm, setShowCreatorForm] = useState(false);
+    /* 강사 신청 사유 */
+    const [creatorReason, setCreatorReason] = useState('');
 
     /* 탭 목록 - CREATOR는 추가 탭 노출 */
     const tabs = [
@@ -25,24 +30,83 @@ const MyPage = () => {
         ] : []),
     ];
 
+    /* 강사 신청 제출 */
+    const handleCreatorRequest = async () => {
+        if (!creatorReason.trim()) {
+            alert('신청 사유를 입력해주세요.');
+            return;
+        }
+
+        try {
+            await requestCreator(creatorReason.trim());
+            alert('강사 신청이 완료되었습니다. 관리자 승인 후 강사 계정으로 전환됩니다.');
+            
+            setShowCreatorForm(false);
+            setCreatorReason('');
+        } catch (err) {
+            alert(err.response?.data?.message || '강사 신청에 실패했습니다.');
+        }
+    };
+
     return (
         <div className="max-w-4xl mx-auto mt-10 p-6">
             <h1 className="text-3xl font-extrabold text-gray-900 mb-8">마이페이지</h1>
 
+            {/* 강사 신청 폼 */}
+            {user?.role === 'STUDENT' && showCreatorForm && (
+                <div className="bg-gray-50 rounded-xl border border-gray-200 p-5 mb-8">
+                    <h2 className="text-sm font-semibold text-gray-800 mb-3">강사 신청</h2>
+                    <textarea
+                        value={creatorReason}
+                        onChange={(e) => setCreatorReason(e.target.value)}
+                        placeholder="강사 신청 사유를 입력해주세요."
+                        rows={3}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                    />
+                    <div className="flex justify-end gap-2 mt-3">
+                        <button
+                            onClick={() => { setShowCreatorForm(false); setCreatorReason(''); }}
+                            className="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                        >
+                            취소
+                        </button>
+                        <button
+                            onClick={handleCreatorRequest}
+                            className="px-4 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors cursor-pointer"
+                        >
+                            신청하기
+                        </button>
+                    </div>
+                </div>
+            )}
+
             {/* 탭 버튼들 */}
-            <div className="flex gap-1 border-b border-gray-200 mb-8">
-                {tabs.map(tab => (
-                    <button
-                        key={tab.key}
-                        onClick={() => setActiveTab(tab.key)}
-                        className={`px-5 py-2.5 text-sm font-semibold transition-colors cursor-pointer ${activeTab === tab.key
-                                ? 'border-b-2 border-blue-600 text-blue-600'
-                                : 'text-gray-500 hover:text-gray-700'
-                            }`}
-                    >
-                        {tab.label}
-                    </button>
-                ))}
+            <div className="flex items-center border-b border-gray-200 mb-8">
+                <div className="flex gap-1 flex-1">
+                    {tabs.map(tab => (
+                        <button
+                            key={tab.key}
+                            onClick={() => setActiveTab(tab.key)}
+                            className={`px-5 py-2.5 text-sm font-semibold transition-colors cursor-pointer ${activeTab === tab.key
+                                    ? 'border-b-2 border-blue-600 text-blue-600'
+                                    : 'text-gray-500 hover:text-gray-700'
+                                }`}
+                        >
+                            {tab.label}
+                        </button>
+                    ))}
+                </div>
+                {user?.role === 'STUDENT' && !showCreatorForm && (
+                    <div className="flex items-center gap-3 mb-1">
+                        <span className="text-xs text-gray-400">강의를 만들고 싶으신가요?</span>
+                        <button
+                            onClick={() => setShowCreatorForm(true)}
+                            className="px-4 py-1.5 text-sm font-semibold bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer"
+                        >
+                            강사 신청
+                        </button>
+                    </div>
+                )}
             </div>
 
             {/* 탭 콘텐츠 */}
@@ -50,6 +114,7 @@ const MyPage = () => {
             {activeTab === 'payments' && <PaymentTab />}
             {activeTab === 'my-courses' && <MyCourseTab />}
             {activeTab === 'students' && <StudentTab />}
+
         </div>
     );
 };


### PR DESCRIPTION
  ## 작업 내용
  - creator_requests 테이블 추가, ADMIN 계정 추가
  - POST /api/creator-requests 강사 신청, GET /api/admin/creator-requests 목록 조회, PATCH 승인/거절 API 구현
  - 승인 시 users.role → CREATOR로 즉시 변경, 거절 시 reject_reason 저장
  - 마이페이지 탭 바 우측 강사 신청 버튼/폼 추가 (STUDENT 전용)
  - 관리자 페이지 (/admin) 추가 - 신청 목록, 승인/거절 버튼, AdminRoute 추가
  - 헤더 ADMIN 역할 시 관리자 페이지 버튼 노출, 로그인 페이지 ADMIN 역할 라벨 추가
  - CreatorRequestServiceTest 추가 (신청/승인/거절 총 10개 케이스)

  ## 구현 시 고려한 점
  - ADMIN, CREATOR, STUDENT 역할 기반 접근 제어(SecurityConfig)는 별도의 이슈에서 일괄 처리
  - 중복 신청 방지: PENDING 상태 신청이 존재하면 409 반환

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - STUDENT 계정 로그인 → 마이페이지 → 강사 신청 → 사유 입력 후 제출
  - 관리자 계정 로그인 → 관리자 페이지 → 신청 목록 확인 → 승인/거절

  ## 연관 이슈
  Closes #42