### PR TITLE
[feat] Spring Security + JWT 인증/인가 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -19,12 +19,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.security:spring-security-crypto'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-starter-devtools'
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5'

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
@@ -16,12 +16,17 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * JWT 인증 필터
+ * 요청마다 accessToken 쿠키에서 토큰을 추출해 검증하고 SecurityContext에 인증 정보를 설정
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
 
+    /* 요청마다 실행 — 쿠키에서 토큰 추출 후 유효하면 SecurityContext에 인증 정보 설정 */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = extractToken(request);
@@ -41,6 +46,7 @@ public class JwtFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /* 쿠키에서 accessToken 추출 */
     private String extractToken(HttpServletRequest request) {
         if (request.getCookies() == null) return null;
 

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
@@ -7,10 +7,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ import java.util.List;
  * JWT 인증 필터
  * 요청마다 accessToken 쿠키에서 토큰을 추출해 검증하고 SecurityContext에 인증 정보를 설정
  */
-@Component
+@Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -29,6 +30,8 @@ public class JwtFilter extends OncePerRequestFilter {
     /* 요청마다 실행 — 쿠키에서 토큰 추출 후 유효하면 SecurityContext에 인증 정보 설정 */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.debug("[JwtFilter] 필터 진입 - uri: {}", request.getRequestURI());
+
         String token = extractToken(request);
 
         if (token != null) {
@@ -38,9 +41,16 @@ public class JwtFilter extends OncePerRequestFilter {
                 String role = claims.get("role", String.class);
 
                 UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("ROLE_" + role)));
-                SecurityContextHolder.getContext().setAuthentication(auth);
-            } catch (Exception ignored) {
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                context.setAuthentication(auth);
+                SecurityContextHolder.setContext(context);
+
+                log.debug("[JwtFilter] 인증 설정 완료 - userId: {}, role: ROLE_{}", userId, role);
+            } catch (Exception e) {
+                log.debug("[JwtFilter] 토큰 파싱 실패: {}", e.getMessage());
             }
+        } else {
+            log.debug("[JwtFilter] accessToken 쿠키 없음 - uri: {}", request.getRequestURI());
         }
 
         filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
@@ -1,0 +1,55 @@
+package com.yujin.course_enrollment.config;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null) {
+            try {
+                Claims claims = jwtUtil.parseToken(token);
+                Long userId = Long.parseLong(claims.getSubject());
+                String role = claims.get("role", String.class);
+
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (Exception ignored) {
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("accessToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtUtil.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtUtil.java
@@ -1,0 +1,43 @@
+package com.yujin.course_enrollment.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    public String generateToken(Long userId, String role) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public Claims parseToken(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtUtil.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtUtil.java
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.util.Date;
 
+/**
+ * JWT 유틸리티
+ * AccessToken 생성 및 파싱을 담당
+ */
 @Component
 public class JwtUtil {
 
@@ -19,6 +23,12 @@ public class JwtUtil {
     @Value("${jwt.expiration}")
     private long expiration;
 
+    /**
+     * AccessToken 생성
+     * @param userId 사용자 ID (subject)
+     * @param role 사용자 역할 (claim)
+     * @return 서명된 JWT 문자열
+     */
     public String generateToken(Long userId, String role) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
@@ -29,6 +39,11 @@ public class JwtUtil {
                 .compact();
     }
 
+    /**
+     * 토큰 파싱 및 서명 검증
+     * @param token JWT 문자열
+     * @return Claims (subject, role 등 payload)
+     */
     public Claims parseToken(String token) {
         return Jwts.parser()
                 .verifyWith(getSigningKey())
@@ -37,6 +52,7 @@ public class JwtUtil {
                 .getPayload();
     }
 
+    /* Base64 디코딩된 secret으로 HMAC-SHA 서명 키 생성 */
     private SecretKey getSigningKey() {
         return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.yujin.course_enrollment.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-username", "/api/auth/check-email").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/courses", "/api/courses/{courseId}").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtFilter jwtFilter;
+    private final JwtUtil jwtUtil;
 
     /* 비밀번호 암호화 빈 */
     @Bean
@@ -40,21 +40,34 @@ public class SecurityConfig {
                 /* 세션 미사용 — JWT로 stateless 인증 */
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        /* H2 콘솔, 인증 엔드포인트, 강의 목록/상세 조회는 인증 없이 허용 */
-                        .requestMatchers("/h2-console/**").permitAll()
-                        .requestMatchers("/api/auth/login", "/api/auth/logout", "/api/auth/signup", "/api/auth/check-username", "/api/auth/check-email").permitAll()
+                        /* H2 콘솔, 인증 엔드포인트는 인증 없이 허용 */
+                        .requestMatchers("/h2-console/**", "/error").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup").anonymous()
+                        .requestMatchers("/api/auth/logout", "/api/auth/check-username", "/api/auth/check-email").permitAll()
+                        /* 강사 전용 */
+                        .requestMatchers(HttpMethod.GET, "/api/courses/my", "/api/courses/{courseId}/enrollments").hasRole("CREATOR")
+                        .requestMatchers(HttpMethod.POST, "/api/courses").hasRole("CREATOR")
+                        .requestMatchers(HttpMethod.PUT, "/api/courses/{courseId}").hasRole("CREATOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/courses/{courseId}/publish", "/api/courses/{courseId}/close").hasRole("CREATOR")
+                        /* 강의 목록/상세 조회는 인증 없이 허용 */
                         .requestMatchers(HttpMethod.GET, "/api/courses", "/api/courses/{courseId}").permitAll()
-                        /* 관리자 전용 엔드포인트 */
+                        /* 수강생 전용 */
+                        .requestMatchers("/api/enrollments/**", "/api/payments/**").hasRole("STUDENT")
+                        .requestMatchers(HttpMethod.POST, "/api/creator-requests").hasRole("STUDENT")
+                        /* 관리자 전용 */
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
-                /* 인증 실패 시 401 반환 */
                 .exceptionHandling(e -> e
+                        /* 미인증 요청 — 401 */
                         .authenticationEntryPoint((request, response, ex) ->
-                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED)))
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                        /* 인증됐으나 권한 없음 — 403 */
+                        .accessDeniedHandler((request, response, ex) ->
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN)))
                 /* H2 콘솔 iframe 허용 */
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -8,9 +8,14 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * Spring Security 설정
+ */
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -18,18 +23,33 @@ public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
 
+    /* 비밀번호 암호화 빈 */
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                /* CSRF 비활성화 — JWT 사용으로 불필요 */
                 .csrf(AbstractHttpConfigurer::disable)
+                /* 세션 미사용 — JWT로 stateless 인증 */
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        /* H2 콘솔, 인증 엔드포인트, 강의 목록/상세 조회는 인증 없이 허용 */
                         .requestMatchers("/h2-console/**").permitAll()
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/check-username", "/api/auth/check-email").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/logout", "/api/auth/signup", "/api/auth/check-username", "/api/auth/check-email").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/courses", "/api/courses/{courseId}").permitAll()
+                        /* 관리자 전용 엔드포인트 */
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
+                /* 인증 실패 시 401 반환 */
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint((request, response, ex) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED)))
+                /* H2 콘솔 iframe 허용 */
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -32,6 +33,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                /* CORS 설정 */
+                .cors(Customizer.withDefaults())
                 /* CSRF 비활성화 — JWT 사용으로 불필요 */
                 .csrf(AbstractHttpConfigurer::disable)
                 /* 세션 미사용 — JWT로 stateless 인증 */

--- a/backend/src/main/java/com/yujin/course_enrollment/config/WebConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/WebConfig.java
@@ -13,8 +13,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOriginPatterns("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
@@ -1,12 +1,17 @@
 package com.yujin.course_enrollment.controller;
 
+import com.yujin.course_enrollment.dto.req.ReqLoginDto;
+import com.yujin.course_enrollment.dto.resp.RespLoginDto;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.response.ApiResponse;
-import com.yujin.course_enrollment.service.UserService;
+import com.yujin.course_enrollment.service.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.Map;
 
 /**
@@ -27,7 +33,53 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final UserService userService;
+    private final AuthService authService;
+
+    /**
+     * 로그인
+     * POST /api/auth/login
+     * @param reqLoginDto 로그인 요청 (username, password)
+     * @param response HTTP 응답 (accessToken httpOnly 쿠키 설정)
+     * @return 사용자 정보 (id, username, name, role)
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<RespLoginDto>> login(@Valid @RequestBody ReqLoginDto reqLoginDto, HttpServletResponse response) {
+        log.debug("[AuthController] 로그인 요청 - username: {}", reqLoginDto.getUsername());
+
+        User user = authService.login(reqLoginDto.getUsername(), reqLoginDto.getPassword());
+        String token = authService.generateToken(user);
+
+        ResponseCookie cookie = ResponseCookie.from("accessToken", token)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofMinutes(15))
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok(ApiResponse.success(RespLoginDto.from(user)));
+    }
+
+    /**
+     * 로그아웃
+     * POST /api/auth/logout
+     * @param response HTTP 응답 (accessToken 쿠키 삭제)
+     * @return 200 OK
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+        log.debug("[AuthController] 로그아웃 요청");
+
+        ResponseCookie cookie = ResponseCookie.from("accessToken", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
 
     /**
      * 아이디 중복 확인
@@ -39,7 +91,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkUsername(@RequestParam String value) {
         log.debug("[AuthController] 아이디 중복 확인 - username: {}", value);
 
-        return ResponseEntity.ok(ApiResponse.success(Map.of("available", userService.isUsernameAvailable(value))));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("available", authService.isUsernameAvailable(value))));
     }
 
     /**
@@ -52,7 +104,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkEmail(@RequestParam String value) {
         log.debug("[AuthController] 이메일 중복 확인 - email: {}", value);
 
-        return ResponseEntity.ok(ApiResponse.success(Map.of("available", userService.isEmailAvailable(value))));
+        return ResponseEntity.ok(ApiResponse.success(Map.of("available", authService.isEmailAvailable(value))));
     }
 
     /**
@@ -65,7 +117,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody User user) {
         log.debug("[AuthController] 회원가입 요청 - username: {}", user.getUsername());
 
-        userService.signup(user);
+        authService.signup(user);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created());
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CourseController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -39,7 +40,7 @@ public class CourseController {
      * @param reqCourseCreateDto 강의 등록 요청 DTO
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<RespCourseCreateDto>> createCourse(@RequestHeader("X-User-Id") Long creatorId, @Valid @RequestBody ReqCourseCreateDto reqCourseCreateDto) {
+    public ResponseEntity<ApiResponse<RespCourseCreateDto>> createCourse(@AuthenticationPrincipal Long creatorId, @Valid @RequestBody ReqCourseCreateDto reqCourseCreateDto) {
         log.debug("[CourseController] 강의 등록 요청 - creatorId: {}, title: {}", creatorId, reqCourseCreateDto.getTitle());
 
         RespCourseCreateDto respCourseCreateDto = courseService.registerCourse(creatorId, reqCourseCreateDto);
@@ -68,7 +69,7 @@ public class CourseController {
      * @param courseId 강의 ID
      */
     @GetMapping("/{courseId}")
-    public ResponseEntity<ApiResponse<RespCourseDetailDto>> getCourseDetail(@RequestHeader(value = "X-User-Id", required = false) Long userId, @PathVariable Long courseId) {
+    public ResponseEntity<ApiResponse<RespCourseDetailDto>> getCourseDetail(@AuthenticationPrincipal Long userId, @PathVariable Long courseId) {
         log.debug("[CourseController] 강의 상세 조회 요청 - courseId: {}", courseId);
 
         RespCourseDetailDto result = courseService.findCourseById(courseId, userId);
@@ -84,7 +85,7 @@ public class CourseController {
      * @param reqCourseUpdateDto 강의 수정 요청 DTO
      */
     @PutMapping("/{courseId}")
-    public ResponseEntity<ApiResponse<RespCourseDetailDto>> updateCourse(@RequestHeader("X-User-Id") Long creatorId, @PathVariable Long courseId, @Valid @RequestBody ReqCourseUpdateDto reqCourseUpdateDto) {
+    public ResponseEntity<ApiResponse<RespCourseDetailDto>> updateCourse(@AuthenticationPrincipal Long creatorId, @PathVariable Long courseId, @Valid @RequestBody ReqCourseUpdateDto reqCourseUpdateDto) {
         log.debug("[CourseController] 강의 수정 요청 - creatorId: {}, courseId: {}", creatorId, courseId);
 
         RespCourseDetailDto result = courseService.modifyCourse(creatorId, courseId, reqCourseUpdateDto);
@@ -99,7 +100,7 @@ public class CourseController {
      * @param courseId 강의 ID
      */
     @PatchMapping("/{courseId}/publish")
-    public ResponseEntity<ApiResponse<RespCourseDetailDto>> publishCourse(@RequestHeader("X-User-Id") Long creatorId, @PathVariable Long courseId) {
+    public ResponseEntity<ApiResponse<RespCourseDetailDto>> publishCourse(@AuthenticationPrincipal Long creatorId, @PathVariable Long courseId) {
         log.debug("[CourseController] 강의 공개 요청 - creatorId: {}, courseId: {}", creatorId, courseId);
 
         RespCourseDetailDto result = courseService.publishCourse(creatorId, courseId);
@@ -114,7 +115,7 @@ public class CourseController {
      * @param courseId 강의 ID
      */
     @PatchMapping("/{courseId}/close")
-    public ResponseEntity<ApiResponse<RespCourseDetailDto>> closeCourse(@RequestHeader("X-User-Id") Long creatorId, @PathVariable Long courseId) {
+    public ResponseEntity<ApiResponse<RespCourseDetailDto>> closeCourse(@AuthenticationPrincipal Long creatorId, @PathVariable Long courseId) {
         log.debug("[CourseController] 강의 마감 요청 - creatorId: {}, courseId: {}", creatorId, courseId);
 
         RespCourseDetailDto result = courseService.closeCourse(creatorId, courseId);
@@ -129,7 +130,7 @@ public class CourseController {
      * @param reqMyCoursePageDto 페이징 조건 DTO
      */
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<RespPageDto<RespCourseListDto>>> getMyCourses(@RequestHeader("X-User-Id") Long creatorId, ReqMyCoursePageDto reqMyCoursePageDto) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespCourseListDto>>> getMyCourses(@AuthenticationPrincipal Long creatorId, ReqMyCoursePageDto reqMyCoursePageDto) {
         log.debug("[CourseController] 나의 강의 목록 조회 요청 - creatorId: {}", creatorId);
 
         RespPageDto<RespCourseListDto> result = courseService.findMyCourses(creatorId, reqMyCoursePageDto);
@@ -145,7 +146,7 @@ public class CourseController {
      * @param reqCourseEnrollmentPageDto 페이징 조건 DTO
      */
     @GetMapping("/{courseId}/enrollments")
-    public ResponseEntity<ApiResponse<RespPageDto<RespEnrollmentCreatorDto>>> getCourseEnrollments(@RequestHeader("X-User-Id") Long creatorId, @PathVariable Long courseId, ReqCourseEnrollmentPageDto reqCourseEnrollmentPageDto) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespEnrollmentCreatorDto>>> getCourseEnrollments(@AuthenticationPrincipal Long creatorId, @PathVariable Long courseId, ReqCourseEnrollmentPageDto reqCourseEnrollmentPageDto) {
         log.debug("[CourseController] 강의별 수강생 목록 조회 요청 - creatorId: {}, courseId: {}", creatorId, courseId);
 
         RespPageDto<RespEnrollmentCreatorDto> result = courseService.findCourseEnrollments(creatorId, courseId, reqCourseEnrollmentPageDto);

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/CreatorRequestController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/CreatorRequestController.java
@@ -10,12 +10,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,7 +41,7 @@ public class CreatorRequestController {
      * @return 201 Created
      */
     @PostMapping("/creator-requests")
-    public ResponseEntity<ApiResponse<Void>> requestCreator(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqCreatorRequestDto reqCreatorRequestDto) {
+    public ResponseEntity<ApiResponse<Void>> requestCreator(@AuthenticationPrincipal Long userId, @Valid @RequestBody ReqCreatorRequestDto reqCreatorRequestDto) {
         log.debug("[CreatorRequestController] 강사 신청 요청 - userId: {}", userId);
 
         creatorRequestService.requestCreator(userId, reqCreatorRequestDto);

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/EnrollmentController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -34,7 +35,7 @@ public class EnrollmentController {
      * @param reqEnrollmentCreateDto 수강 신청 요청 DTO
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<RespEnrollmentDto>> createEnrollment(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqEnrollmentCreateDto reqEnrollmentCreateDto) {
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> createEnrollment(@AuthenticationPrincipal Long userId, @Valid @RequestBody ReqEnrollmentCreateDto reqEnrollmentCreateDto) {
         log.debug("[EnrollmentController] 수강 신청 요청 - userId: {}, courseId: {}", userId, reqEnrollmentCreateDto.getCourseId());
 
         RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, reqEnrollmentCreateDto);
@@ -49,7 +50,7 @@ public class EnrollmentController {
      * @param reqEnrollmentPageDto 페이징 조건 (page, size)
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<RespPageDto<RespEnrollmentStudentDto>>> getMyEnrollments(@RequestHeader("X-User-Id") Long userId, ReqEnrollmentPageDto reqEnrollmentPageDto) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespEnrollmentStudentDto>>> getMyEnrollments(@AuthenticationPrincipal Long userId, ReqEnrollmentPageDto reqEnrollmentPageDto) {
         log.debug("[EnrollmentController] 나의 수강 신청 목록 조회 요청 - userId: {}", userId);
 
         RespPageDto<RespEnrollmentStudentDto> result = enrollmentService.findMyEnrollments(userId, reqEnrollmentPageDto);
@@ -64,7 +65,7 @@ public class EnrollmentController {
      * @param enrollmentId 수강 신청 ID
      */
     @PatchMapping("/{enrollmentId}/confirm")
-    public ResponseEntity<ApiResponse<RespEnrollmentDto>> confirmEnrollment(@RequestHeader("X-User-Id") Long userId, @PathVariable Long enrollmentId) {
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> confirmEnrollment(@AuthenticationPrincipal Long userId, @PathVariable Long enrollmentId) {
         log.debug("[EnrollmentController] 결제 요청 - userId: {}, enrollmentId: {}", userId, enrollmentId);
 
         RespEnrollmentDto result = enrollmentService.confirmEnrollment(userId, enrollmentId);
@@ -80,7 +81,7 @@ public class EnrollmentController {
      * @param reqEnrollmentCancelDto 취소 요청 DTO (CONFIRMED 취소 시 cancelReason 필수)
      */
     @PatchMapping("/{enrollmentId}/cancel")
-    public ResponseEntity<ApiResponse<RespEnrollmentDto>> cancelEnrollment(@RequestHeader("X-User-Id") Long userId, @PathVariable Long enrollmentId, @RequestBody(required = false) ReqEnrollmentCancelDto reqEnrollmentCancelDto) {
+    public ResponseEntity<ApiResponse<RespEnrollmentDto>> cancelEnrollment(@AuthenticationPrincipal Long userId, @PathVariable Long enrollmentId, @RequestBody(required = false) ReqEnrollmentCancelDto reqEnrollmentCancelDto) {
         log.debug("[EnrollmentController] 수강 취소 요청 - userId: {}, enrollmentId: {}", userId, enrollmentId);
 
         String cancelReason = reqEnrollmentCancelDto != null ? reqEnrollmentCancelDto.getCancelReason() : null;

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/PaymentController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -33,7 +34,7 @@ public class PaymentController {
      * @return 저장된 결제 응답 DTO
      */
     @PostMapping("/confirm")
-    public ResponseEntity<ApiResponse<RespPaymentDto>> confirmPayment(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody ReqPaymentConfirmDto reqPaymentConfirmDto) {
+    public ResponseEntity<ApiResponse<RespPaymentDto>> confirmPayment(@AuthenticationPrincipal Long userId, @Valid @RequestBody ReqPaymentConfirmDto reqPaymentConfirmDto) {
         log.debug("[PaymentController] 결제 승인 요청 - userId: {}, enrollmentId: {}", userId, reqPaymentConfirmDto.getEnrollmentId());
 
         RespPaymentDto result = paymentService.confirmPayment(userId, reqPaymentConfirmDto);
@@ -49,7 +50,7 @@ public class PaymentController {
      * @return 페이징된 결제 내역 목록 (DONE, CANCELLED)
      */
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<RespPageDto<RespPaymentDto>>> getMyPayments(@RequestHeader("X-User-Id") Long userId, ReqMyPaymentPageDto reqMyPaymentPageDto) {
+    public ResponseEntity<ApiResponse<RespPageDto<RespPaymentDto>>> getMyPayments(@AuthenticationPrincipal Long userId, ReqMyPaymentPageDto reqMyPaymentPageDto) {
         log.debug("[PaymentController] 결제 내역 조회 요청 - userId: {}", userId);
 
         RespPageDto<RespPaymentDto> result = paymentService.findMyPayments(userId, reqMyPaymentPageDto);

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqLoginDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqLoginDto.java
@@ -1,0 +1,16 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Getter
+public class ReqLoginDto {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespLoginDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespLoginDto.java
@@ -1,0 +1,27 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import com.yujin.course_enrollment.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 로그인 응답 DTO
+ */
+@Getter
+@Builder
+public class RespLoginDto {
+    private Long id;
+    private String username;
+    private String name;
+    private String role;
+
+    /* User 엔티티 → 로그인 응답 DTO 변환 */
+    public static RespLoginDto from(User user) {
+        return RespLoginDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .name(user.getName())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
@@ -1,0 +1,97 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.config.JwtUtil;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+/**
+ * 인증 서비스
+ * 로그인, 회원가입, 중복 확인 등 인증 관련 비즈니스 로직을 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserMapper userMapper;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    /**
+     * AccessToken 생성
+     * @param user 인증된 사용자 엔티티
+     * @return 서명된 JWT 문자열
+     */
+    public String generateToken(User user) {
+        return jwtUtil.generateToken(user.getId(), user.getRole());
+    }
+
+    /**
+     * 로그인
+     * @param username 아이디
+     * @param password 비밀번호
+     * @return 인증된 사용자 엔티티
+     * @throws BusinessException 아이디 없음 또는 비밀번호 불일치 (401)
+     */
+    public User login(String username, String password) {
+        log.debug("[AuthService] 로그인 - username: {}", username);
+
+        User user = userMapper.selectUserByUsername(username);
+        if (user == null || !passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        return user;
+    }
+
+    /**
+     * 아이디 사용 가능 여부 확인
+     * @param username 확인할 아이디
+     * @return 사용 가능 여부
+     */
+    public boolean isUsernameAvailable(String username) {
+        log.debug("[AuthService] 아이디 중복 확인 - username: {}", username);
+
+        return userMapper.selectUserByUsername(username) == null;
+    }
+
+    /**
+     * 이메일 사용 가능 여부 확인
+     * @param email 확인할 이메일
+     * @return 사용 가능 여부
+     */
+    public boolean isEmailAvailable(String email) {
+        log.debug("[AuthService] 이메일 중복 확인 - email: {}", email);
+
+        return userMapper.selectUserByEmail(email) == null;
+    }
+
+    /**
+     * 회원가입
+     * @param user 회원가입 요청 (username, name, email, password)
+     * @throws BusinessException 아이디 또는 이메일 중복 (409)
+     */
+    @Transactional
+    public void signup(User user) {
+        log.info("[AuthService] 회원가입 - username: {}, email: {}", user.getUsername(), user.getEmail());
+
+        if (userMapper.selectUserByUsername(user.getUsername()) != null) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다.");
+        }
+
+        if (userMapper.selectUserByEmail(user.getEmail()) != null) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+        }
+
+        userMapper.insertUser(User.ofSignup(user.getUsername(), user.getName(), user.getEmail(), passwordEncoder.encode(user.getPassword())));
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
@@ -1,12 +1,9 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.entity.User;
-import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +20,6 @@ import java.util.List;
 public class UserService {
 
     private final UserMapper userMapper;
-    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     /**
      * 전체 사용자 목록 조회
@@ -33,47 +29,5 @@ public class UserService {
         log.info("[UserService] 전체 사용자 목록 조회");
 
         return userMapper.selectUserList();
-    }
-
-    /**
-     * 아이디 사용 가능 여부 확인
-     * @param username 확인할 아이디
-     * @return 사용 가능 여부
-     */
-    public boolean isUsernameAvailable(String username) {
-        log.debug("[UserService] 아이디 중복 확인 - username: {}", username);
-
-        return userMapper.selectUserByUsername(username) == null;
-    }
-
-    /**
-     * 이메일 사용 가능 여부 확인
-     * @param email 확인할 이메일
-     * @return 사용 가능 여부
-     */
-    public boolean isEmailAvailable(String email) {
-        log.debug("[UserService] 이메일 중복 확인 - email: {}", email);
-
-        return userMapper.selectUserByEmail(email) == null;
-    }
-
-    /**
-     * 회원가입
-     * @param user 회원가입 요청 (username, name, email, password)
-     * @throws BusinessException 아이디 또는 이메일 중복 (409)
-     */
-    @Transactional
-    public void signup(User user) {
-        log.info("[UserService] 회원가입 - username: {}, email: {}", user.getUsername(), user.getEmail());
-
-        if (userMapper.selectUserByUsername(user.getUsername()) != null) {
-            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다.");
-        }
-
-        if (userMapper.selectUserByEmail(user.getEmail()) != null) {
-            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
-        }
-
-        userMapper.insertUser(User.ofSignup(user.getUsername(), user.getName(), user.getEmail(), passwordEncoder.encode(user.getPassword())));
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -33,6 +33,10 @@ logging:
   level:
     com.yujin.course_enrollment: DEBUG
 
+jwt:
+  secret: ${JWT_SECRET}
+  expiration: 900000
+
 toss:
   secret-key: ${TOSS_SECRET_KEY:}
   confirm-url: https://api.tosspayments.com/v1/payments/confirm

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,5 +1,15 @@
 import instance from './axios';
 
+/* 로그인 */
+export const login = (data) => {
+    return instance.post('/api/auth/login', data).then(res => res.data);
+};
+
+/* 로그아웃 */
+export const logout = () => {
+    return instance.post('/api/auth/logout').then(res => res.data);
+};
+
 /* 회원가입 */
 export const signup = (data) => {
     return instance.post('/api/auth/signup', data).then(res => res.data);

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -2,20 +2,10 @@ import axios from 'axios';
 
 const instance = axios.create({
     baseURL: 'http://localhost:8080',
+    withCredentials: true,
     headers: {
         'Content-Type': 'application/json',
     },
-});
-
-/* 요청 인터셉터: localStorage에서 유저 정보를 읽어 X-User-Id 헤더 자동 추가 */
-instance.interceptors.request.use(config => {
-    const user = localStorage.getItem('user');
-
-    if (user) {
-        config.headers['X-User-Id'] = JSON.parse(user).id;
-    }
-    
-    return config;
 });
 
 export default instance;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -11,9 +11,9 @@ const Header = () => {
     const roleLabel = (role) => role === 'CREATOR' ? '강사' : role === 'ADMIN' ? '관리자' : '수강생';
 
     /* 로그아웃 처리 */
-    const handleLogout = () => {
-        logout();
-        navigate('/signup');
+    const handleLogout = async () => {
+        await logout();
+        navigate('/login');
     };
 
     return (
@@ -58,12 +58,20 @@ const Header = () => {
                             </button>
                         </>
                     ) : (
-                        <button
-                            onClick={() => navigate('/signup')}
-                            className="text-sm px-3 py-1.5 rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors cursor-pointer"
-                        >
-                            회원가입
-                        </button>
+                        <>
+                            <button
+                                onClick={() => navigate('/login')}
+                                className="text-sm px-3 py-1.5 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+                            >
+                                로그인
+                            </button>
+                            <button
+                                onClick={() => navigate('/signup')}
+                                className="text-sm px-3 py-1.5 rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors cursor-pointer"
+                            >
+                                회원가입
+                            </button>
+                        </>
                     )}
                 </div>
             </div>

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState } from 'react';
+import { login as loginApi, logout as logoutApi } from '../api/auth';
 
 const AuthContext = createContext(null);
 
@@ -9,14 +10,19 @@ export const AuthProvider = ({ children }) => {
         return saved ? JSON.parse(saved) : null;
     });
 
-    /* 로그인: 선택한 유저를 전역 상태 및 localStorage에 저장 */
-    const login = (selectedUser) => {
-        localStorage.setItem('user', JSON.stringify(selectedUser));
-        setUser(selectedUser);
+    /* 로그인: API 호출 후 응답에서 사용자 정보 저장 */
+    const login = async (username, password) => {
+        const res = await loginApi({ username, password });
+        const userInfo = res.data;
+
+        localStorage.setItem('user', JSON.stringify(userInfo));
+        setUser(userInfo);
     };
 
-    /* 로그아웃: 전역 상태 및 localStorage 초기화 */
-    const logout = () => {
+    /* 로그아웃: API 호출 후 상태 및 localStorage 초기화 */
+    const logout = async () => {
+        await logoutApi();
+        
         localStorage.removeItem('user');
         setUser(null);
     };

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,144 +1,40 @@
 import { useState } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getCreatorRequestList, approveCreatorRequest, rejectCreatorRequest } from '../api/creatorRequest';
+import CreatorRequestTab from './admin/CreatorRequestTab';
 
-/* 상태 라벨/스타일 */
-const statusLabel = (status) => status === 'PENDING' ? '검토 중' : status === 'APPROVED' ? '승인' : '거절';
-const statusStyle = (status) =>
-    status === 'PENDING' ? 'bg-yellow-100 text-yellow-700' :
-    status === 'APPROVED' ? 'bg-green-100 text-green-700' :
-    'bg-red-100 text-red-700';
-
-/* 관리자 페이지 - 강사 신청 목록 */
+/* 관리자 페이지 */
 const AdminPage = () => {
-    /* React Query 클라이언트 */
-    const queryClient = useQueryClient();
-    /* 거절 모달 상태: { id, rejectReason } */
-    const [rejectModal, setRejectModal] = useState(null);
+    /* 현재 활성화된 탭 상태 */
+    const [activeTab, setActiveTab] = useState('creator-requests');
 
-    /* 강사 신청 목록 조회 */
-    const { data: requests = [], isLoading } = useQuery({
-        queryKey: ['creatorRequests'],
-        queryFn: () => getCreatorRequestList().then(res => res.data),
-    });
-
-    /* 승인 */
-    const handleApprove = async (id) => {
-        if (!window.confirm('강사 신청을 승인하시겠습니까?')) return;
-        try {
-            await approveCreatorRequest(id);
-            alert('승인되었습니다.');
-            queryClient.invalidateQueries({ queryKey: ['creatorRequests'] });
-        } catch (err) {
-            alert(err.response?.data?.message || '승인에 실패했습니다.');
-        }
-    };
-
-    /* 거절 */
-    const handleReject = async () => {
-        if (!rejectModal.rejectReason.trim()) {
-            alert('거절 사유를 입력해주세요.');
-            return;
-        }
-        try {
-            await rejectCreatorRequest(rejectModal.id, rejectModal.rejectReason.trim());
-            alert('거절되었습니다.');
-            setRejectModal(null);
-            queryClient.invalidateQueries({ queryKey: ['creatorRequests'] });
-        } catch (err) {
-            alert(err.response?.data?.message || '거절에 실패했습니다.');
-        }
-    };
-
-    if (isLoading) return <div className="max-w-4xl mx-auto mt-10 p-6 text-gray-500">로딩 중...</div>;
+    /* 탭 목록 */
+    const tabs = [
+        { key: 'creator-requests', label: '강사 신청 관리' },
+    ];
 
     return (
         <div className="max-w-4xl mx-auto mt-10 p-6">
-            <h1 className="text-3xl font-extrabold text-gray-900 mb-8">강사 신청 관리</h1>
+            <h1 className="text-3xl font-extrabold text-gray-900 mb-8">관리자 페이지</h1>
 
-            {requests.length === 0 ? (
-                <div className="text-center py-16 text-gray-400">강사 신청 내역이 없습니다.</div>
-            ) : (
-                <div className="flex flex-col gap-4">
-                    {requests.map(req => (
-                        <div key={req.id} className="border border-gray-200 rounded-xl p-5 bg-white shadow-sm">
-                            <div className="flex items-start justify-between gap-4">
-
-                                {/* 신청자 정보 및 사유 */}
-                                <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 mb-1">
-                                        <span className="font-semibold text-gray-900">{req.name}</span>
-                                        <span className="text-sm text-gray-400">@{req.username}</span>
-                                        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusStyle(req.status)}`}>
-                                            {statusLabel(req.status)}
-                                        </span>
-                                    </div>
-                                    <p className="text-sm text-gray-600 mt-2">
-                                        <span className="font-medium text-gray-700">신청 사유</span>
-                                        <span className="mx-2 text-gray-300">|</span>
-                                        {req.reason}
-                                    </p>
-                                    {req.rejectReason && (
-                                        <p className="text-sm text-red-500 mt-1">
-                                            <span className="font-medium">거절 사유</span>
-                                            <span className="mx-2 text-red-300">|</span>
-                                            {req.rejectReason}
-                                        </p>
-                                    )}
-                                    <p className="text-xs text-gray-400 mt-2">
-                                        {new Date(req.requestedAt).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
-                                    </p>
-                                </div>
-
-                                {/* 승인/거절 버튼 */}
-                                {req.status === 'PENDING' && (
-                                    <div className="flex gap-2 shrink-0">
-                                        <button
-                                            onClick={() => handleApprove(req.id)}
-                                            className="px-4 py-1.5 text-sm font-semibold bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors cursor-pointer"
-                                        >
-                                            승인
-                                        </button>
-                                        <button
-                                            onClick={() => setRejectModal({ id: req.id, rejectReason: '' })}
-                                            className="px-4 py-1.5 text-sm font-semibold bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors cursor-pointer"
-                                        >
-                                            거절
-                                        </button>
-                                    </div>
-                                )}
-                            </div>
-
-                            {/* 거절 사유 입력 */}
-                            {rejectModal?.id === req.id && (
-                                <div className="mt-4 pt-4 border-t border-gray-100">
-                                    <textarea
-                                        value={rejectModal.rejectReason}
-                                        onChange={(e) => setRejectModal(prev => ({ ...prev, rejectReason: e.target.value }))}
-                                        placeholder="거절 사유를 입력해주세요."
-                                        rows={2}
-                                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-red-400 resize-none"
-                                    />
-                                    <div className="flex justify-end gap-2 mt-2">
-                                        <button
-                                            onClick={() => setRejectModal(null)}
-                                            className="px-4 py-1.5 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
-                                        >
-                                            취소
-                                        </button>
-                                        <button
-                                            onClick={handleReject}
-                                            className="px-4 py-1.5 text-sm font-semibold bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors cursor-pointer"
-                                        >
-                                            거절하기
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-                        </div>
+            {/* 탭 버튼들 */}
+            <div className="flex items-center border-b border-gray-200 mb-8">
+                <div className="flex gap-1 flex-1">
+                    {tabs.map(tab => (
+                        <button
+                            key={tab.key}
+                            onClick={() => setActiveTab(tab.key)}
+                            className={`px-5 py-2.5 text-sm font-semibold transition-colors cursor-pointer ${activeTab === tab.key
+                                ? 'border-b-2 border-blue-600 text-blue-600'
+                                : 'text-gray-500 hover:text-gray-700'
+                            }`}
+                        >
+                            {tab.label}
+                        </button>
                     ))}
                 </div>
-            )}
+            </div>
+
+            {/* 탭 콘텐츠 */}
+            {activeTab === 'creator-requests' && <CreatorRequestTab />}
         </div>
     );
 };

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
+import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { useUserList } from '../hooks/useUserList';
 
 const LoginPage = () => {
     /* 페이지 이동을 위한 네비게이트 함수 */
@@ -9,20 +9,26 @@ const LoginPage = () => {
     const location = useLocation();
     /* 인증 관련 함수 */
     const { login } = useAuth();
-    /* 유저 목록 조회 */
-    const { data: users = [] } = useUserList();
+    /* 입력 폼 상태 */
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    /* 에러 메시지 */
+    const [error, setError] = useState('');
 
     /* 로그인 후 리다이렉트할 경로 */
     const redirect = location.state?.redirect || '/courses';
-    /* 역할에 따른 라벨 */
-    const roleLabel = (role) => role === 'CREATOR' ? '강사' : role === 'ADMIN' ? '관리자' : '수강생';
-    /* 역할에 따른 스타일 */
-    const roleStyle = (role) => role === 'CREATOR' ? 'bg-blue-100 text-blue-700' : role === 'ADMIN' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700';
 
-    /* 유저 선택 시 로그인 처리 */
-    const handleSelectUser = (user) => {
-        login(user);
-        navigate(redirect, { replace: true });
+    /* 로그인 처리 */
+    const handleLogin = async (e) => {
+        e.preventDefault();
+        setError('');
+
+        try {
+            await login(username, password);
+            navigate(redirect, { replace: true });
+        } catch (err) {
+            setError(err.response?.data?.message || '아이디 또는 비밀번호가 올바르지 않습니다.');
+        }
     };
 
     return (
@@ -30,28 +36,41 @@ const LoginPage = () => {
             <div className="w-full max-w-md">
                 <div className="text-center mb-8">
                     <h1 className="text-3xl font-extrabold text-gray-900 mb-2">로그인</h1>
-                    <p className="text-sm text-gray-500">테스트할 계정을 선택하세요</p>
                 </div>
 
-                <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-                    {users.map((user, index) => (
-                        <button
-                            key={user.id}
-                            onClick={() => handleSelectUser(user)}
-                            className={`w-full flex items-center justify-between px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer text-left ${index !== 0 ? 'border-t border-gray-100' : ''}`}
-                        >
-                            <div className="flex items-center gap-3">
-                                <div className="w-9 h-9 rounded-full bg-gray-100 flex items-center justify-center text-sm font-bold text-gray-500">
-                                    {user.name.charAt(0)}
-                                </div>
-                                <span className="font-medium text-gray-800">{user.name}</span>
-                            </div>
-                            <span className={`text-xs font-semibold px-2 py-1 rounded-full ${roleStyle(user.role)}`}>
-                                {roleLabel(user.role)}
-                            </span>
-                        </button>
-                    ))}
-                </div>
+                <form onSubmit={handleLogin} className="bg-white rounded-xl border border-gray-200 shadow-sm p-8 flex flex-col gap-5">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1.5">아이디</label>
+                        <input
+                            type="text"
+                            value={username}
+                            onChange={(e) => setUsername(e.target.value)}
+                            placeholder="아이디를 입력하세요"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            required
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1.5">비밀번호</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            placeholder="비밀번호를 입력하세요"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            required
+                        />
+                    </div>
+
+                    {error && <p className="text-sm text-red-500">{error}</p>}
+
+                    <button
+                        type="submit"
+                        className="w-full py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors cursor-pointer mt-1"
+                    >
+                        로그인
+                    </button>
+                </form>
 
                 <button
                     onClick={() => navigate('/courses')}

--- a/frontend/src/pages/admin/CreatorRequestTab.jsx
+++ b/frontend/src/pages/admin/CreatorRequestTab.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCreatorRequestList, approveCreatorRequest, rejectCreatorRequest } from '../../api/creatorRequest';
+
+/* 상태 라벨/스타일 */
+const statusLabel = (status) => status === 'PENDING' ? '검토 중' : status === 'APPROVED' ? '승인' : '거절';
+const statusStyle = (status) =>
+    status === 'PENDING' ? 'bg-yellow-100 text-yellow-700' :
+    status === 'APPROVED' ? 'bg-green-100 text-green-700' :
+    'bg-red-100 text-red-700';
+
+/* 강사 신청 관리 탭 */
+const CreatorRequestTab = () => {
+    /* React Query 클라이언트 */
+    const queryClient = useQueryClient();
+    /* 거절 모달 상태: { id, rejectReason } */
+    const [rejectModal, setRejectModal] = useState(null);
+
+    /* 강사 신청 목록 조회 */
+    const { data: requests = [], isLoading } = useQuery({
+        queryKey: ['creatorRequests'],
+        queryFn: () => getCreatorRequestList().then(res => res.data),
+    });
+
+    /* 승인 */
+    const handleApprove = async (id) => {
+        if (!window.confirm('강사 신청을 승인하시겠습니까?')) return;
+
+        try {
+            await approveCreatorRequest(id);
+            alert('승인되었습니다.');
+            queryClient.invalidateQueries({ queryKey: ['creatorRequests'] });
+        } catch (err) {
+            alert(err.response?.data?.message || '승인에 실패했습니다.');
+        }
+    };
+
+    /* 거절 */
+    const handleReject = async () => {
+        if (!rejectModal.rejectReason.trim()) {
+            alert('거절 사유를 입력해주세요.');
+            return;
+        }
+
+        try {
+            await rejectCreatorRequest(rejectModal.id, rejectModal.rejectReason.trim());
+
+            alert('거절되었습니다.');
+            setRejectModal(null);
+            queryClient.invalidateQueries({ queryKey: ['creatorRequests'] });
+        } catch (err) {
+            alert(err.response?.data?.message || '거절에 실패했습니다.');
+        }
+    };
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
+
+    if (requests.length === 0) return (
+        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+            강사 신청 내역이 없습니다.
+        </div>
+    );
+
+    return (
+        <div className="flex flex-col gap-4">
+            {requests.map(req => (
+                <div key={req.id} className="border border-gray-200 rounded-xl p-5 bg-white shadow-sm">
+                    <div className="flex items-start justify-between gap-4">
+
+                        {/* 신청자 정보 및 사유 */}
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 mb-1">
+                                <span className="font-semibold text-gray-900">{req.name}</span>
+                                <span className="text-sm text-gray-400">@{req.username}</span>
+                                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusStyle(req.status)}`}>
+                                    {statusLabel(req.status)}
+                                </span>
+                            </div>
+                            <p className="text-sm text-gray-600 mt-2">
+                                <span className="font-medium text-gray-700">신청 사유</span>
+                                <span className="mx-2 text-gray-300">|</span>
+                                {req.reason}
+                            </p>
+                            {req.rejectReason && (
+                                <p className="text-sm text-red-500 mt-1">
+                                    <span className="font-medium">거절 사유</span>
+                                    <span className="mx-2 text-red-300">|</span>
+                                    {req.rejectReason}
+                                </p>
+                            )}
+                            <p className="text-xs text-gray-400 mt-2">
+                                {new Date(req.requestedAt).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
+                            </p>
+                        </div>
+
+                        {/* 승인/거절 버튼 */}
+                        {req.status === 'PENDING' && (
+                            <div className="flex gap-2 shrink-0">
+                                <button
+                                    onClick={() => handleApprove(req.id)}
+                                    className="px-4 py-1.5 text-sm font-semibold bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors cursor-pointer"
+                                >
+                                    승인
+                                </button>
+                                <button
+                                    onClick={() => setRejectModal({ id: req.id, rejectReason: '' })}
+                                    className="px-4 py-1.5 text-sm font-semibold bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors cursor-pointer"
+                                >
+                                    거절
+                                </button>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* 거절 사유 입력 */}
+                    {rejectModal?.id === req.id && (
+                        <div className="mt-4 pt-4 border-t border-gray-100">
+                            <textarea
+                                value={rejectModal.rejectReason}
+                                onChange={(e) => setRejectModal(prev => ({ ...prev, rejectReason: e.target.value }))}
+                                placeholder="거절 사유를 입력해주세요."
+                                rows={2}
+                                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-red-400 resize-none"
+                            />
+                            <div className="flex justify-end gap-2 mt-2">
+                                <button
+                                    onClick={() => setRejectModal(null)}
+                                    className="px-4 py-1.5 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                                >
+                                    취소
+                                </button>
+                                <button
+                                    onClick={handleReject}
+                                    className="px-4 py-1.5 text-sm font-semibold bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors cursor-pointer"
+                                >
+                                    거절하기
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default CreatorRequestTab;


### PR DESCRIPTION
  ## 작업 내용
  - jjwt 의존성 추가 및 JwtUtil 추가 - AccessToken 생성 및 파싱
  - JwtFilter 추가 - 요청마다 accessToken 쿠키 검증 후 SecurityContext에 인증 정보 설정
  - SecurityConfig 추가 - STATELESS 세션 정책, 역할별 엔드포인트 접근 제어, 미인증 401 / 권한 없음 403 분리
  - POST /api/auth/login — 로그인 성공 시 accessToken httpOnly 쿠키 발급
  - POST /api/auth/logout — accessToken 쿠키 만료 처리
  - 기존 X-User-Id 헤더 방식 제거 -> @AuthenticationPrincipal로 전환
  - 로그인·회원가입 엔드포인트 인증된 사용자 접근 차단 (anonymous())
  - AuthContext 추가 - 로그인 상태 전역 관리
  - 로그인/로그아웃 API 연동 및 쿠키 기반 인증으로 전환
  - axios 인터셉터에서 X-User-Id 헤더 제거
  - 관리자 페이지 탭 구조 개선 (CreatorRequestTab 분리)
  - CORS allowedOrigins 설정 수정

  ## 구현 시 고려한 점
  - JwtFilter를 @Component 대신 SecurityConfig에서 직접 생성해 Security 체인에만 등록 (서블릿 이중 등록 방지)
  - Spring Security 6 방식에 맞게 SecurityContextHolder.createEmptyContext() + setContext()로 SecurityContext 명시적 설정
  - /error 엔드포인트 permitAll 추가 - Spring Boot 에러 dispatch 시 재차 401이 발생하는 문제 해결

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - 로그인 → accessToken 쿠키 발급 확인
  - 인증 없이 보호된 엔드포인트 접근 → 401
  - 잘못된 역할로 접근 (예: STUDENT → CREATOR 전용 엔드포인트) → 403
  - 로그인 상태에서 회원가입 시도 → 403
  - 로그아웃 → 쿠키 만료 확인

  ## 연관 이슈
  Closes #44