### PR TITLE
[feat] RefreshToken 구현 및 역할 기반 라우팅 가드

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         /* H2 콘솔, 인증 엔드포인트는 인증 없이 허용 */
                         .requestMatchers("/h2-console/**", "/error").permitAll()
-                        .requestMatchers("/api/auth/login", "/api/auth/signup").permitAll()
+                        .requestMatchers("/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/signup").anonymous()
                         .requestMatchers("/api/auth/logout", "/api/auth/refresh", "/api/auth/check-username", "/api/auth/check-email").permitAll()
                         /* 강사 전용 */
                         .requestMatchers(HttpMethod.GET, "/api/courses/my", "/api/courses/{courseId}/enrollments").hasRole("CREATOR")

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         /* H2 콘솔, 인증 엔드포인트는 인증 없이 허용 */
                         .requestMatchers("/h2-console/**", "/error").permitAll()
-                        .requestMatchers("/api/auth/login", "/api/auth/signup").anonymous()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup").permitAll()
                         .requestMatchers("/api/auth/logout", "/api/auth/refresh", "/api/auth/check-username", "/api/auth/check-email").permitAll()
                         /* 강사 전용 */
                         .requestMatchers(HttpMethod.GET, "/api/courses/my", "/api/courses/{courseId}/enrollments").hasRole("CREATOR")
@@ -51,8 +51,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/courses/{courseId}/publish", "/api/courses/{courseId}/close").hasRole("CREATOR")
                         /* 강의 목록/상세 조회는 인증 없이 허용 */
                         .requestMatchers(HttpMethod.GET, "/api/courses", "/api/courses/{courseId}").permitAll()
+                        /* 수강생/강사 공통 */
+                        .requestMatchers("/api/enrollments/**", "/api/payments/**").hasAnyRole("STUDENT", "CREATOR")
                         /* 수강생 전용 */
-                        .requestMatchers("/api/enrollments/**", "/api/payments/**").hasRole("STUDENT")
                         .requestMatchers(HttpMethod.POST, "/api/creator-requests").hasRole("STUDENT")
                         /* 관리자 전용 */
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                         /* H2 콘솔, 인증 엔드포인트는 인증 없이 허용 */
                         .requestMatchers("/h2-console/**", "/error").permitAll()
                         .requestMatchers("/api/auth/login", "/api/auth/signup").anonymous()
-                        .requestMatchers("/api/auth/logout", "/api/auth/check-username", "/api/auth/check-email").permitAll()
+                        .requestMatchers("/api/auth/logout", "/api/auth/refresh", "/api/auth/check-username", "/api/auth/check-email").permitAll()
                         /* 강사 전용 */
                         .requestMatchers(HttpMethod.GET, "/api/courses/my", "/api/courses/{courseId}/enrollments").hasRole("CREATOR")
                         .requestMatchers(HttpMethod.POST, "/api/courses").hasRole("CREATOR")

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
@@ -37,6 +38,21 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+
+    /**
+     * 현재 인증된 사용자 정보 조회
+     * GET /api/auth/me
+     * @param userId SecurityContext에서 추출된 사용자 ID
+     * @return 사용자 정보 (id, username, name, role)
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<RespLoginDto>> me(@AuthenticationPrincipal Long userId) {
+        log.debug("[AuthController] 내 정보 조회 - userId: {}", userId);
+
+        User user = authService.getUserById(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(RespLoginDto.from(user)));
+    }
 
     /**
      * 로그인

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
@@ -3,8 +3,11 @@ package com.yujin.course_enrollment.controller;
 import com.yujin.course_enrollment.dto.req.ReqLoginDto;
 import com.yujin.course_enrollment.dto.resp.RespLoginDto;
 import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +42,7 @@ public class AuthController {
      * 로그인
      * POST /api/auth/login
      * @param reqLoginDto 로그인 요청 (username, password)
-     * @param response HTTP 응답 (accessToken httpOnly 쿠키 설정)
+     * @param response HTTP 응답 (accessToken, refreshToken httpOnly 쿠키 설정)
      * @return 사용자 정보 (id, username, name, role)
      */
     @PostMapping("/login")
@@ -47,15 +50,11 @@ public class AuthController {
         log.debug("[AuthController] 로그인 요청 - username: {}", reqLoginDto.getUsername());
 
         User user = authService.login(reqLoginDto.getUsername(), reqLoginDto.getPassword());
-        String token = authService.generateToken(user);
+        String accessToken = authService.generateAccessToken(user);
+        String refreshToken = authService.generateRefreshToken(user.getId());
 
-        ResponseCookie cookie = ResponseCookie.from("accessToken", token)
-                .httpOnly(true)
-                .path("/")
-                .maxAge(Duration.ofMinutes(15))
-                .sameSite("Lax")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, buildAccessTokenCookie(accessToken).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, buildRefreshTokenCookie(refreshToken).toString());
 
         return ResponseEntity.ok(ApiResponse.success(RespLoginDto.from(user)));
     }
@@ -63,20 +62,44 @@ public class AuthController {
     /**
      * 로그아웃
      * POST /api/auth/logout
-     * @param response HTTP 응답 (accessToken 쿠키 삭제)
+     * @param request HTTP 요청 (refreshToken 쿠키 추출)
+     * @param response HTTP 응답 (쿠키 만료 처리)
      * @return 200 OK
      */
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
         log.debug("[AuthController] 로그아웃 요청");
 
-        ResponseCookie cookie = ResponseCookie.from("accessToken", "")
-                .httpOnly(true)
-                .path("/")
-                .maxAge(Duration.ZERO)
-                .sameSite("Lax")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        authService.deleteRefreshToken(extractRefreshToken(request));
+
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie("accessToken").toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie("refreshToken").toString());
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * AccessToken 재발급
+     * POST /api/auth/refresh
+     * @param request HTTP 요청 (refreshToken 쿠키 추출)
+     * @param response HTTP 응답 (새 accessToken, refreshToken 쿠키 설정)
+     * @return 200 OK
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<Void>> refresh(HttpServletRequest request, HttpServletResponse response) {
+        log.debug("[AuthController] 토큰 재발급 요청");
+
+        String refreshToken = extractRefreshToken(request);
+        if (refreshToken == null) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "refreshToken이 없습니다.");
+        }
+
+        User user = authService.validateAndRotateRefreshToken(refreshToken);
+        String newAccessToken = authService.generateAccessToken(user);
+        String newRefreshToken = authService.generateRefreshToken(user.getId());
+
+        response.addHeader(HttpHeaders.SET_COOKIE, buildAccessTokenCookie(newAccessToken).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, buildRefreshTokenCookie(newRefreshToken).toString());
 
         return ResponseEntity.ok(ApiResponse.success());
     }
@@ -120,5 +143,62 @@ public class AuthController {
         authService.signup(user);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created());
+    }
+
+    /**
+     * accessToken httpOnly 쿠키 생성 (15분 유효)
+     * @param value 쿠키에 담을 토큰 값
+     * @return Set-Cookie 헤더용 ResponseCookie
+     */
+    private ResponseCookie buildAccessTokenCookie(String value) {
+        return ResponseCookie.from("accessToken", value)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofMinutes(15))
+                .sameSite("Lax")
+                .build();
+    }
+
+    /**
+     * refreshToken httpOnly 쿠키 생성 (7일 유효)
+     * @param value 쿠키에 담을 토큰 값
+     * @return Set-Cookie 헤더용 ResponseCookie
+     */
+    private ResponseCookie buildRefreshTokenCookie(String value) {
+        return ResponseCookie.from("refreshToken", value)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("Lax")
+                .build();
+    }
+
+    /**
+     * 만료된 쿠키 생성 (로그아웃 시 기존 쿠키 제거용)
+     * @param name 쿠키 이름
+     * @return maxAge=0인 ResponseCookie
+     */
+    private ResponseCookie expiredCookie(String name) {
+        return ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .sameSite("Lax")
+                .build();
+    }
+
+    /**
+     * 요청 쿠키에서 refreshToken 추출
+     * @param request HTTP 요청
+     * @return refreshToken 값, 없으면 null
+     */
+    private String extractRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refreshToken".equals(cookie.getName())) return cookie.getValue();
+        }
+
+        return null;
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
@@ -25,14 +25,52 @@ public class AuthService {
     private final UserMapper userMapper;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * AccessToken 생성
      * @param user 인증된 사용자 엔티티
-     * @return 서명된 JWT 문자열
+     * @return 서명된 JWT accessToken 문자열
      */
-    public String generateToken(User user) {
+    public String generateAccessToken(User user) {
         return jwtUtil.generateToken(user.getId(), user.getRole());
+    }
+
+    /**
+     * RefreshToken 생성 후 Redis 저장
+     * @param userId 사용자 ID
+     * @return 생성된 refreshToken (UUID)
+     */
+    public String generateRefreshToken(Long userId) {
+        return refreshTokenService.save(userId);
+    }
+
+    /**
+     * RefreshToken 검증 → 사용자 조회 + RefreshToken 삭제 (rotation은 컨트롤러에서 완성)
+     * @param refreshToken 기존 refreshToken
+     * @return 검증된 사용자 엔티티
+     * @throws BusinessException 유효하지 않은 토큰 (401), 사용자 없음 (401)
+     */
+    public User validateAndRotateRefreshToken(String refreshToken) {
+        Long userId = refreshTokenService.getUserId(refreshToken);
+        User user = userMapper.selectUserById(userId);
+        if (user == null) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다.");
+        }
+
+        refreshTokenService.delete(refreshToken);
+
+        return user;
+    }
+
+    /**
+     * RefreshToken 삭제 (로그아웃)
+     * @param refreshToken 삭제할 refreshToken (null이면 무시)
+     */
+    public void deleteRefreshToken(String refreshToken) {
+        if (refreshToken != null) {
+            refreshTokenService.delete(refreshToken);
+        }
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
@@ -46,6 +46,21 @@ public class AuthService {
     }
 
     /**
+     * 사용자 ID로 사용자 조회
+     * @param id 사용자 ID
+     * @return 사용자 엔티티
+     * @throws BusinessException 사용자 없음 (401)
+     */
+    public User getUserById(Long id) {
+        User user = userMapper.selectUserById(id);
+        if (user == null) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다.");
+        }
+
+        return user;
+    }
+
+    /**
      * RefreshToken 검증 → 사용자 조회 + RefreshToken 삭제 (rotation은 컨트롤러에서 완성)
      * @param refreshToken 기존 refreshToken
      * @return 검증된 사용자 엔티티

--- a/backend/src/main/java/com/yujin/course_enrollment/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/RefreshTokenService.java
@@ -1,0 +1,65 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * RefreshToken 서비스
+ * Redis에 RefreshToken을 저장/조회/삭제
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final Duration TTL = Duration.ofDays(7);
+    private static final String PREFIX = "RT:";
+
+    /**
+     * RefreshToken 생성 후 Redis에 저장
+     * @param userId 사용자 ID
+     * @return 생성된 refreshToken (UUID)
+     */
+    public String save(Long userId) {
+        String token = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(PREFIX + token, String.valueOf(userId), TTL);
+
+        log.debug("[RefreshTokenService] RefreshToken 저장 - userId: {}", userId);
+        return token;
+    }
+
+    /**
+     * RefreshToken 검증 후 userId 반환
+     * @param token refreshToken
+     * @return 토큰에 매핑된 사용자 ID
+     * @throws BusinessException 유효하지 않은 토큰 (401)
+     */
+    public Long getUserId(String token) {
+        String value = redisTemplate.opsForValue().get(PREFIX + token);
+
+        if (value == null) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "유효하지 않은 refreshToken입니다.");
+        }
+
+        return Long.parseLong(value);
+    }
+
+    /**
+     * RefreshToken 삭제
+     * @param token 삭제할 refreshToken
+     */
+    public void delete(String token) {
+        redisTemplate.delete(PREFIX + token);
+
+        log.debug("[RefreshTokenService] RefreshToken 삭제 완료");
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -19,6 +19,11 @@ spring:
       schema-locations: classpath:sql/schema.sql
       data-locations: classpath:sql/data.sql
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   jackson:
     time-zone: Asia/Seoul
 

--- a/backend/src/test/java/com/yujin/course_enrollment/security/AuthRefreshIntegrationTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/security/AuthRefreshIntegrationTest.java
@@ -1,0 +1,136 @@
+package com.yujin.course_enrollment.security;
+
+import com.yujin.course_enrollment.service.RefreshTokenService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.springframework.http.MediaType;
+
+/**
+ * /api/auth/refresh 엔드포인트 통합 테스트
+ * 실제 Redis 연결로 token rotation 동작 검증
+ */
+@SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@AutoConfigureMockMvc
+class AuthRefreshIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @AfterEach
+    void cleanup() {
+        Set<String> keys = redisTemplate.keys("RT:*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("refreshToken 쿠키 없음 - 401")
+    void noRefreshToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 refreshToken - 401")
+    void invalidRefreshToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie("refreshToken", "invalid-token")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("유효한 refreshToken - 200 + 새 accessToken/refreshToken 쿠키 발급")
+    void validRefreshToken_returns200_withNewCookies() throws Exception {
+        // given: userId=1 (creator_a, data.sql에 존재)
+        String oldToken = refreshTokenService.save(1L);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie("refreshToken", oldToken)))
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    List<String> cookies = result.getResponse().getHeaders("Set-Cookie");
+                    assertThat(cookies)
+                            .anyMatch(c -> c.startsWith("accessToken="))
+                            .anyMatch(c -> c.startsWith("refreshToken="));
+                });
+
+        // then: 기존 refreshToken Redis에서 삭제 (rotation)
+        assertThat(redisTemplate.opsForValue().get("RT:" + oldToken)).isNull();
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - 200 + accessToken/refreshToken 쿠키 발급")
+    void login_success_returns200WithCookies() throws Exception {
+        // given: creator_a / Test1234! (data.sql)
+        String body = "{\"username\":\"creator_a\",\"password\":\"Test1234!\"}";
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    List<String> cookies = result.getResponse().getHeaders("Set-Cookie");
+                    assertThat(cookies)
+                            .anyMatch(c -> c.startsWith("accessToken=") && !c.contains("Max-Age=0"))
+                            .anyMatch(c -> c.startsWith("refreshToken=") && !c.contains("Max-Age=0"));
+                });
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 비밀번호 → 401")
+    void login_wrongPassword_returns401() throws Exception {
+        // given
+        String body = "{\"username\":\"creator_a\",\"password\":\"wrongpassword\"}";
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 200 + 쿠키 만료 + Redis 삭제")
+    void logout_expiresCookiesAndDeletesToken() throws Exception {
+        // given
+        String refreshToken = refreshTokenService.save(1L);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/logout")
+                        .cookie(new Cookie("refreshToken", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    List<String> cookies = result.getResponse().getHeaders("Set-Cookie");
+                    assertThat(cookies)
+                            .anyMatch(c -> c.startsWith("accessToken=") && c.contains("Max-Age=0"))
+                            .anyMatch(c -> c.startsWith("refreshToken=") && c.contains("Max-Age=0"));
+                });
+
+        // then: Redis에서 refreshToken 삭제 확인
+        assertThat(redisTemplate.opsForValue().get("RT:" + refreshToken)).isNull();
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/security/SecurityIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.yujin.course_enrollment.security;
+
+import com.yujin.course_enrollment.config.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Spring Security 통합 테스트
+ * JWT 인증/인가 필터 및 접근 제어 규칙 검증
+ */
+@SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@AutoConfigureMockMvc
+class SecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Test
+    @DisplayName("토큰 없음 - 보호된 엔드포인트 접근 시 401")
+    void noToken_protectedEndpoint_returns401() throws Exception {
+        mockMvc.perform(post("/api/courses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 - 보호된 엔드포인트 접근 시 401")
+    void invalidToken_protectedEndpoint_returns401() throws Exception {
+        mockMvc.perform(post("/api/courses")
+                        .cookie(new Cookie("accessToken", "invalid.jwt.token"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("STUDENT 역할로 강사 전용 엔드포인트 접근 - 403")
+    void studentRole_creatorEndpoint_returns403() throws Exception {
+        String token = jwtUtil.generateToken(1L, "STUDENT");
+
+        mockMvc.perform(post("/api/courses")
+                        .cookie(new Cookie("accessToken", token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("CREATOR 토큰으로 강사 전용 엔드포인트 접근 - Security 통과 (401/403 아님)")
+    void creatorToken_creatorEndpoint_passesSecurity() throws Exception {
+        String token = jwtUtil.generateToken(1L, "CREATOR");
+
+        mockMvc.perform(post("/api/courses")
+                        .cookie(new Cookie("accessToken", token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(result ->
+                        assertThat(result.getResponse().getStatus())
+                                .isNotEqualTo(401)
+                                .isNotEqualTo(403));
+    }
+
+    @Test
+    @DisplayName("ADMIN 역할로 수강생 전용 엔드포인트 접근 - 403")
+    void adminRole_studentEndpoint_returns403() throws Exception {
+        String token = jwtUtil.generateToken(1L, "ADMIN");
+
+        mockMvc.perform(get("/api/enrollments")
+                        .cookie(new Cookie("accessToken", token)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 회원가입 시도 - 403")
+    void authenticatedUser_signup_returns403() throws Exception {
+        String token = jwtUtil.generateToken(1L, "STUDENT");
+
+        mockMvc.perform(post("/api/auth/signup")
+                        .cookie(new Cookie("accessToken", token))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"newuser\",\"password\":\"pass\",\"name\":\"테스트\",\"email\":\"test@test.com\"}"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/AuthServiceTest.java
@@ -1,0 +1,181 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.config.JwtUtil;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * 인증 서비스 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() {
+        // given
+        User user = User.builder().id(1L).username("user1").password("encoded").role("STUDENT").build();
+        given(userMapper.selectUserByUsername("user1")).willReturn(user);
+        given(passwordEncoder.matches("raw", "encoded")).willReturn(true);
+
+        // when
+        User result = authService.login("user1", "raw");
+
+        // then
+        assertThat(result.getUsername()).isEqualTo("user1");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 존재하지 않는 아이디")
+    void login_userNotFound() {
+        // given
+        given(userMapper.selectUserByUsername("unknown")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("unknown", "any"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("아이디 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void login_wrongPassword() {
+        // given
+        User user = User.builder().id(1L).username("user1").password("encoded").build();
+        given(userMapper.selectUserByUsername("user1")).willReturn(user);
+        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.login("user1", "wrong"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("아이디 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("아이디 사용 가능 - 미등록 아이디")
+    void isUsernameAvailable_true() {
+        // given
+        given(userMapper.selectUserByUsername("newuser")).willReturn(null);
+
+        // when & then
+        assertThat(authService.isUsernameAvailable("newuser")).isTrue();
+    }
+
+    @Test
+    @DisplayName("아이디 사용 불가 - 이미 등록된 아이디")
+    void isUsernameAvailable_false() {
+        // given
+        given(userMapper.selectUserByUsername("existing")).willReturn(User.builder().build());
+
+        // when & then
+        assertThat(authService.isUsernameAvailable("existing")).isFalse();
+    }
+
+    @Test
+    @DisplayName("이메일 사용 가능 - 미등록 이메일")
+    void isEmailAvailable_true() {
+        // given
+        given(userMapper.selectUserByEmail("new@test.com")).willReturn(null);
+
+        // when & then
+        assertThat(authService.isEmailAvailable("new@test.com")).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 사용 불가 - 이미 등록된 이메일")
+    void isEmailAvailable_false() {
+        // given
+        given(userMapper.selectUserByEmail("dup@test.com")).willReturn(User.builder().build());
+
+        // when & then
+        assertThat(authService.isEmailAvailable("dup@test.com")).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signup_success() {
+        // given
+        User newUser = User.builder().username("newuser").name("이름").email("new@test.com").password("raw").build();
+        given(userMapper.selectUserByUsername("newuser")).willReturn(null);
+        given(userMapper.selectUserByEmail("new@test.com")).willReturn(null);
+        given(passwordEncoder.encode("raw")).willReturn("encoded");
+        willDoNothing().given(userMapper).insertUser(any());
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> authService.signup(newUser));
+        then(userMapper).should().insertUser(any());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 아이디 중복")
+    void signup_usernameConflict() {
+        // given
+        User newUser = User.builder().username("dup").name("이름").email("new@test.com").password("raw").build();
+        given(userMapper.selectUserByUsername("dup")).willReturn(User.builder().build());
+
+        // when & then
+        assertThatThrownBy(() -> authService.signup(newUser))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 사용 중인 아이디입니다.");
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    void signup_emailConflict() {
+        // given
+        User newUser = User.builder().username("newuser").name("이름").email("dup@test.com").password("raw").build();
+        given(userMapper.selectUserByUsername("newuser")).willReturn(null);
+        given(userMapper.selectUserByEmail("dup@test.com")).willReturn(User.builder().build());
+
+        // when & then
+        assertThatThrownBy(() -> authService.signup(newUser))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("이미 사용 중인 이메일입니다.");
+    }
+
+    @Test
+    @DisplayName("로그아웃 - refreshToken 삭제")
+    void deleteRefreshToken_withToken() {
+        // when
+        authService.deleteRefreshToken("some-token");
+
+        // then
+        then(refreshTokenService).should().delete("some-token");
+    }
+
+    @Test
+    @DisplayName("로그아웃 - refreshToken null이면 삭제 생략")
+    void deleteRefreshToken_withNull() {
+        // when
+        authService.deleteRefreshToken(null);
+
+        // then
+        then(refreshTokenService).should(never()).delete(any());
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 수강 신청 동시성 통합 테스트
  * 실제 DB의 조건부 UPDATE(enrolled_count < capacity)가 동시 요청에서 정원 초과를 막는지 검증
  */
-@SpringBootTest
+@SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 class EnrollmentConcurrencyTest {
 
     @Autowired

--- a/backend/src/test/java/com/yujin/course_enrollment/service/RefreshTokenServiceIntegrationTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/RefreshTokenServiceIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * RefreshToken 서비스 Redis 통합 테스트
+ * 실제 Redis 연결로 저장/조회/삭제/TTL 동작 검증
+ */
+@SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+class RefreshTokenServiceIntegrationTest {
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @AfterEach
+    void cleanup() {
+        Set<String> keys = redisTemplate.keys("RT:*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("RefreshToken 저장 - Redis에 정상 저장")
+    void save_storesTokenInRedis() {
+        // when
+        String token = refreshTokenService.save(1L);
+
+        // then
+        String value = redisTemplate.opsForValue().get("RT:" + token);
+        assertThat(value).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("RefreshToken 조회 - 저장된 토큰에서 userId 반환")
+    void getUserId_returnsUserId() {
+        // given
+        String token = refreshTokenService.save(42L);
+
+        // when
+        Long userId = refreshTokenService.getUserId(token);
+
+        // then
+        assertThat(userId).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 조회 - 401 예외")
+    void getUserId_invalidToken_throws401() {
+        assertThatThrownBy(() -> refreshTokenService.getUserId("nonexistent-token"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("유효하지 않은 refreshToken입니다.");
+    }
+
+    @Test
+    @DisplayName("RefreshToken 삭제 - Redis에서 제거")
+    void delete_removesTokenFromRedis() {
+        // given
+        String token = refreshTokenService.save(1L);
+
+        // when
+        refreshTokenService.delete(token);
+
+        // then
+        assertThat(redisTemplate.opsForValue().get("RT:" + token)).isNull();
+    }
+
+    @Test
+    @DisplayName("RefreshToken TTL - 7일 이하로 설정")
+    void save_setsTtlWithinSevenDays() {
+        // when
+        String token = refreshTokenService.save(1L);
+
+        // then
+        Long ttl = redisTemplate.getExpire("RT:" + token);
+        assertThat(ttl)
+                .isGreaterThan(0)
+                .isLessThanOrEqualTo(Duration.ofDays(7).getSeconds());
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,11 +14,21 @@ import PaymentFailPage from './pages/PaymentFailPage'
 /* 비회원도 접근 가능한 공개 라우트 */
 const PublicRoute = ({ children }) => <Layout>{children}</Layout>;
 
-/* 인증 여부에 따라 라우트 보호 및 공통 레이아웃 적용 */
+/* 인증된 사용자 전용 라우트 */
 const PrivateRoute = ({ children }) => {
     const { user } = useAuth();
 
     return user ? <Layout>{children}</Layout> : <Navigate to="/login" replace />;
+};
+
+/* STUDENT/CREATOR 전용 라우트 - ADMIN은 /admin으로 리다이렉트 */
+const StudentRoute = ({ children }) => {
+    const { user } = useAuth();
+
+    if (!user) return <Navigate to="/login" replace />;
+    if (user.role === 'ADMIN') return <Navigate to="/admin" replace />;
+
+    return <Layout>{children}</Layout>;
 };
 
 /* CREATOR 권한 전용 라우트 */
@@ -36,27 +46,38 @@ const AdminRoute = ({ children }) => {
     const { user } = useAuth();
 
     if (!user) return <Navigate to="/login" replace />;
-    if (user.role !== 'ADMIN') return <Navigate to="/courses" replace />;
+    if (user.role !== 'ADMIN') return <Navigate to="/my-page" replace />;
 
     return <Layout>{children}</Layout>;
 };
 
+/* 인증 초기화 완료 후 라우트 렌더링 */
+function AppRoutes() {
+    const { isInitializing } = useAuth();
+
+    if (isInitializing) return null;
+
+    return (
+        <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/courses" element={<PublicRoute><CourseListPage /></PublicRoute>} />
+            <Route path="/courses/:courseId" element={<PublicRoute><CourseDetailPage /></PublicRoute>} />
+            <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
+            <Route path="/courses/:courseId/edit" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
+            <Route path="/my-page" element={<StudentRoute><MyPage /></StudentRoute>} />
+            <Route path="/admin" element={<AdminRoute><AdminPage /></AdminRoute>} />
+            <Route path="/payment/success" element={<PrivateRoute><PaymentSuccessPage /></PrivateRoute>} />
+            <Route path="/payment/fail" element={<PrivateRoute><PaymentFailPage /></PrivateRoute>} />
+            <Route path="*" element={<Navigate to="/courses" replace />} />
+        </Routes>
+    );
+}
+
 function App() {
     return (
         <AuthProvider>
-            <Routes>
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/signup" element={<SignupPage />} />
-                <Route path="/courses" element={<PublicRoute><CourseListPage /></PublicRoute>} />
-                <Route path="/courses/:courseId" element={<PublicRoute><CourseDetailPage /></PublicRoute>} />
-                <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
-                <Route path="/courses/:courseId/edit" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />
-                <Route path="/my-page" element={<PrivateRoute><MyPage /></PrivateRoute>} />
-                <Route path="/admin" element={<AdminRoute><AdminPage /></AdminRoute>} />
-                <Route path="/payment/success" element={<PrivateRoute><PaymentSuccessPage /></PrivateRoute>} />
-                <Route path="/payment/fail" element={<PrivateRoute><PaymentFailPage /></PrivateRoute>} />
-                <Route path="*" element={<Navigate to="/courses" replace />} />
-            </Routes>
+            <AppRoutes />
         </AuthProvider>
     )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,13 @@ import PaymentFailPage from './pages/PaymentFailPage'
 /* 비회원도 접근 가능한 공개 라우트 */
 const PublicRoute = ({ children }) => <Layout>{children}</Layout>;
 
+/* 비인증 전용 라우트 - 로그인 상태면 /courses로 리다이렉트 */
+const GuestRoute = ({ children }) => {
+    const { user } = useAuth();
+
+    return user ? <Navigate to="/courses" replace /> : children;
+};
+
 /* 인증된 사용자 전용 라우트 */
 const PrivateRoute = ({ children }) => {
     const { user } = useAuth();
@@ -59,8 +66,8 @@ function AppRoutes() {
 
     return (
         <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/login" element={<GuestRoute><LoginPage /></GuestRoute>} />
+            <Route path="/signup" element={<GuestRoute><SignupPage /></GuestRoute>} />
             <Route path="/courses" element={<PublicRoute><CourseListPage /></PublicRoute>} />
             <Route path="/courses/:courseId" element={<PublicRoute><CourseDetailPage /></PublicRoute>} />
             <Route path="/courses/new" element={<CreatorRoute><CourseRegisterPage /></CreatorRoute>} />

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -12,37 +12,6 @@ const instance = axios.create({
     },
 });
 
-/* 응답 인터셉터: 401 Unauthorized 응답 시 자동으로 토큰 갱신 시도
- * - refresh/login 요청 자체거나 이미 재시도한 경우는 그대로 reject
- * - refresh 성공 시 원래 요청 재시도
- * - refresh 실패 시 로컬 스토리지에서 사용자 정보 제거 후 로그인 페이지로 리다이렉트 */
-instance.interceptors.response.use(
-    res => res,
-    async error => {
-        const original = error.config;
-
-        if (
-            error.response?.status !== 401 ||
-            original._retry ||
-            original.url === '/api/auth/refresh' ||
-            original.url === '/api/auth/login'
-        ) {
-            return Promise.reject(error);
-        }
-
-        original._retry = true;
-
-        try {
-            await instance.post('/api/auth/refresh');
-            return instance(original);
-        } catch {
-            localStorage.removeItem('user');
-            window.location.href = '/login';
-            return Promise.reject(error);
-        }
-    }
-);
-
 /* 인터셉터 없는 인스턴스 — 앱 초기화 시 인증 상태 확인 전용 */
 export const plainAxios = axios.create({
     baseURL: 'http://localhost:8080',

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,11 +1,54 @@
 import axios from 'axios';
 
+/* Axios 인스턴스 설정
+ * - baseURL: API 서버 주소
+ * - withCredentials: 쿠키 자동 포함
+ * - headers: JSON 요청 기본값 */
 const instance = axios.create({
     baseURL: 'http://localhost:8080',
     withCredentials: true,
     headers: {
         'Content-Type': 'application/json',
     },
+});
+
+/* 응답 인터셉터: 401 Unauthorized 응답 시 자동으로 토큰 갱신 시도
+ * - refresh/login 요청 자체거나 이미 재시도한 경우는 그대로 reject
+ * - refresh 성공 시 원래 요청 재시도
+ * - refresh 실패 시 로컬 스토리지에서 사용자 정보 제거 후 로그인 페이지로 리다이렉트 */
+instance.interceptors.response.use(
+    res => res,
+    async error => {
+        const original = error.config;
+
+        if (
+            error.response?.status !== 401 ||
+            original._retry ||
+            original.url === '/api/auth/refresh' ||
+            original.url === '/api/auth/login'
+        ) {
+            return Promise.reject(error);
+        }
+
+        original._retry = true;
+
+        try {
+            await instance.post('/api/auth/refresh');
+            return instance(original);
+        } catch {
+            localStorage.removeItem('user');
+            window.location.href = '/login';
+            return Promise.reject(error);
+        }
+    }
+);
+
+/* 인터셉터 없는 인스턴스 — 앱 초기화 시 인증 상태 확인 전용 */
+export const plainAxios = axios.create({
+    baseURL: 'http://localhost:8080',
+    withCredentials: true,
+    headers: { 'Content-Type': 'application/json' },
+    validateStatus: s => s < 500,
 });
 
 export default instance;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,24 +1,68 @@
-import { createContext, useContext, useState, useEffect, useRef } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { login as loginApi, logout as logoutApi } from '../api/auth';
-import { plainAxios } from '../api/axios';
+import instance, { plainAxios } from '../api/axios';
 
 /* 인증 컨텍스트 */
 const AuthContext = createContext(null);
 
+/* StrictMode 이중 실행 방지 — useRef는 remount 시 초기화되므로 모듈 레벨 변수 사용 */
+let didAuthInit = false;
+
 export const AuthProvider = ({ children }) => {
+    /* 네비게이션 훅 */
+    const navigate = useNavigate();
     /* 현재 로그인한 사용자 정보 상태 */
     const [user, setUser] = useState(null);
     /* 앱 초기 구동 시 서버 인증 상태 확인 완료 여부 */
     const [isInitializing, setIsInitializing] = useState(true);
-    /* StrictMode 이중 실행 방지 — refreshToken rotation 충돌 방어 */
-    const initRef = useRef(false);
 
-    /* 앱 마운트 시 서버에서 토큰 유효성 및 사용자 정보 검증
-     * validateStatus로 인터셉터 개입 없이 직접 401/200 처리 */
+    /* 응답 인터셉터: 401 Unauthorized 응답 시 자동으로 토큰 갱신 시도
+     * - refresh/login 요청 자체거나 이미 재시도한 경우는 그대로 reject
+     * - refresh 성공 시 원래 요청 재시도
+     * - refresh 실패 시 로컬 스토리지에서 사용자 정보 제거 후 로그인 페이지로 리다이렉트 */
     useEffect(() => {
-        if (initRef.current) return;
+        const id = instance.interceptors.response.use(
+            res => res,
+            async error => {
+                const original = error.config;
 
-        initRef.current = true;
+                if (
+                    error.response?.status !== 401 ||
+                    original._retry ||
+                    original.url === '/api/auth/refresh' ||
+                    original.url === '/api/auth/login'
+                ) {
+                    return Promise.reject(error);
+                }
+
+                original._retry = true;
+
+                try {
+                    await instance.post('/api/auth/refresh');
+                    return instance(original);
+                } catch {
+                    localStorage.removeItem('user');
+                    setUser(null);
+                    navigate('/login', { replace: true });
+                    return Promise.reject(error);
+                }
+            }
+        );
+
+        return () => instance.interceptors.response.eject(id);
+    }, [navigate]);
+
+    /* 앱 초기 구동 시 서버 인증 상태 확인
+     * - localStorage에 사용자 정보가 없으면 바로 초기화 완료 처리
+     * - 있으면 /api/auth/me로 인증 상태 확인 시도
+     *   - 401 응답 시 토큰 갱신 시도 후 재확인
+     *   - 성공 시 사용자 정보 상태 및 localStorage에 저장
+     *   - 실패 시 사용자 정보 제거 */
+    useEffect(() => {
+        if (didAuthInit) return;
+
+        didAuthInit = true;
 
         if (!localStorage.getItem('user')) {
             setIsInitializing(false);
@@ -26,26 +70,29 @@ export const AuthProvider = ({ children }) => {
         }
 
         const init = async () => {
+            localStorage.removeItem('user');
+
             try {
-                let res = await plainAxios.get('/api/auth/me');
+                let res = await plainAxios.get('/api/auth/me', {
+                    headers: { 'Cache-Control': 'no-cache' },
+                });
 
                 if (res.status === 401) {
                     const refreshRes = await plainAxios.post('/api/auth/refresh');
 
-                    if (refreshRes.status !== 200) throw new Error('refresh failed');
-                    
-                    res = await plainAxios.get('/api/auth/me');
+                    if (refreshRes.status === 200) {
+                        res = await plainAxios.get('/api/auth/me', {
+                            headers: { 'Cache-Control': 'no-cache' },
+                        });
+                    }
                 }
 
                 if (res.status === 200) {
                     setUser(res.data.data);
                     localStorage.setItem('user', JSON.stringify(res.data.data));
-                } else {
-                    throw new Error('me failed');
                 }
             } catch {
-                setUser(null);
-                localStorage.removeItem('user');
+                /* network error — user stays null */
             } finally {
                 setIsInitializing(false);
             }
@@ -78,4 +125,5 @@ export const AuthProvider = ({ children }) => {
     );
 };
 
+/* 인증 컨텍스트 훅 */
 export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,14 +1,58 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { login as loginApi, logout as logoutApi } from '../api/auth';
+import { plainAxios } from '../api/axios';
 
+/* 인증 컨텍스트 */
 const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
-    /* localStorage에서 초기 유저 상태 복원 */
-    const [user, setUser] = useState(() => {
-        const saved = localStorage.getItem('user');
-        return saved ? JSON.parse(saved) : null;
-    });
+    /* 현재 로그인한 사용자 정보 상태 */
+    const [user, setUser] = useState(null);
+    /* 앱 초기 구동 시 서버 인증 상태 확인 완료 여부 */
+    const [isInitializing, setIsInitializing] = useState(true);
+    /* StrictMode 이중 실행 방지 — refreshToken rotation 충돌 방어 */
+    const initRef = useRef(false);
+
+    /* 앱 마운트 시 서버에서 토큰 유효성 및 사용자 정보 검증
+     * validateStatus로 인터셉터 개입 없이 직접 401/200 처리 */
+    useEffect(() => {
+        if (initRef.current) return;
+
+        initRef.current = true;
+
+        if (!localStorage.getItem('user')) {
+            setIsInitializing(false);
+            return;
+        }
+
+        const init = async () => {
+            try {
+                let res = await plainAxios.get('/api/auth/me');
+
+                if (res.status === 401) {
+                    const refreshRes = await plainAxios.post('/api/auth/refresh');
+
+                    if (refreshRes.status !== 200) throw new Error('refresh failed');
+                    
+                    res = await plainAxios.get('/api/auth/me');
+                }
+
+                if (res.status === 200) {
+                    setUser(res.data.data);
+                    localStorage.setItem('user', JSON.stringify(res.data.data));
+                } else {
+                    throw new Error('me failed');
+                }
+            } catch {
+                setUser(null);
+                localStorage.removeItem('user');
+            } finally {
+                setIsInitializing(false);
+            }
+        };
+
+        init();
+    }, []);
 
     /* 로그인: API 호출 후 응답에서 사용자 정보 저장 */
     const login = async (username, password) => {
@@ -22,13 +66,13 @@ export const AuthProvider = ({ children }) => {
     /* 로그아웃: API 호출 후 상태 및 localStorage 초기화 */
     const logout = async () => {
         await logoutApi();
-        
+
         localStorage.removeItem('user');
         setUser(null);
     };
 
     return (
-        <AuthContext.Provider value={{ user, login, logout }}>
+        <AuthContext.Provider value={{ user, isInitializing, login, logout }}>
             {children}
         </AuthContext.Provider>
     );

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,4 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ['@tosspayments/tosspayments-sdk'],
-  },
 })


### PR DESCRIPTION
  ## 작업 내용
  - RefreshToken 발급·저장(Redis)·검증·rotation 구현
  - POST /api/auth/refresh - RefreshToken으로 AccessToken 재발급, token rotation 적용
  - GET /api/auth/me 엔드포인트 추가 - 현재 인증된 사용자 정보 조회 엔드포인트 추가
  - plainAxios 인스턴스 추가 - 인터셉터 없이 초기화 전용 인증 검증
  - AuthContext 초기화 시 서버에서 토큰 유효성 검증 및 만료 시 자동 갱신
  - useRef로 StrictMode 이중 실행 방지 - refreshToken rotation 충돌 해결
  - GuestRoute 추가 - 로그인 상태에서 /login·/signup 접근 시 /courses 리다이렉트
  - axios 인터셉터 - 401 발생 시 자동 토큰 갱신 후 원래 요청 재시도, 실패 시 /login 리다이렉트
  - StudentRoute / AdminRoute / AppRoutes 컴포넌트 추가 - 역할 기반 라우팅 가드
  - ADMIN → /my-page 접근 시 /admin 리다이렉트, STUDENT/CREATOR → /admin 접근 시 /my-page 리다이렉트
  - CREATOR 수강 신청·결제 API 권한 추가 (hasAnyRole("STUDENT", "CREATOR"))
  - /api/auth/login permitAll, /api/auth/signup anonymous()로 분리
  - Toss SDK optimizeDeps.exclude 제거로 Vite dev server 503 오류 수정
  - AuthService·RefreshTokenService 단위 테스트, 로그인/로그아웃/재발급 통합 테스트 추가

  ## 구현 시 고려한 점
  - 앱 초기화 시에만 서버 인증 검증 수행 - 이후 요청은 axios 인터셉터가 자동 토큰 갱신 처리
  - plainAxios(validateStatus: s => s < 500)로 401/200을 예외 없이 직접 처리해 인터셉터와 충돌 방지
  - StrictMode에서 useEffect 이중 실행 시 두 init()이 동시에 refreshToken rotation을 시도해 두 번째 갱신이 실패하는 문제를 모듈 레벨 변수로 해결
  - init() 인증 실패 판단을 throw/catch가 아닌 상태 코드 조건 분기로 처리 - finally의 무조건 실행 보장을 활용해 라우트 가드가 리다이렉트를 결정하도록 책임 분리
  - token rotation 적용 - 재발급 시 기존 RefreshToken 즉시 삭제 후 신규 발급으로 탈취 대응

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - accessToken 쿠키 삭제 후 새로고침 → 자동 갱신 후 페이지 유지 확인
  - accessToken + refreshToken 쿠키 모두 삭제 후 새로고침 1회 → /login 리다이렉트 확인
  - ADMIN → /my-page 접근 시 /admin 리다이렉트 확인
  - STUDENT/CREATOR → /admin 접근 시 /my-page 리다이렉트 확인
  - 로그인 상태에서 /login·/signup 접근 시 /courses 리다이렉트 확인
  - 결제 버튼 반복 클릭 시 Vite 503 없음 확인

  ## 연관 이슈
  Closes #46