### PR TITLE
[feat] 프로필 수정 및 비밀번호 변경 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/courses", "/api/courses/{courseId}").permitAll()
                         /* 수강생/강사 공통 */
                         .requestMatchers("/api/enrollments/**", "/api/payments/**").hasAnyRole("STUDENT", "CREATOR")
+                        /* 프로필 수정 (STUDENT / CREATOR 전용) */
+                        .requestMatchers(HttpMethod.PATCH, "/api/users/me", "/api/users/me/password").hasAnyRole("STUDENT", "CREATOR")
                         /* 수강생 전용 */
                         .requestMatchers(HttpMethod.POST, "/api/creator-requests").hasRole("STUDENT")
                         /* 관리자 전용 */

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -1,0 +1,43 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
+import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 컨트롤러
+ * 관리자 전용 HTTP 요청을 처리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+
+    /**
+     * 관리자 비밀번호 변경
+     * PATCH /api/admin/me/password
+     * @param userId SecurityContext에서 추출된 관리자 ID
+     * @param reqUpdatePasswordDto 현재 비밀번호·새 비밀번호
+     * @return 200 OK
+     */
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(@AuthenticationPrincipal Long userId, @Valid @RequestBody ReqUpdatePasswordDto reqUpdatePasswordDto) {
+        log.debug("[AdminController] 비밀번호 변경 - userId: {}", userId);
+
+        userService.updatePassword(userId, reqUpdatePasswordDto.getCurrentPassword(), reqUpdatePasswordDto.getNewPassword());
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/UserController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/UserController.java
@@ -1,12 +1,18 @@
 package com.yujin.course_enrollment.controller;
 
+import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
+import com.yujin.course_enrollment.dto.req.ReqUpdateProfileDto;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,8 +38,38 @@ public class UserController {
     public ResponseEntity<ApiResponse<List<User>>> getUserList() {
         log.debug("[UserController] 전체 사용자 목록 조회 요청");
 
-        List<User> users = userService.findUserList();
+        return ResponseEntity.ok(ApiResponse.success(userService.findUserList()));
+    }
 
-        return ResponseEntity.ok(ApiResponse.success(users));
+    /**
+     * 프로필 수정 (이름·이메일)
+     * PATCH /api/users/me
+     * @param userId SecurityContext에서 추출된 사용자 ID
+     * @param reqUpdateProfileDto 이름·이메일
+     * @return 200 OK
+     */
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> updateProfile(@AuthenticationPrincipal Long userId, @Valid @RequestBody ReqUpdateProfileDto reqUpdateProfileDto) {
+        log.debug("[UserController] 프로필 수정 - userId: {}", userId);
+
+        userService.updateProfile(userId, reqUpdateProfileDto.getName(), reqUpdateProfileDto.getEmail());
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 비밀번호 변경 (STUDENT / CREATOR)
+     * PATCH /api/users/me/password
+     * @param userId SecurityContext에서 추출된 사용자 ID
+     * @param reqUpdatePasswordDto 현재 비밀번호·새 비밀번호
+     * @return 200 OK
+     */
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(@AuthenticationPrincipal Long userId, @Valid @RequestBody ReqUpdatePasswordDto reqUpdatePasswordDto) {
+        log.debug("[UserController] 비밀번호 변경 - userId: {}", userId);
+
+        userService.updatePassword(userId, reqUpdatePasswordDto.getCurrentPassword(), reqUpdatePasswordDto.getNewPassword());
+
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqUpdatePasswordDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqUpdatePasswordDto.java
@@ -1,0 +1,23 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+/**
+ * 비밀번호 변경 요청 DTO
+ */
+@Getter
+public class ReqUpdatePasswordDto {
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 16, message = "비밀번호는 8~16자여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?])\\S{8,16}$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+    )
+    private String newPassword;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqUpdateProfileDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqUpdateProfileDto.java
@@ -1,0 +1,18 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * 프로필 수정 요청 DTO (이름·이메일)
+ */
+@Getter
+public class ReqUpdateProfileDto {
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespLoginDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespLoginDto.java
@@ -13,6 +13,7 @@ public class RespLoginDto {
     private Long id;
     private String username;
     private String name;
+    private String email;
     private String role;
 
     /* User 엔티티 → 로그인 응답 DTO 변환 */
@@ -21,6 +22,7 @@ public class RespLoginDto {
                 .id(user.getId())
                 .username(user.getUsername())
                 .name(user.getName())
+                .email(user.getEmail())
                 .role(user.getRole())
                 .build();
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/User.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/User.java
@@ -58,4 +58,13 @@ public class User {
                 .role("STUDENT")
                 .build();
     }
+
+    /* 프로필 수정용 엔티티 생성 */
+    public static User ofProfileUpdate(Long id, String name, String email) {
+        return User.builder()
+                .id(id)
+                .name(name)
+                .email(email)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
@@ -29,4 +29,13 @@ public interface UserMapper {
 
     /* 사용자 역할 변경 */
     void updateUserRole(@Param("id") Long id, @Param("role") String role);
+
+    /* 프로필 수정 (이름·이메일) */
+    void updateUserInfo(User user);
+
+    /* 비밀번호 변경 */
+    void updateUserPassword(@Param("id") Long id, @Param("password") String password);
+
+    /* 비밀번호 조회 (검증용) */
+    String selectPasswordById(Long id);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/UserService.java
@@ -1,9 +1,12 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,7 @@ import java.util.List;
 public class UserService {
 
     private final UserMapper userMapper;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     /**
      * 전체 사용자 목록 조회
@@ -29,5 +33,43 @@ public class UserService {
         log.info("[UserService] 전체 사용자 목록 조회");
 
         return userMapper.selectUserList();
+    }
+
+    /**
+     * 프로필 수정 (이름·이메일)
+     * @param userId 사용자 ID
+     * @param name 새 이름
+     * @param email 새 이메일
+     * @throws BusinessException 이메일 중복(409)
+     */
+    @Transactional
+    public void updateProfile(Long userId, String name, String email) {
+        log.info("[UserService] 프로필 수정 - userId: {}", userId);
+
+        User existing = userMapper.selectUserByEmail(email);
+        if (existing != null && !existing.getId().equals(userId)) {
+            throw new BusinessException(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+        }
+
+        userMapper.updateUserInfo(User.ofProfileUpdate(userId, name, email));
+    }
+
+    /**
+     * 비밀번호 변경
+     * @param userId 사용자 ID
+     * @param currentPassword 현재 비밀번호
+     * @param newPassword 새 비밀번호
+     * @throws BusinessException 현재 비밀번호 불일치(401)
+     */
+    @Transactional
+    public void updatePassword(Long userId, String currentPassword, String newPassword) {
+        log.info("[UserService] 비밀번호 변경 - userId: {}", userId);
+
+        String stored = userMapper.selectPasswordById(userId);
+        if (!passwordEncoder.matches(currentPassword, stored)) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        userMapper.updateUserPassword(userId, passwordEncoder.encode(newPassword));
     }
 }

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -81,4 +81,26 @@
          WHERE id = #{id}
     </update>
 
+    <!-- 프로필 수정 (이름·이메일) -->
+    <update id="updateUserInfo" parameterType="User">
+        UPDATE users
+           SET name = #{name}
+             , email = #{email}
+         WHERE id = #{id}
+    </update>
+
+    <!-- 비밀번호 변경 -->
+    <update id="updateUserPassword">
+        UPDATE users
+           SET password = #{password}
+         WHERE id = #{id}
+    </update>
+
+    <!-- 비밀번호 조회 (검증용) -->
+    <select id="selectPasswordById" parameterType="Long" resultType="String">
+        SELECT password
+          FROM users
+         WHERE id = #{id}
+    </select>
+
 </mapper>

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,0 +1,6 @@
+import instance from './axios';
+
+/* 관리자 비밀번호 변경 */
+export const updateAdminPassword = (currentPassword, newPassword) => {
+    return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);
+};

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -4,3 +4,13 @@ import instance from './axios';
 export const getUserList = () => {
     return instance.get('/api/users').then(res => res.data);
 };
+
+/* 프로필 수정 (이름·이메일) */
+export const updateProfile = (name, email) => {
+    return instance.patch('/api/users/me', { name, email }).then(res => res.data);
+};
+
+/* 비밀번호 변경 */
+export const updatePassword = (currentPassword, newPassword) => {
+    return instance.patch('/api/users/me/password', { currentPassword, newPassword }).then(res => res.data);
+};

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -118,8 +118,14 @@ export const AuthProvider = ({ children }) => {
         setUser(null);
     };
 
+    /* 프로필 수정 후 사용자 정보 갱신 */
+    const updateUser = (newUserInfo) => {
+        localStorage.setItem('user', JSON.stringify(newUserInfo));
+        setUser(newUserInfo);
+    };
+
     return (
-        <AuthContext.Provider value={{ user, isInitializing, login, logout }}>
+        <AuthContext.Provider value={{ user, isInitializing, login, logout, updateUser }}>
             {children}
         </AuthContext.Provider>
     );

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,19 +1,62 @@
 import { useState } from 'react';
 import CreatorRequestTab from './admin/CreatorRequestTab';
+import { updateAdminPassword } from '../api/admin';
 
 /* 관리자 페이지 */
 const AdminPage = () => {
     /* 현재 활성화된 탭 상태 */
     const [activeTab, setActiveTab] = useState('creator-requests');
+    /* 비밀번호 변경 모달 표시 상태 */
+    const [showPasswordModal, setShowPasswordModal] = useState(false);
+    /* 비밀번호 폼 */
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [passwordLoading, setPasswordLoading] = useState(false);
 
     /* 탭 목록 */
     const tabs = [
         { key: 'creator-requests', label: '강사 신청 관리' },
     ];
 
+    /* 모달 닫기 */
+    const handleCloseModal = () => {
+        setShowPasswordModal(false);
+        setCurrentPassword('');
+        setNewPassword('');
+    };
+
+    /* 비밀번호 변경 */
+    const handlePasswordSave = async () => {
+        if (!currentPassword || !newPassword) {
+            alert('비밀번호를 입력해주세요.');
+            return;
+        }
+
+        if (!window.confirm('비밀번호를 변경하시겠습니까?')) return;
+
+        setPasswordLoading(true);
+        try {
+            await updateAdminPassword(currentPassword, newPassword);
+            alert('비밀번호가 변경되었습니다.');
+            handleCloseModal();
+        } catch (err) {
+            alert(err.response?.data?.message || '비밀번호 변경에 실패했습니다.');
+        } finally {
+            setPasswordLoading(false);
+        }
+    };
+
     return (
         <div className="max-w-4xl mx-auto mt-10 p-6">
-            <h1 className="text-3xl font-extrabold text-gray-900 mb-8">관리자 페이지</h1>
+            <div className="flex items-center justify-between mb-8">
+                <h1 className="text-3xl font-extrabold text-gray-900">관리자 페이지</h1>
+                <button
+                    onClick={() => setShowPasswordModal(true)}
+                    className="px-4 py-2 text-sm font-semibold text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
+                >
+                    비밀번호 변경
+                </button>
+            </div>
 
             {/* 탭 버튼들 */}
             <div className="flex items-center border-b border-gray-200 mb-8">
@@ -35,6 +78,51 @@ const AdminPage = () => {
 
             {/* 탭 콘텐츠 */}
             {activeTab === 'creator-requests' && <CreatorRequestTab />}
+
+            {/* 비밀번호 변경 모달 */}
+            {showPasswordModal && (
+                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+                    <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6">
+                        <h2 className="text-lg font-bold text-gray-900 mb-6">비밀번호 변경</h2>
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-xs font-semibold text-gray-500 mb-1">현재 비밀번호</label>
+                                <input
+                                    type="password"
+                                    value={currentPassword}
+                                    onChange={(e) => setCurrentPassword(e.target.value)}
+                                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-xs font-semibold text-gray-500 mb-1">새 비밀번호</label>
+                                <input
+                                    type="password"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    placeholder="영문·숫자·특수문자 각 1개 이상, 8~16자"
+                                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-gray-300"
+                                />
+                            </div>
+                        </div>
+                        <div className="flex justify-end gap-2 mt-6">
+                            <button
+                                onClick={handleCloseModal}
+                                className="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                            >
+                                취소
+                            </button>
+                            <button
+                                onClick={handlePasswordSave}
+                                disabled={passwordLoading}
+                                className="px-4 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50"
+                            >
+                                {passwordLoading ? '변경 중...' : '변경'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -6,6 +6,7 @@ import EnrollmentTab from './mypage/EnrollmentTab';
 import PaymentTab from './mypage/PaymentTab';
 import MyCourseTab from './mypage/MyCourseTab';
 import StudentTab from './mypage/StudentTab';
+import ProfileTab from './mypage/ProfileTab';
 
 /* 마이페이지 */
 const MyPage = () => {
@@ -14,20 +15,23 @@ const MyPage = () => {
     /* 인증 정보 */
     const { user } = useAuth();
     /* 현재 활성화된 탭 상태 */
-    const [activeTab, setActiveTab] = useState(location.state?.tab || 'enrollments');
+    const [activeTab, setActiveTab] = useState(location.state?.tab || (user?.role === 'CREATOR' ? 'my-courses' : 'enrollments'));
     /* 강사 신청 폼 표시 상태 */
     const [showCreatorForm, setShowCreatorForm] = useState(false);
     /* 강사 신청 사유 */
     const [creatorReason, setCreatorReason] = useState('');
 
-    /* 탭 목록 - CREATOR는 추가 탭 노출 */
+    /* 탭 목록
+     * STUDENT: 나의 수강목록 → 프로필 수정 → 결제 내역
+     * CREATOR: 내 강의 → 강의별 수강생 목록 → 나의 수강목록 → 프로필 수정 → 결제 내역 */
     const tabs = [
-        { key: 'enrollments', label: '나의 수강목록' },
-        { key: 'payments', label: '결제 내역' },
         ...(user?.role === 'CREATOR' ? [
             { key: 'my-courses', label: '내 강의' },
             { key: 'students', label: '강의별 수강생 목록' },
         ] : []),
+        { key: 'enrollments', label: '나의 수강목록' },
+        { key: 'profile', label: '프로필 수정' },
+        { key: 'payments', label: '결제 내역' },
     ];
 
     /* 강사 신청 제출 */
@@ -114,6 +118,7 @@ const MyPage = () => {
             {activeTab === 'payments' && <PaymentTab />}
             {activeTab === 'my-courses' && <MyCourseTab />}
             {activeTab === 'students' && <StudentTab />}
+            {activeTab === 'profile' && <ProfileTab />}
 
         </div>
     );

--- a/frontend/src/pages/mypage/ProfileTab.jsx
+++ b/frontend/src/pages/mypage/ProfileTab.jsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import { useAuth } from '../../context/AuthContext';
+import { updateProfile, updatePassword } from '../../api/user';
+
+/* 프로필 수정 탭 (STUDENT / CREATOR 공통) */
+const ProfileTab = () => {
+    /* 인증 정보 및 업데이트 함수 */
+    const { user, updateUser } = useAuth();
+
+    /* 프로필 폼 */
+    const [name, setName] = useState(user?.name || '');
+    const [email, setEmail] = useState(user?.email || '');
+    const [profileLoading, setProfileLoading] = useState(false);
+
+    /* 비밀번호 폼 */
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [passwordLoading, setPasswordLoading] = useState(false);
+
+    /* 프로필 저장 */
+    const handleProfileSave = async () => {
+        if (!name.trim() || !email.trim()) {
+            alert('이름과 이메일을 입력해주세요.');
+            return;
+        }
+
+        if (!window.confirm('프로필을 수정하시겠습니까?')) return;
+
+        setProfileLoading(true);
+        try {
+            await updateProfile(name.trim(), email.trim());
+            updateUser({ ...user, name: name.trim(), email: email.trim() });
+            alert('프로필이 수정되었습니다.');
+        } catch (err) {
+            alert(err.response?.data?.message || '프로필 수정에 실패했습니다.');
+        } finally {
+            setProfileLoading(false);
+        }
+    };
+
+    /* 비밀번호 변경 */
+    const handlePasswordSave = async () => {
+        if (!currentPassword || !newPassword) {
+            alert('비밀번호를 입력해주세요.');
+            return;
+        }
+        
+        if (!window.confirm('비밀번호를 변경하시겠습니까?')) return;
+
+        setPasswordLoading(true);
+        try {
+            await updatePassword(currentPassword, newPassword);
+            alert('비밀번호가 변경되었습니다.');
+            setCurrentPassword('');
+            setNewPassword('');
+        } catch (err) {
+            alert(err.response?.data?.message || '비밀번호 변경에 실패했습니다.');
+        } finally {
+            setPasswordLoading(false);
+        }
+    };
+
+    return (
+        <div className="space-y-10 max-w-lg">
+            {/* 프로필 수정 */}
+            <div>
+                <h2 className="text-base font-bold text-gray-800 mb-4">프로필 수정</h2>
+                <div className="space-y-4">
+                    {/* 아이디는 수정 불가 - 회색으로 표시 */}
+                    <div>
+                        <label className="block text-xs font-semibold text-gray-500 mb-1">아이디</label>
+                        <input
+                            type="text"
+                            value={user?.username || ''}
+                            disabled
+                            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-400 bg-gray-50 cursor-not-allowed"
+                        />
+                    </div>
+                    {/* 이름과 이메일은 수정 가능 */ }
+                    <div>
+                        <label className="block text-xs font-semibold text-gray-500 mb-1">이름</label>
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-xs font-semibold text-gray-500 mb-1">이메일</label>
+                        <input
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                    </div>
+                    {/* 저장 버튼 */ }
+                    <div className="flex justify-end">
+                        <button
+                            onClick={handleProfileSave}
+                            disabled={profileLoading}
+                            className="px-5 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50"
+                        >
+                            {profileLoading ? '저장 중...' : '저장'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <hr className="border-gray-100" />
+
+            {/* 비밀번호 변경 */}
+            <div>
+                <h2 className="text-base font-bold text-gray-800 mb-4">비밀번호 변경</h2>
+                <div className="space-y-4">
+                    <div>
+                        <label className="block text-xs font-semibold text-gray-500 mb-1">현재 비밀번호</label>
+                        <input
+                            type="password"
+                            value={currentPassword}
+                            onChange={(e) => setCurrentPassword(e.target.value)}
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-xs font-semibold text-gray-500 mb-1">새 비밀번호</label>
+                        <input
+                            type="password"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            placeholder="영문·숫자·특수문자 각 1개 이상, 8~16자"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-gray-300"
+                        />
+                    </div>
+                    <div className="flex justify-end">
+                        <button
+                            onClick={handlePasswordSave}
+                            disabled={passwordLoading}
+                            className="px-5 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50"
+                        >
+                            {passwordLoading ? '변경 중...' : '변경'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ProfileTab;


### PR DESCRIPTION
  ## 작업 내용
  - PATCH /api/users/me - 이름·이메일 수정 (STUDENT·CREATOR 전용)
  - PATCH /api/users/me/password - 비밀번호 변경 (STUDENT·CREATOR 전용)
  - PATCH /api/admin/me/password - 관리자 비밀번호 변경 (ADMIN 전용 네임스페이스)
  - 이메일 중복 검사, BCrypt 현재 비밀번호 검증 후 암호화 저장
  - RespLoginDto에 email 필드 추가
  - 마이페이지 프로필 수정 탭 추가 (이름·이메일·비밀번호 변경, STUDENT·CREATOR 공통)
  - 관리자 페이지 비밀번호 변경 모달 추가
  - AuthContext updateUser 추가 - 프로필 수정 후 상태·localStorage 즉시 동기화
  - 마이페이지 탭 순서 조정 및 CREATOR 기본 탭 변경 (내 강의로 진입)

  ## 구현 시 고려한 점
  - ADMIN은 이름·이메일 고정(계정 생성 시 확정), 비밀번호만 변경 가능하도록 역할별 엔드포인트 분리
  - /api/users/** 는 STUDENT·CREATOR, /api/admin/** 는 ADMIN 전용으로 SecurityConfig에서 명시적으로 제한
  - 아이디(username)는 전 역할 수정 불가 - UI에서 disabled 처리
  - 프로필 수정 성공 시 서버 재요청 없이 AuthContext의 updateUser로 즉시 UI 반영

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - STUDENT/CREATOR → 마이페이지 → 프로필 수정 탭 → 이름·이메일 수정 후 헤더 반영 확인
  - ADMIN → 관리자 페이지 → 비밀번호 변경 버튼 → 모달에서 변경 확인
  - STUDENT/CREATOR가 /api/admin/me/password 호출 시 403 확인

  ## 연관 이슈
  Closes #48