### PR TITLE
[feat] 관리자 페이지 확장

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -1,7 +1,9 @@
 package com.yujin.course_enrollment.controller;
 
+import com.yujin.course_enrollment.dto.req.ReqAdminRoleUpdateDto;
 import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.AdminService;
 import com.yujin.course_enrollment.service.UserService;
@@ -12,9 +14,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * 관리자 컨트롤러
@@ -39,6 +44,34 @@ public class AdminController {
         log.debug("[AdminController] 대시보드 통계 조회 요청");
 
         return ResponseEntity.ok(ApiResponse.success(adminService.getDashboardStats()));
+    }
+
+    /**
+     * 전체 사용자 목록 조회
+     * GET /api/admin/users
+     * @return 전체 사용자 목록
+     */
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<List<User>>> getUserList() {
+        log.debug("[AdminController] 전체 사용자 목록 조회 요청");
+
+        return ResponseEntity.ok(ApiResponse.success(adminService.findAllUsers()));
+    }
+
+    /**
+     * 사용자 역할 변경
+     * PATCH /api/admin/users/{userId}/role
+     * @param userId 대상 사용자 ID
+     * @param reqAdminRoleUpdateDto 변경할 역할
+     * @return 200 OK
+     */
+    @PatchMapping("/users/{userId}/role")
+    public ResponseEntity<ApiResponse<Void>> updateUserRole(@PathVariable Long userId, @Valid @RequestBody ReqAdminRoleUpdateDto reqAdminRoleUpdateDto) {
+        log.debug("[AdminController] 사용자 역할 변경 - userId: {}, role: {}", userId, reqAdminRoleUpdateDto.getRole());
+
+        adminService.updateUserRole(userId, reqAdminRoleUpdateDto.getRole());
+
+        return ResponseEntity.ok(ApiResponse.success());
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -1,13 +1,16 @@
 package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
 import com.yujin.course_enrollment.global.response.ApiResponse;
+import com.yujin.course_enrollment.service.AdminService;
 import com.yujin.course_enrollment.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +27,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminController {
 
     private final UserService userService;
+    private final AdminService adminService;
+
+    /**
+     * 대시보드 통계 조회
+     * GET /api/admin/dashboard
+     * @return 전체 사용자 수, 강의 수, 확정 수강 신청 수
+     */
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<RespAdminDashboardDto>> getDashboard() {
+        log.debug("[AdminController] 대시보드 통계 조회 요청");
+
+        return ResponseEntity.ok(ApiResponse.success(adminService.getDashboardStats()));
+    }
 
     /**
      * 관리자 비밀번호 변경

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -1,8 +1,11 @@
 package com.yujin.course_enrollment.controller;
 
+import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
 import com.yujin.course_enrollment.dto.req.ReqAdminRoleUpdateDto;
 import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import com.yujin.course_enrollment.service.AdminService;
@@ -70,6 +73,34 @@ public class AdminController {
         log.debug("[AdminController] 사용자 역할 변경 - userId: {}, role: {}", userId, reqAdminRoleUpdateDto.getRole());
 
         adminService.updateUserRole(userId, reqAdminRoleUpdateDto.getRole());
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 전체 강의 목록 조회
+     * GET /api/admin/courses
+     * @param reqAdminCoursePageDto 페이징 조건
+     * @return 전체 강의 목록 (모든 상태 포함)
+     */
+    @GetMapping("/courses")
+    public ResponseEntity<ApiResponse<RespPageDto<RespCourseListDto>>> getCourseList(ReqAdminCoursePageDto reqAdminCoursePageDto) {
+        log.debug("[AdminController] 전체 강의 목록 조회 요청");
+
+        return ResponseEntity.ok(ApiResponse.success(adminService.findAllCourses(reqAdminCoursePageDto)));
+    }
+
+    /**
+     * 강의 강제 폐강
+     * PATCH /api/admin/courses/{courseId}/close
+     * @param courseId 강의 ID
+     * @return 200 OK
+     */
+    @PatchMapping("/courses/{courseId}/close")
+    public ResponseEntity<ApiResponse<Void>> forceCloseCourse(@PathVariable Long courseId) {
+        log.debug("[AdminController] 강의 강제 폐강 요청 - courseId: {}", courseId);
+
+        adminService.forceCloseCourse(courseId);
 
         return ResponseEntity.ok(ApiResponse.success());
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminCoursePageDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminCoursePageDto.java
@@ -1,0 +1,21 @@
+package com.yujin.course_enrollment.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 관리자 강의 목록 페이징 조건 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqAdminCoursePageDto {
+    private int page = 0;
+    private int size = 10;
+
+    /* offset 계산 */
+    public int getOffset() {
+        return page * size;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminRoleUpdateDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminRoleUpdateDto.java
@@ -1,0 +1,13 @@
+package com.yujin.course_enrollment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * 관리자 역할 변경 요청 DTO
+ */
+@Getter
+public class ReqAdminRoleUpdateDto {
+    @NotBlank(message = "역할을 입력해주세요.")
+    private String role;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
@@ -10,14 +10,24 @@ import lombok.Getter;
 @Builder
 public class RespAdminDashboardDto {
     private int totalUsers;
+    private int studentCount;
+    private int creatorCount;
     private int totalCourses;
+    private int draftCount;
+    private int openCount;
+    private int closedCount;
     private int totalEnrollments;
 
     /* 통계 집계 결과로 대시보드 응답 생성 */
-    public static RespAdminDashboardDto of(int totalUsers, int totalCourses, int totalEnrollments) {
+    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int totalEnrollments) {
         return RespAdminDashboardDto.builder()
                 .totalUsers(totalUsers)
+                .studentCount(studentCount)
+                .creatorCount(creatorCount)
                 .totalCourses(totalCourses)
+                .draftCount(draftCount)
+                .openCount(openCount)
+                .closedCount(closedCount)
                 .totalEnrollments(totalEnrollments)
                 .build();
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
@@ -1,0 +1,24 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 관리자 대시보드 통계 응답 DTO
+ */
+@Getter
+@Builder
+public class RespAdminDashboardDto {
+    private int totalUsers;
+    private int totalCourses;
+    private int totalEnrollments;
+
+    /* 통계 집계 결과로 대시보드 응답 생성 */
+    public static RespAdminDashboardDto of(int totalUsers, int totalCourses, int totalEnrollments) {
+        return RespAdminDashboardDto.builder()
+                .totalUsers(totalUsers)
+                .totalCourses(totalCourses)
+                .totalEnrollments(totalEnrollments)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
 import com.yujin.course_enrollment.dto.req.ReqCourseSearchDto;
 import com.yujin.course_enrollment.dto.req.ReqMyCoursePageDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
@@ -47,6 +48,9 @@ public interface CourseMapper {
 
     /* 나의 강의 목록 전체 수 조회 (페이징용) */
     int selectCourseListByCreatorIdCount(Long creatorId);
+
+    /* 관리자 전체 강의 목록 조회 */
+    List<RespCourseListDto> selectAdminCourseList(ReqAdminCoursePageDto reqAdminCoursePageDto);
 
     /* 관리자 전체 강의 수 조회 */
     int selectAdminCourseListCount();

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -47,4 +47,7 @@ public interface CourseMapper {
 
     /* 나의 강의 목록 전체 수 조회 (페이징용) */
     int selectCourseListByCreatorIdCount(Long creatorId);
+
+    /* 관리자 전체 강의 수 조회 */
+    int selectAdminCourseListCount();
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -7,6 +7,7 @@ import com.yujin.course_enrollment.dto.resp.RespCourseDetailDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.entity.Course;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -54,4 +55,7 @@ public interface CourseMapper {
 
     /* 관리자 전체 강의 수 조회 */
     int selectAdminCourseListCount();
+
+    /* 상태별 강의 수 조회 */
+    int selectCourseCountByStatus(@Param("status") String status);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -45,4 +45,7 @@ public interface EnrollmentMapper {
 
     /* 대기열 승격 (WAITLIST 상태일 때만 PENDING으로 변경) */
     int updateEnrollmentStatusPromote(Long id);
+
+    /* 확정된 수강 신청 수 조회 */
+    int selectConfirmedEnrollmentCount();
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
@@ -38,4 +38,7 @@ public interface UserMapper {
 
     /* 비밀번호 조회 (검증용) */
     String selectPasswordById(Long id);
+
+    /* 전체 사용자 수 조회 */
+    int selectUserCount();
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/UserMapper.java
@@ -41,4 +41,7 @@ public interface UserMapper {
 
     /* 전체 사용자 수 조회 */
     int selectUserCount();
+
+    /* 역할별 사용자 수 조회 */
+    int selectUserCountByRole(@Param("role") String role);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -1,7 +1,12 @@
 package com.yujin.course_enrollment.service;
 
+import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
+import com.yujin.course_enrollment.dto.resp.RespPageDto;
+import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
@@ -68,5 +73,40 @@ public class AdminService {
         }
 
         userMapper.updateUserRole(userId, role);
+    }
+
+    /**
+     * 전체 강의 목록 조회 (모든 상태 포함)
+     * @param reqAdminCoursePageDto 페이징 조건
+     * @return 페이징된 강의 목록
+     */
+    public RespPageDto<RespCourseListDto> findAllCourses(ReqAdminCoursePageDto reqAdminCoursePageDto) {
+        log.info("[AdminService] 전체 강의 목록 조회 - page: {}, size: {}", reqAdminCoursePageDto.getPage(), reqAdminCoursePageDto.getSize());
+
+        List<RespCourseListDto> content = courseMapper.selectAdminCourseList(reqAdminCoursePageDto);
+        int totalCount = courseMapper.selectAdminCourseListCount();
+
+        return RespPageDto.of(content, reqAdminCoursePageDto.getPage(), reqAdminCoursePageDto.getSize(), totalCount);
+    }
+
+    /**
+     * 강의 강제 폐강
+     * @param courseId 강의 ID
+     * @throws BusinessException 강의 없음(404), 이미 폐강(400)
+     */
+    @Transactional
+    public void forceCloseCourse(Long courseId) {
+        log.info("[AdminService] 강의 강제 폐강 - courseId: {}", courseId);
+
+        Course course = courseMapper.selectCourseById(courseId);
+        if (course == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "존재하지 않는 강의입니다.");
+        }
+
+        if (CourseStatus.CLOSED.equals(course.getStatus())) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 폐강된 강의입니다.");
+        }
+
+        courseMapper.updateCourseStatus(Course.builder().id(courseId).status(CourseStatus.CLOSED).build());
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -1,0 +1,35 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자 서비스
+ * 관리자 전용 비즈니스 로직을 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+
+    private final UserMapper userMapper;
+    private final CourseMapper courseMapper;
+    private final EnrollmentMapper enrollmentMapper;
+
+    /**
+     * 대시보드 통계 조회
+     * @return 전체 사용자 수, 강의 수, 확정 수강 신청 수
+     */
+    public RespAdminDashboardDto getDashboardStats() {
+        log.info("[AdminService] 대시보드 통계 조회");
+
+        return RespAdminDashboardDto.of(userMapper.selectUserCount(), courseMapper.selectAdminCourseListCount(), enrollmentMapper.selectConfirmedEnrollmentCount());
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -1,13 +1,18 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.entity.User;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 관리자 서비스
@@ -31,5 +36,37 @@ public class AdminService {
         log.info("[AdminService] 대시보드 통계 조회");
 
         return RespAdminDashboardDto.of(userMapper.selectUserCount(), courseMapper.selectAdminCourseListCount(), enrollmentMapper.selectConfirmedEnrollmentCount());
+    }
+
+    /**
+     * 전체 사용자 목록 조회
+     * @return 전체 사용자 목록
+     */
+    public List<User> findAllUsers() {
+        log.info("[AdminService] 전체 사용자 목록 조회");
+
+        return userMapper.selectUserList();
+    }
+
+    /**
+     * 사용자 역할 변경
+     * @param userId 대상 사용자 ID
+     * @param role 변경할 역할
+     * @throws BusinessException 사용자 없음(404), ADMIN 역할 변경 시도(400)
+     */
+    @Transactional
+    public void updateUserRole(Long userId, String role) {
+        log.info("[AdminService] 사용자 역할 변경 - userId: {}, role: {}", userId, role);
+
+        User user = userMapper.selectUserById(userId);
+        if (user == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.");
+        }
+
+        if ("ADMIN".equals(role)) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "관리자 역할로 변경할 수 없습니다.");
+        }
+
+        userMapper.updateUserRole(userId, role);
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -40,7 +40,16 @@ public class AdminService {
     public RespAdminDashboardDto getDashboardStats() {
         log.info("[AdminService] 대시보드 통계 조회");
 
-        return RespAdminDashboardDto.of(userMapper.selectUserCount(), courseMapper.selectAdminCourseListCount(), enrollmentMapper.selectConfirmedEnrollmentCount());
+        int totalUsers = userMapper.selectUserCount();
+        int studentCount = userMapper.selectUserCountByRole("STUDENT");
+        int creatorCount = userMapper.selectUserCountByRole("CREATOR");
+        int totalCourses = courseMapper.selectAdminCourseListCount();
+        int draftCount = courseMapper.selectCourseCountByStatus("DRAFT");
+        int openCount = courseMapper.selectCourseCountByStatus("OPEN");
+        int closedCount = courseMapper.selectCourseCountByStatus("CLOSED");
+        int totalEnrollments = enrollmentMapper.selectConfirmedEnrollmentCount();
+
+        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, totalEnrollments);
     }
 
     /**

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -202,6 +202,25 @@
            AND enrolled_count > 0
     </update>
 
+    <!-- 관리자 전체 강의 목록 조회 -->
+    <select id="selectAdminCourseList" parameterType="ReqAdminCoursePageDto" resultType="RespCourseListDto">
+        SELECT c.id
+             , c.creator_id
+             , u.name AS creatorName
+             , c.title
+             , c.price
+             , c.capacity
+             , c.enrolled_count
+             , c.status
+             , c.start_date
+             , c.end_date
+             , c.created_at
+          FROM courses c
+          JOIN users u ON c.creator_id = u.id
+        ORDER BY c.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
     <!-- 관리자 전체 강의 수 조회 -->
     <select id="selectAdminCourseListCount" resultType="int">
         SELECT COUNT(*)

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -202,4 +202,10 @@
            AND enrolled_count > 0
     </update>
 
+    <!-- 관리자 전체 강의 수 조회 -->
+    <select id="selectAdminCourseListCount" resultType="int">
+        SELECT COUNT(*)
+          FROM courses
+    </select>
+
 </mapper>

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -227,4 +227,11 @@
           FROM courses
     </select>
 
+    <!-- 상태별 강의 수 조회 -->
+    <select id="selectCourseCountByStatus" resultType="int">
+        SELECT COUNT(*)
+          FROM courses
+         WHERE status = #{status}
+    </select>
+
 </mapper>

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -124,6 +124,13 @@
            AND status = 'WAITLIST'
     </update>
 
+    <!-- 확정된 수강 신청 수 조회 -->
+    <select id="selectConfirmedEnrollmentCount" resultType="int">
+        SELECT COUNT(*)
+          FROM enrollments
+         WHERE status = 'CONFIRMED'
+    </select>
+
     <!-- 대기열 첫 번째 조회 (자동 승격용) -->
     <select id="selectNextWaitlist" parameterType="Long" resultType="Enrollment">
         SELECT id

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -109,4 +109,11 @@
           FROM users
     </select>
 
+    <!-- 역할별 사용자 수 조회 -->
+    <select id="selectUserCountByRole" resultType="int">
+        SELECT COUNT(*)
+          FROM users
+         WHERE role = #{role}
+    </select>
+
 </mapper>

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -103,4 +103,10 @@
          WHERE id = #{id}
     </select>
 
+    <!-- 전체 사용자 수 조회 -->
+    <select id="selectUserCount" resultType="int">
+        SELECT COUNT(*)
+          FROM users
+    </select>
+
 </mapper>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "axios": "^1.15.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "react-router-dom": "^7.14.2"
+        "react-router-dom": "^7.14.2",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -590,6 +591,42 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
@@ -875,6 +912,18 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -1175,6 +1224,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1193,7 +1305,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1209,6 +1321,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1481,6 +1599,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1559,8 +1686,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1579,6 +1827,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1683,6 +1937,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1891,6 +2155,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2223,6 +2493,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2248,6 +2528,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2944,6 +3233,37 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
@@ -2981,6 +3301,58 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3132,6 +3504,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3208,6 +3586,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "axios": "^1.15.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-router-dom": "^7.14.2"
+    "react-router-dom": "^7.14.2",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -15,6 +15,16 @@ export const updateUserRole = (userId, role) => {
     return instance.patch(`/api/admin/users/${userId}/role`, { role }).then(res => res.data);
 };
 
+/* 전체 강의 목록 조회 */
+export const getAdminCourses = (page = 0, size = 10) => {
+    return instance.get('/api/admin/courses', { params: { page, size } }).then(res => res.data);
+};
+
+/* 강의 강제 폐강 */
+export const forceCloseCourse = (courseId) => {
+    return instance.patch(`/api/admin/courses/${courseId}/close`).then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,5 +1,10 @@
 import instance from './axios';
 
+/* 대시보드 통계 조회 */
+export const getAdminDashboard = () => {
+    return instance.get('/api/admin/dashboard').then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -5,6 +5,16 @@ export const getAdminDashboard = () => {
     return instance.get('/api/admin/dashboard').then(res => res.data);
 };
 
+/* 전체 사용자 목록 조회 */
+export const getAdminUsers = () => {
+    return instance.get('/api/admin/users').then(res => res.data);
+};
+
+/* 사용자 역할 변경 */
+export const updateUserRole = (userId, role) => {
+    return instance.patch(`/api/admin/users/${userId}/role`, { role }).then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import CreatorRequestTab from './admin/CreatorRequestTab';
 import DashboardTab from './admin/DashboardTab';
 import UserManagementTab from './admin/UserManagementTab';
+import CourseManagementTab from './admin/CourseManagementTab';
 import { updateAdminPassword } from '../api/admin';
 
 /* 관리자 페이지 */
@@ -20,6 +21,7 @@ const AdminPage = () => {
         { key: 'dashboard', label: '대시보드' },
         { key: 'creator-requests', label: '강사 신청 관리' },
         { key: 'users', label: '사용자 관리' },
+        { key: 'courses', label: '강의 관리' },
     ];
 
     /* 모달 닫기 */
@@ -84,6 +86,7 @@ const AdminPage = () => {
             {activeTab === 'dashboard' && <DashboardTab />}
             {activeTab === 'creator-requests' && <CreatorRequestTab />}
             {activeTab === 'users' && <UserManagementTab />}
+            {activeTab === 'courses' && <CourseManagementTab />}
 
             {/* 비밀번호 변경 모달 */}
             {showPasswordModal && (

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import CreatorRequestTab from './admin/CreatorRequestTab';
 import DashboardTab from './admin/DashboardTab';
+import UserManagementTab from './admin/UserManagementTab';
 import { updateAdminPassword } from '../api/admin';
 
 /* 관리자 페이지 */
@@ -18,6 +19,7 @@ const AdminPage = () => {
     const tabs = [
         { key: 'dashboard', label: '대시보드' },
         { key: 'creator-requests', label: '강사 신청 관리' },
+        { key: 'users', label: '사용자 관리' },
     ];
 
     /* 모달 닫기 */
@@ -81,6 +83,7 @@ const AdminPage = () => {
             {/* 탭 콘텐츠 */}
             {activeTab === 'dashboard' && <DashboardTab />}
             {activeTab === 'creator-requests' && <CreatorRequestTab />}
+            {activeTab === 'users' && <UserManagementTab />}
 
             {/* 비밀번호 변경 모달 */}
             {showPasswordModal && (

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import CreatorRequestTab from './admin/CreatorRequestTab';
+import DashboardTab from './admin/DashboardTab';
 import { updateAdminPassword } from '../api/admin';
 
 /* 관리자 페이지 */
 const AdminPage = () => {
     /* 현재 활성화된 탭 상태 */
-    const [activeTab, setActiveTab] = useState('creator-requests');
+    const [activeTab, setActiveTab] = useState('dashboard');
     /* 비밀번호 변경 모달 표시 상태 */
     const [showPasswordModal, setShowPasswordModal] = useState(false);
     /* 비밀번호 폼 */
@@ -15,6 +16,7 @@ const AdminPage = () => {
 
     /* 탭 목록 */
     const tabs = [
+        { key: 'dashboard', label: '대시보드' },
         { key: 'creator-requests', label: '강사 신청 관리' },
     ];
 
@@ -77,6 +79,7 @@ const AdminPage = () => {
             </div>
 
             {/* 탭 콘텐츠 */}
+            {activeTab === 'dashboard' && <DashboardTab />}
             {activeTab === 'creator-requests' && <CreatorRequestTab />}
 
             {/* 비밀번호 변경 모달 */}

--- a/frontend/src/pages/admin/CourseManagementTab.jsx
+++ b/frontend/src/pages/admin/CourseManagementTab.jsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { getAdminCourses, forceCloseCourse } from '../../api/admin';
+import { COURSE_STATUS_LABEL, COURSE_STATUS_BADGE_STYLE } from '../../utils/statusConfig';
+
+/* 관리자 강의 관리 탭 */
+const CourseManagementTab = () => {
+    /* 강의 목록 상태 */
+    const [courses, setCourses] = useState([]);
+    /* 페이징 상태 */
+    const [page, setPage] = useState(0);
+    /* 전체 페이지 수 상태 */
+    const [totalPages, setTotalPages] = useState(0);
+    /* 마지막 페이지 여부 상태 */
+    const [isLast, setIsLast] = useState(false);
+    /* 로딩 상태 */
+    const [isLoading, setIsLoading] = useState(true);
+
+    /* 강의 목록 조회 */
+    const fetchCourses = (p) => {
+        setIsLoading(true);
+
+        getAdminCourses(p)
+            .then(res => {
+                setCourses(res.data.content);
+                setTotalPages(res.data.totalPages);
+                setIsLast(res.data.last);
+            })
+            .catch(() => alert('강의 목록 조회에 실패했습니다.'))
+            .finally(() => setIsLoading(false));
+    };
+
+    /* 페이지 변경 시 강의 목록 재조회 */
+    useEffect(() => {
+        fetchCourses(page);
+    }, [page]);
+
+    /* 강제 폐강 */
+    const handleForceClose = async (courseId, title) => {
+        if (!window.confirm(`"${title}" 강의를 강제 폐강하시겠습니까?`)) return;
+
+        try {
+            await forceCloseCourse(courseId);
+            setCourses(prev => prev.map(c => c.id === courseId ? { ...c, status: 'CLOSED' } : c));
+        } catch (err) {
+            alert(err.response?.data?.message || '강제 폐강에 실패했습니다.');
+        }
+    };
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
+
+    if (courses.length === 0) return (
+        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+            강의가 없습니다.
+        </div>
+    );
+
+    return (
+        <>
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm text-left">
+                    
+                    {/* 테이블 헤더 */ }
+                    <thead>
+                        <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
+                            <th className="pb-3 pr-6 font-semibold">강의명</th>
+                            <th className="pb-3 pr-6 font-semibold">강사</th>
+                            <th className="pb-3 pr-6 font-semibold">상태</th>
+                            <th className="pb-3 pr-6 font-semibold">수강인원</th>
+                            <th className="pb-3 pr-6 font-semibold">등록일</th>
+                            <th className="pb-3 font-semibold"></th>
+                        </tr>
+                    </thead>
+                    {/* 테이블 바디 */ }
+                    <tbody className="divide-y divide-gray-100">
+                        {courses.map(course => (
+                            <tr key={course.id} className="hover:bg-gray-50">
+                                <td className="py-4 pr-6 font-medium text-gray-900 max-w-xs truncate">{course.title}</td>
+                                <td className="py-4 pr-6 text-gray-700">{course.creatorName}</td>
+                                <td className="py-4 pr-6">
+                                    <span className={`text-xs font-bold px-2 py-0.5 rounded border ${COURSE_STATUS_BADGE_STYLE[course.status]}`}>
+                                        {COURSE_STATUS_LABEL[course.status]}
+                                    </span>
+                                </td>
+                                <td className="py-4 pr-6 text-gray-500">{course.enrolledCount} / {course.capacity}</td>
+                                <td className="py-4 pr-6 text-gray-500">{course.createdAt?.substring(0, 10)}</td>
+                                <td className="py-4">
+                                    {course.status !== 'CLOSED' && (
+                                        <button
+                                            onClick={() => handleForceClose(course.id, course.title)}
+                                            className="px-3 py-1 text-xs font-semibold text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"
+                                        >
+                                            강제 폐강
+                                        </button>
+                                    )}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* 페이징 */}
+            {totalPages > 1 && (
+                <div className="flex justify-center items-center gap-4 mt-8">
+                    <button disabled={page === 0}
+                        onClick={() => setPage(prev => prev - 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                        </svg>
+                    </button>
+                    <span className="text-sm font-medium text-gray-700">
+                        <span className="text-blue-600">{page + 1}</span> / {totalPages}
+                    </span>
+                    <button disabled={isLast}
+                        onClick={() => setPage(prev => prev + 1)}
+                        className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </button>
+                </div>
+            )}
+        </>
+    );
+};
+
+export default CourseManagementTab;

--- a/frontend/src/pages/admin/DashboardTab.jsx
+++ b/frontend/src/pages/admin/DashboardTab.jsx
@@ -1,5 +1,42 @@
 import { useEffect, useState } from 'react';
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, LabelList, Label } from 'recharts';
 import { getAdminDashboard } from '../../api/admin';
+
+/* 사용자 역할별 레이블 및 색상 설정 */
+const USER_COLORS = ['#4F46E5', '#8B5CF6'];
+const COURSE_COLORS = ['#10B981', '#9ca3af', '#F87171'];
+
+/* 도넛 차트 중앙 라벨 */
+const DonutCenter = ({ viewBox, total }) => {
+    const { cx, cy } = viewBox;
+    return (
+        <g>
+            <text x={cx} y={cy - 5} textAnchor="middle" fill="#111827" style={{ fontSize: 22, fontWeight: 700 }}>
+                {total.toLocaleString()}
+            </text>
+            <text x={cx} y={cy + 15} textAnchor="middle" fill="#9ca3af" style={{ fontSize: 11 }}>
+                명
+            </text>
+        </g>
+    );
+};
+
+/* 카드 아이콘 */
+const IconUsers = () => (
+    <svg className="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2M9 7a4 4 0 100 8 4 4 0 000-8zM23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" />
+    </svg>
+);
+const IconBook = () => (
+    <svg className="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+    </svg>
+);
+const IconCheck = () => (
+    <svg className="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+);
 
 /* 관리자 대시보드 탭 */
 const DashboardTab = () => {
@@ -8,7 +45,7 @@ const DashboardTab = () => {
     /* 로딩 상태 */
     const [isLoading, setIsLoading] = useState(true);
 
-    /* 컴포넌트 마운트 시 대시보드 통계 데이터 조회 */
+    /* 컴포넌트 마운트 시 통계 데이터 조회 */
     useEffect(() => {
         getAdminDashboard()
             .then(res => setStats(res.data))
@@ -16,26 +53,113 @@ const DashboardTab = () => {
             .finally(() => setIsLoading(false));
     }, []);
 
-    /* 카드 정보 배열 */
+    /* 카드 및 차트 데이터 구성 */
     const cards = [
-        { label: '전체 사용자', value: stats?.totalUsers ?? 0, unit: '명' },
-        { label: '전체 강의', value: stats?.totalCourses ?? 0, unit: '개' },
-        { label: '확정 수강 신청', value: stats?.totalEnrollments ?? 0, unit: '건' },
+        { label: '전체 사용자', value: stats?.totalUsers ?? 0, unit: '명', icon: <IconUsers /> },
+        { label: '전체 강의', value: stats?.totalCourses ?? 0, unit: '개', icon: <IconBook /> },
+        { label: '확정 수강 신청', value: stats?.totalEnrollments ?? 0, unit: '건', icon: <IconCheck /> },
     ];
+
+    /* 사용자 역할 분포 차트 데이터 */
+    const userChartData = [
+        { name: '수강생', value: stats?.studentCount ?? 0 },
+        { name: '강사', value: stats?.creatorCount ?? 0 },
+    ];
+
+    /* 강의 상태 분포 차트 데이터 */
+    const courseChartData = [
+        { name: '모집 중', value: stats?.openCount ?? 0 },
+        { name: '준비 중', value: stats?.draftCount ?? 0 },
+        { name: '마감', value: stats?.closedCount ?? 0 },
+    ];
+
+    /* 전체 사용자 수 계산 (도넛 차트 중앙 라벨용) */
+    const totalUsers = (stats?.studentCount ?? 0) + (stats?.creatorCount ?? 0);
 
     if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
     return (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-            {cards.map(card => (
-                <div key={card.label} className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
-                    <p className="text-xs font-semibold text-gray-400 mb-2">{card.label}</p>
-                    <p className="text-3xl font-extrabold text-gray-900">
-                        {card.value.toLocaleString()}
-                        <span className="text-base font-semibold text-gray-400 ml-1">{card.unit}</span>
-                    </p>
+        <div className="space-y-8">
+            {/* 요약 카드 */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
+                {cards.map(card => (
+                    <div key={card.label} className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
+                        <div className="flex items-start justify-between mb-1">
+                            <p className="text-xs font-semibold text-gray-400 tracking-wide uppercase">{card.label}</p>
+                            {card.icon}
+                        </div>
+                        <p className="text-4xl font-extrabold text-gray-900">
+                            {card.value.toLocaleString()}
+                            <span className="text-sm font-medium text-gray-400 ml-1">{card.unit}</span>
+                        </p>
+                    </div>
+                ))}
+            </div>
+
+            {/* 차트 */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {/* 사용자 역할 분포 */}
+                <div className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
+                    <p className="text-sm font-bold text-gray-700 mb-1">사용자 역할 분포</p>
+                    <ResponsiveContainer width="100%" height={200}>
+                        <PieChart>
+                            <Pie
+                                data={userChartData}
+                                cx="50%"
+                                cy="50%"
+                                innerRadius={58}
+                                outerRadius={82}
+                                paddingAngle={3}
+                                dataKey="value"
+                                startAngle={90}
+                                endAngle={-270}
+                            >
+                                {userChartData.map((_, i) => (
+                                    <Cell key={i} fill={USER_COLORS[i]} strokeWidth={0} />
+                                ))}
+                                <Label content={<DonutCenter total={totalUsers} />} position="center" />
+                            </Pie>
+                            <Tooltip formatter={(v) => `${v.toLocaleString()}명`} />
+                        </PieChart>
+                    </ResponsiveContainer>
+                    <div className="flex justify-center gap-6 mt-1">
+                        {userChartData.map((item, i) => (
+                            <div key={item.name} className="flex items-center gap-1.5">
+                                <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: USER_COLORS[i] }} />
+                                <span className="text-xs text-gray-500">{item.name}</span>
+                                <span className="text-xs font-bold text-gray-700">{item.value.toLocaleString()}</span>
+                            </div>
+                        ))}
+                    </div>
                 </div>
-            ))}
+
+                {/* 강의 상태 분포 */}
+                <div className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
+                    <p className="text-sm font-bold text-gray-700 mb-1">강의 상태 분포</p>
+                    <ResponsiveContainer width="100%" height={200}>
+                        <BarChart data={courseChartData} barSize={44} barCategoryGap="30%">
+                            <XAxis dataKey="name" tick={{ fontSize: 12, fill: '#6b7280' }} axisLine={false} tickLine={false} />
+                            <YAxis allowDecimals={false} tick={{ fontSize: 11, fill: '#9ca3af' }} axisLine={false} tickLine={false} width={28} />
+                            <Tooltip formatter={(v) => `${v.toLocaleString()}개`} cursor={{ fill: '#f9fafb' }} />
+                            <Bar dataKey="value" radius={[6, 6, 0, 0]}>
+                                {courseChartData.map((_, i) => (
+                                    <Cell key={i} fill={COURSE_COLORS[i]} />
+                                ))}
+                                <LabelList dataKey="value" position="top" style={{ fontSize: 12, fontWeight: 700, fill: '#374151' }} />
+                            </Bar>
+                        </BarChart>
+                    </ResponsiveContainer>
+                    <div className="flex justify-center gap-6 mt-1">
+                        {courseChartData.map((item, i) => (
+                            <div key={item.name} className="flex items-center gap-1.5">
+                                <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: COURSE_COLORS[i] }} />
+                                <span className="text-xs text-gray-500">{item.name}</span>
+                                <span className="text-xs font-bold text-gray-700">{item.value.toLocaleString()}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
         </div>
     );
 };

--- a/frontend/src/pages/admin/DashboardTab.jsx
+++ b/frontend/src/pages/admin/DashboardTab.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { getAdminDashboard } from '../../api/admin';
+
+/* 관리자 대시보드 탭 */
+const DashboardTab = () => {
+    /* 통계 데이터 상태 */
+    const [stats, setStats] = useState(null);
+    /* 로딩 상태 */
+    const [isLoading, setIsLoading] = useState(true);
+
+    /* 컴포넌트 마운트 시 대시보드 통계 데이터 조회 */
+    useEffect(() => {
+        getAdminDashboard()
+            .then(res => setStats(res.data))
+            .catch(() => alert('통계 조회에 실패했습니다.'))
+            .finally(() => setIsLoading(false));
+    }, []);
+
+    /* 카드 정보 배열 */
+    const cards = [
+        { label: '전체 사용자', value: stats?.totalUsers ?? 0, unit: '명' },
+        { label: '전체 강의', value: stats?.totalCourses ?? 0, unit: '개' },
+        { label: '확정 수강 신청', value: stats?.totalEnrollments ?? 0, unit: '건' },
+    ];
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
+
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            {cards.map(card => (
+                <div key={card.label} className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+                    <p className="text-xs font-semibold text-gray-400 mb-2">{card.label}</p>
+                    <p className="text-3xl font-extrabold text-gray-900">
+                        {card.value.toLocaleString()}
+                        <span className="text-base font-semibold text-gray-400 ml-1">{card.unit}</span>
+                    </p>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default DashboardTab;

--- a/frontend/src/pages/admin/UserManagementTab.jsx
+++ b/frontend/src/pages/admin/UserManagementTab.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { getAdminUsers, updateUserRole } from '../../api/admin';
+
+/* 역할 레이블 */
+const ROLE_LABEL = { STUDENT: '수강생', CREATOR: '강사', ADMIN: '관리자' };
+/* 역할별 배지 스타일 */
+const ROLE_BADGE = {
+    STUDENT: 'bg-blue-50 text-blue-700 border-blue-200',
+    CREATOR: 'bg-purple-50 text-purple-700 border-purple-200',
+    ADMIN: 'bg-red-50 text-red-700 border-red-200',
+};
+
+/* 관리자 사용자 관리 탭 */
+const UserManagementTab = () => {
+    /* 사용자 목록 상태 */
+    const [users, setUsers] = useState([]);
+    /* 로딩 상태 */
+    const [isLoading, setIsLoading] = useState(true);
+
+    /* 컴포넌트 마운트 시 사용자 목록 조회 */
+    useEffect(() => {
+        getAdminUsers()
+            .then(res => setUsers(res.data))
+            .catch(() => alert('사용자 목록 조회에 실패했습니다.'))
+            .finally(() => setIsLoading(false));
+    }, []);
+
+    /* 역할 변경 */
+    const handleRoleChange = async (userId, newRole) => {
+        if (!window.confirm(`역할을 ${ROLE_LABEL[newRole]}(으)로 변경하시겠습니까?`)) return;
+
+        try {
+            await updateUserRole(userId, newRole);
+            setUsers(prev => prev.map(u => u.id === userId ? { ...u, role: newRole } : u));
+        } catch (err) {
+            alert(err.response?.data?.message || '역할 변경에 실패했습니다.');
+        }
+    };
+
+    if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
+
+    if (users.length === 0) return (
+        <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+            사용자가 없습니다.
+        </div>
+    );
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left">
+                <thead>
+                    <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
+                        <th className="pb-3 pr-6 font-semibold">아이디</th>
+                        <th className="pb-3 pr-6 font-semibold">이름</th>
+                        <th className="pb-3 pr-6 font-semibold">이메일</th>
+                        <th className="pb-3 pr-6 font-semibold">역할</th>
+                        <th className="pb-3 font-semibold">가입일</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                    {users.map(user => (
+                        <tr key={user.id} className="hover:bg-gray-50">
+                            <td className="py-4 pr-6 font-medium text-gray-900">{user.username}</td>
+                            <td className="py-4 pr-6 text-gray-700">{user.name}</td>
+                            <td className="py-4 pr-6 text-gray-500">{user.email}</td>
+                            <td className="py-4 pr-6">
+                                {user.role === 'ADMIN' ? (
+                                    <span className={`text-xs font-bold px-2 py-0.5 rounded border ${ROLE_BADGE[user.role]}`}>
+                                        {ROLE_LABEL[user.role]}
+                                    </span>
+                                ) : (
+                                    <select
+                                        value={user.role}
+                                        onChange={(e) => handleRoleChange(user.id, e.target.value)}
+                                        className="text-xs border border-gray-300 rounded px-2 py-1 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+                                    >
+                                        <option value="STUDENT">수강생</option>
+                                        <option value="CREATOR">강사</option>
+                                    </select>
+                                )}
+                            </td>
+                            <td className="py-4 text-gray-500">{user.createdAt?.substring(0, 10)}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default UserManagementTab;


### PR DESCRIPTION
  ## 작업 내용
  - GET /api/admin/dashboard 엔드포인트 추가 - 전체 사용자 수·강의 수·확정 수강 신청 수 통계 제공   
  - GET /api/admin/users 엔드포인트 추가 - 전체 사용자 목록 조회                                                                                             
  - PATCH /api/admin/users/{userId}/role 엔드포인트 추가 - 역할 변경 (ADMIN 역할로의 변경 차단)
  - GET /api/admin/courses 엔드포인트 추가 - 전체 강의 목록 조회 (상태 무관, 페이지네이션)
  - PATCH /api/admin/courses/{courseId}/close 엔드포인트 추가 - 강제 폐강
  - AdminService 분리 생성 - 관리자 전용 비즈니스 로직 전담
  - 대시보드·사용자 관리·강의 관리 API 함수 추가 (admin.js)
  - 관리자 페이지 대시보드·사용자 관리·강의 관리 탭 추가
  - RespAdminDashboardDto 세분화 - 역할별 사용자 수(STUDENT/CREATOR), 상태별 강의 수(DRAFT/OPEN/CLOSED) 필드 추가
  - 대시보드 통계 API에 세분화 데이터 포함
  - recharts 설치 및 사용자 역할 분포 도넛 차트, 강의 상태 분포 바 차트 추가

  ## 구현 시 고려한 점
  - 모든 엔드포인트는 /api/admin/** 하위로 SecurityConfig에서 ADMIN 전용으로 제한
  - AdminService를 UserService·CourseService와 분리해 관리자 로직이 기존 서비스에 침범하지 않도록 설계
  - 역할 변경 시 ADMIN 역할로의 변경은 서비스 레이어에서 명시적으로 차단
  - 강제 폐강은 DRAFT·OPEN 상태 모두 허용, 이미 CLOSED인 강의 재요청 시 400 반환
  - 사용자 역할 변경 후 서버 재조회 없이 로컬 상태 즉시 반영

  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - ADMIN 계정으로 로그인 후 관리자 페이지 진입 → 대시보드 통계 확인
  - 대시보드 탭 → 사용자 역할 분포(수강생/강사) 도넛 차트, 강의 상태 분포(모집 중/준비 중/마감) 바 차트 확인
  - 사용자 관리 탭 → 역할 드롭다운으로 STUDENT·CREATOR 전환 확인
  - ADMIN 계정은 드롭다운 없이 배지만 표시되는지 확인
  - 강의 관리 탭 → OPEN/DRAFT 강의 강제 폐강 후 상태 변경 확인
  - 이미 폐강된 강의에 강제 폐강 버튼 미노출 확인
  - STUDENT/CREATOR 계정으로 /api/admin/** 접근 시 403 확인

  ## 연관 이슈
  Closes #50