### PR TITLE
[fix] 동시 수강 신청 중복 처리 및 취소 동시성 버그 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,7 +32,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:mysql'
+	testImplementation 'org.testcontainers:junit-jupiter'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.mysql:mysql-connector-j'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
@@ -55,6 +55,22 @@ public class Enrollment {
                 .build();
     }
 
+    /* 재신청 시 PENDING 상태로 변경할 엔티티 생성 */
+    public static Enrollment ofPending(Long id) {
+        return Enrollment.builder()
+                .id(id)
+                .status(EnrollmentStatus.PENDING)
+                .build();
+    }
+
+    /* 재신청 시 WAITLIST 상태로 변경할 엔티티 생성 */
+    public static Enrollment ofWaitlistById(Long id) {
+        return Enrollment.builder()
+                .id(id)
+                .status(EnrollmentStatus.WAITLIST)
+                .build();
+    }
+
     /* 대기열에서 PENDING으로 승격할 엔티티 생성 */
     public static Enrollment ofPromote(Long id) {
         return Enrollment.builder()

--- a/backend/src/main/java/com/yujin/course_enrollment/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.global.exception;
 
 import com.yujin.course_enrollment.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,12 +19,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     /**
+     * 중복 수강 신청 처리 (동시 요청으로 UNIQUE 제약 위반 시)
+     */
+    @ExceptionHandler(DuplicateKeyException.class)
+    public ResponseEntity<ApiResponse<?>> handleDuplicateKeyException(DuplicateKeyException e) {
+        log.warn("[GlobalExceptionHandler] DuplicateKeyException: {}", e.getMessage());
+
+        return ResponseEntity.badRequest().body(ApiResponse.fail(400, "이미 신청한 강의입니다."));
+    }
+
+    /**
      * 비즈니스 로직 예외 처리
      * BusinessException이 가진 HTTP 상태 코드로 응답
      */
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<?>> handleBusinessException(BusinessException e) {
         log.warn("[GlobalExceptionHandler] BusinessException: {}", e.getMessage());
+
         return ResponseEntity.status(e.getStatus()).body(ApiResponse.fail(e.getStatus().value(), e.getMessage()));
     }
 
@@ -38,6 +50,7 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse("입력값이 올바르지 않습니다.");
         log.warn("[GlobalExceptionHandler] ValidationException: {}", message);
+
         return ResponseEntity.badRequest().body(ApiResponse.fail(400, message));
     }
 
@@ -48,6 +61,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleMissingHeaderException(MissingRequestHeaderException e) {
         String message = e.getHeaderName() + " 헤더가 누락되었습니다.";
         log.warn("[GlobalExceptionHandler] MissingRequestHeaderException: {}", message);
+
         return ResponseEntity.badRequest().body(ApiResponse.fail(400, message));
     }
 
@@ -57,6 +71,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         log.warn("[GlobalExceptionHandler] HttpMessageNotReadableException: {}", e.getMessage());
+
         return ResponseEntity.badRequest().body(ApiResponse.fail(400, "요청 형식이 올바르지 않습니다."));
     }
 
@@ -66,6 +81,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("[GlobalExceptionHandler] Unexpected Exception", e);
+
         return ResponseEntity.internalServerError().body(ApiResponse.fail(500, "서버 오류가 발생했습니다."));
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -41,8 +41,8 @@ public interface CourseMapper {
     /* 수강 인원 증가 (정원 미만일 때만, 반환값: 업데이트된 행 수) */
     int updateCourseEnrolledCountPlus(Long courseId);
 
-    /* 수강 인원 감소 */
-    void updateCourseEnrolledCountMinus(Long courseId);
+    /* 수강 인원 감소 (0 초과일 때만, 반환값: 업데이트된 행 수) */
+    int updateCourseEnrolledCountMinus(Long courseId);
 
     /* 나의 강의 목록 조회 (CREATOR 전용) */
     List<RespCourseListDto> selectCourseListByCreatorId(ReqMyCoursePageDto reqMyCoursePageDto);

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -89,6 +90,35 @@ public class EnrollmentService {
 
             log.warn("[EnrollmentService] 중복 신청 - userId: {}, courseId: {}", userId, courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
+        }
+
+        // 재신청: UNIQUE 충돌 방지를 위해 INSERT 대신 기존 행 UPDATE
+        if (existing != null) {
+            if (course.getEnrolledCount() >= course.getCapacity()) {
+                log.info("[EnrollmentService] 정원 초과 - 재신청 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
+
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofWaitlistById(existing.getId()));
+                Enrollment saved = enrollmentMapper.selectEnrollmentById(existing.getId());
+
+                return RespEnrollmentDto.of(saved, course.getTitle());
+            }
+
+            int updated = courseMapper.updateCourseEnrolledCountPlus(courseId);
+            if (updated == 0) {
+                log.info("[EnrollmentService] 동시 신청으로 정원 초과 - 재신청 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
+
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofWaitlistById(existing.getId()));
+                Enrollment saved = enrollmentMapper.selectEnrollmentById(existing.getId());
+
+                return RespEnrollmentDto.of(saved, course.getTitle());
+            }
+
+            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofPending(existing.getId()));
+            log.info("[EnrollmentService] 재신청 완료 - userId: {}, courseId: {}", userId, courseId);
+
+            Enrollment saved = enrollmentMapper.selectEnrollmentById(existing.getId());
+
+            return RespEnrollmentDto.of(saved, course.getTitle());
         }
 
         // 정원 초과 시 WAITLIST 등록
@@ -190,7 +220,7 @@ public class EnrollmentService {
      * @return 취소된 수강 신청 응답 DTO
      * @throws BusinessException 수강 신청 없음(400), 본인 신청 아님(403), 이미 취소됨(400), CONFIRMED 7일 초과(400), 취소 사유 없음(400)
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public RespEnrollmentDto cancelEnrollment(Long userId, Long enrollmentId, String cancelReason) {
         log.info("[EnrollmentService] 수강 취소 - userId: {}, enrollmentId: {}", userId, enrollmentId);
 
@@ -241,18 +271,21 @@ public class EnrollmentService {
             return RespEnrollmentDto.of(saved, course.getTitle());
         }
 
-        courseMapper.updateCourseEnrolledCountMinus(enrollment.getCourseId());
+        int minused = courseMapper.updateCourseEnrolledCountMinus(enrollment.getCourseId());
 
-        // 대기열 승격 시도 (동시 경쟁 실패 시 다음 대기자로 재시도)
-        Enrollment nextWaitlist;
-        while ((nextWaitlist = enrollmentMapper.selectNextWaitlist(enrollment.getCourseId())) != null) {
-            int promoted = enrollmentMapper.updateEnrollmentStatusPromote(nextWaitlist.getId());
+        // minus 성공 시에만 대기열 승격 시도 (동시 경쟁 실패 시 다음 대기자로 재시도)
+        if (minused > 0) {
+            Enrollment nextWaitlist;
 
-            if (promoted > 0) {
-                courseMapper.updateCourseEnrolledCountPlus(enrollment.getCourseId());
-                log.info("[EnrollmentService] 대기열 승격 - enrollmentId: {}", nextWaitlist.getId());
+            while ((nextWaitlist = enrollmentMapper.selectNextWaitlist(enrollment.getCourseId())) != null) {
+                int promoted = enrollmentMapper.updateEnrollmentStatusPromote(nextWaitlist.getId());
 
-                break;
+                if (promoted > 0) {
+                    courseMapper.updateCourseEnrolledCountPlus(enrollment.getCourseId());
+                    log.info("[EnrollmentService] 대기열 승격 - enrollmentId: {}", nextWaitlist.getId());
+
+                    break;
+                }
             }
         }
 

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.yujin.course_enrollment.mapper.EnrollmentMapper">
 
-    <!-- 수강 신청 등록 (취소 후 재신청 시 ON DUPLICATE KEY UPDATE로 PENDING 초기화) -->
+    <!-- 수강 신청 등록 -->
     <insert id="insertEnrollment" parameterType="Enrollment" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO enrollments (
                 user_id
@@ -14,10 +14,6 @@
               , #{courseId}
               , #{status}
         )
-        ON DUPLICATE KEY UPDATE
-              status = #{status}
-            , confirmed_at = NULL
-            , cancelled_at = NULL
     </insert>
 
     <!-- 수강 신청 단건 조회 -->

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
@@ -5,18 +5,23 @@ import com.yujin.course_enrollment.dto.resp.RespEnrollmentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.EnrollmentStatus;
+import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
+import org.springframework.dao.DuplicateKeyException;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.sql.PreparedStatement;
-import java.sql.Statement;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,10 +36,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 수강 신청 동시성 통합 테스트
- * 실제 DB의 조건부 UPDATE(enrolled_count < capacity)가 동시 요청에서 정원 초과를 막는지 검증
+ * 실제 MySQL의 UNIQUE INDEX와 조건부 UPDATE가 동시 요청에서 정합성을 보장하는지 검증
  */
+@Testcontainers
 @SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 class EnrollmentConcurrencyTest {
+
+    @Container
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
 
     @Autowired
     private EnrollmentService enrollmentService;
@@ -246,6 +256,7 @@ class EnrollmentConcurrencyTest {
 
         Course updated = courseMapper.selectCourseById(courseId);
 
+
         System.out.println("[승격 결과] PENDING 승격: " + promotedCount + " / enrolled_count: " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
 
         assertThat(promotedCount).isEqualTo(3); // WAITLIST 3명 모두 PENDING 승격
@@ -316,6 +327,7 @@ class EnrollmentConcurrencyTest {
 
         Course updated = courseMapper.selectCourseById(courseId);
 
+
         System.out.println("[승격 결과] PENDING 승격: " + promotedCount + " / enrolled_count: " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
 
         assertThat(promotedCount).isEqualTo(2); // 취소 2명 → 승격 2명
@@ -375,9 +387,60 @@ class EnrollmentConcurrencyTest {
         // then
         Course updated = courseMapper.selectCourseById(courseId);
 
+
         System.out.println("[취소 결과] enrolled_count: " + updated.getEnrolledCount() + " / capacity: " + updated.getCapacity());
 
         assertThat(updated.getEnrolledCount()).isEqualTo(0);
         assertThat(updated.getEnrolledCount()).isLessThanOrEqualTo(updated.getCapacity());
+    }
+
+    @Test
+    @DisplayName("같은 사용자 동시 신청 - 1건만 성공, 나머지는 500 없이 400 처리")
+    void registerEnrollment_sameUser_concurrentRequests_noDuplicate() throws InterruptedException {
+        // given
+        Long userId = insertStudents(1).get(0);
+        Long courseId = createOpenCourse(1L, 10).getId();
+
+        int requestCount = 5;
+        CopyOnWriteArrayList<String> statuses = new CopyOnWriteArrayList<>();
+        ExecutorService executor = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch readyLatch = new CountDownLatch(requestCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(requestCount);
+
+        for (int i = 0; i < requestCount; i++) {
+            executor.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+                    RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+                    statuses.add(result.getStatus());
+                } catch (BusinessException | DuplicateKeyException e) {
+                    statuses.add("400: " + e.getMessage());
+                } catch (Exception e) {
+                    statuses.add("ERROR: [" + e.getClass().getSimpleName() + "] " + e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then
+        long successCount = statuses.stream().filter(s -> EnrollmentStatus.PENDING.equals(s) || EnrollmentStatus.WAITLIST.equals(s)).count();
+        long errorCount   = statuses.stream().filter(s -> s.startsWith("ERROR")).count();
+
+        System.out.println("[결과] 성공: " + successCount + " / 400 처리: " + (requestCount - successCount - errorCount) + " / ERROR(500): " + errorCount);
+
+        assertThat(errorCount).isEqualTo(0);
+        assertThat(successCount).isEqualTo(1);
+
+        Course updated = courseMapper.selectCourseById(courseId);
+        System.out.println("[enrolled_count] " + updated.getEnrolledCount());
+        assertThat(updated.getEnrolledCount()).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -251,16 +251,18 @@ class EnrollmentServiceTest {
 
         given(userMapper.selectUserById(userId)).willReturn(student);
         given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
-        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(cancelled).willReturn(reEnrolled);
-        willDoNothing().given(enrollmentMapper).insertEnrollment(any());
+        given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(cancelled);
         given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(1);
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(reEnrolled);
 
         // when
         RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, req);
 
         // then
         assertThat(result.getStatus()).isEqualTo("PENDING");
-        then(enrollmentMapper).should().insertEnrollment(any());
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+        then(enrollmentMapper).should(never()).insertEnrollment(any());
         then(courseMapper).should().updateCourseEnrolledCountPlus(courseId);
     }
 
@@ -467,7 +469,7 @@ class EnrollmentServiceTest {
 
         given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(pending).willReturn(cancelled);
         willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
-        willDoNothing().given(courseMapper).updateCourseEnrolledCountMinus(1L);
+        given(courseMapper.updateCourseEnrolledCountMinus(1L)).willReturn(1);
         given(courseMapper.selectCourseById(1L)).willReturn(course);
 
         // when
@@ -549,7 +551,7 @@ class EnrollmentServiceTest {
         given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(confirmed).willReturn(cancelled);
         willDoNothing().given(paymentService).refund(enrollmentId, cancelReason);
         willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
-        willDoNothing().given(courseMapper).updateCourseEnrolledCountMinus(courseId);
+        given(courseMapper.updateCourseEnrolledCountMinus(courseId)).willReturn(1);
         given(enrollmentMapper.selectNextWaitlist(courseId)).willReturn(null);
         given(courseMapper.selectCourseById(courseId)).willReturn(course);
 


### PR DESCRIPTION
  ## 작업 내용
  - ON DUPLICATE KEY UPDATE 제거 - 중복 INSERT 시 DuplicateKeyException 발생, GlobalExceptionHandler에서 400 응답 처리
  - 재신청(CANCELLED → PENDING/WAITLIST)은 INSERT 대신 updateEnrollmentStatus로 명시적 처리, Enrollment.ofPending() / ofWaitlistById() 팩토리 메서드 추가
  - cancelEnrollment READ_COMMITTED 격리 수준 적용 - 대기열 승격 루프에서 REPEATABLE READ 스냅샷 문제 수정
  - updateCourseEnrolledCountMinus 반환값(int) 확인 후 대기열 승격 실행 - 실제 감소 없이 승격하는 언더플로우 방어
  - Testcontainers(MySQL) 기반 동시성 통합 테스트 추가 - H2는 동시성 환경에서 UNIQUE 제약을 제대로 검증하지 못해 실제 MySQL로 전환
  - build.gradle 테스트 의존성 추가 - spring-boot-testcontainers, testcontainers:mysql, junit-jupiter, mysql-connector-j

  ## 구현 시 고려한 점
  - ODKU 제거 후에도 재신청 흐름이 깨지지 않도록 서비스 레이어에서 existing != null 분기를 명시적으로 분리
  - MySQL Connector/J가 기본으로 CLIENT_FOUND_ROWS를 활성화해 ODKU affected rows로 중복 감지가 불가능함을 확인 - INSERT/UPDATE 분리
  - READ_COMMITTED는 cancelEnrollment에만 적용, registerEnrollment는 plain INSERT + DuplicateKeyException으로 해결

  ## 테스트 방법
  - ./gradlew test 실행 후 EnrollmentConcurrencyTest, EnrollmentServiceTest 전체 통과 확인
  - 동일 사용자로 동시 신청 5건 → 1건만 PENDING, 나머지 4건 400 응답 확인
  - 취소 후 재신청 → 기존 행 UPDATE로 PENDING 전환 확인

  ## 연관 이슈
  Closes #52