### PR TITLE
[fix] 재신청 동시성 버그 및 대기열 승격 경합 조건 수정  

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
@@ -70,12 +70,4 @@ public class Enrollment {
                 .status(EnrollmentStatus.WAITLIST)
                 .build();
     }
-
-    /* 대기열에서 PENDING으로 승격할 엔티티 생성 */
-    public static Enrollment ofPromote(Long id) {
-        return Enrollment.builder()
-                .id(id)
-                .status(EnrollmentStatus.PENDING)
-                .build();
-    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -28,6 +28,9 @@ public interface EnrollmentMapper {
     /* 수강 신청 상태 변경 */
     void updateEnrollmentStatus(Enrollment enrollment);
 
+    /* 재신청 상태 변경 (CANCELLED 상태일 때만, 반환값: 업데이트된 행 수) */
+    int updateEnrollmentStatusReEnroll(Enrollment enrollment);
+
     /* 나의 수강 신청 목록 조회 */
     List<RespEnrollmentStudentDto> selectEnrollmentListByUserId(ReqEnrollmentPageDto reqEnrollmentPageDto);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -92,12 +92,16 @@ public class EnrollmentService {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
         }
 
-        // 재신청: UNIQUE 충돌 방지를 위해 INSERT 대신 기존 행 UPDATE
+        // 재신청: UNIQUE 충돌 방지를 위해 INSERT 대신 기존 행 UPDATE (AND status = 'CANCELLED' 조건으로 동시 재신청 방어)
         if (existing != null) {
             if (course.getEnrolledCount() >= course.getCapacity()) {
                 log.info("[EnrollmentService] 정원 초과 - 재신청 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
 
-                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofWaitlistById(existing.getId()));
+                int reEnrolled = enrollmentMapper.updateEnrollmentStatusReEnroll(Enrollment.ofWaitlistById(existing.getId()));
+                if (reEnrolled == 0) {
+                    throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
+                }
+
                 Enrollment saved = enrollmentMapper.selectEnrollmentById(existing.getId());
 
                 return RespEnrollmentDto.of(saved, course.getTitle());
@@ -107,13 +111,21 @@ public class EnrollmentService {
             if (updated == 0) {
                 log.info("[EnrollmentService] 동시 신청으로 정원 초과 - 재신청 대기열 등록 - userId: {}, courseId: {}", userId, courseId);
 
-                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofWaitlistById(existing.getId()));
+                int reEnrolled = enrollmentMapper.updateEnrollmentStatusReEnroll(Enrollment.ofWaitlistById(existing.getId()));
+                if (reEnrolled == 0) {
+                    throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
+                }
+
                 Enrollment saved = enrollmentMapper.selectEnrollmentById(existing.getId());
 
                 return RespEnrollmentDto.of(saved, course.getTitle());
             }
 
-            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofPending(existing.getId()));
+            int reEnrolled = enrollmentMapper.updateEnrollmentStatusReEnroll(Enrollment.ofPending(existing.getId()));
+            if (reEnrolled == 0) {
+                throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 신청한 강의입니다.");
+            }
+
             log.info("[EnrollmentService] 재신청 완료 - userId: {}, courseId: {}", userId, courseId);
 
             Enrollment saved = enrollmentMapper.selectEnrollmentById(existing.getId());

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -54,6 +54,16 @@
          WHERE id = #{id}
     </update>
 
+    <!-- 재신청 상태 변경 (CANCELLED 상태일 때만 업데이트, 동시 재신청 경합 방지) -->
+    <update id="updateEnrollmentStatusReEnroll" parameterType="Enrollment">
+        UPDATE enrollments
+           SET status = #{status}
+             , confirmed_at = #{confirmedAt}
+             , cancelled_at = #{cancelledAt}
+         WHERE id = #{id}
+           AND status = 'CANCELLED'
+    </update>
+
     <!-- 강의별 수강생 목록 조회 (CREATOR 전용) -->
     <select id="selectEnrollmentListByCourseId" parameterType="ReqCourseEnrollmentPageDto" resultType="RespEnrollmentCreatorDto">
         SELECT e.id
@@ -127,7 +137,7 @@
          WHERE status = 'CONFIRMED'
     </select>
 
-    <!-- 대기열 첫 번째 조회 (자동 승격용) -->
+    <!-- 대기열 첫 번째 조회 (자동 승격용, FOR UPDATE SKIP LOCKED으로 동시 취소 경합 방지) -->
     <select id="selectNextWaitlist" parameterType="Long" resultType="Enrollment">
         SELECT id
              , user_id
@@ -142,6 +152,7 @@
            AND status = 'WAITLIST'
         ORDER BY created_at ASC
         LIMIT 1
+        FOR UPDATE SKIP LOCKED
     </select>
 
 </mapper>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentConcurrencyTest.java
@@ -443,4 +443,58 @@ class EnrollmentConcurrencyTest {
         System.out.println("[enrolled_count] " + updated.getEnrolledCount());
         assertThat(updated.getEnrolledCount()).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("같은 사용자 동시 재신청 - 1건만 성공, 나머지는 500 없이 400 처리")
+    void registerEnrollment_sameUser_concurrentReEnrollments_noDuplicate() throws InterruptedException {
+        // given - 사용자가 신청 후 취소한 상태 세팅
+        Long userId = insertStudents(1).get(0);
+        Long courseId = createOpenCourse(1L, 10).getId();
+
+        enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+        Long enrollmentId = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId).getId();
+        enrollmentService.cancelEnrollment(userId, enrollmentId, null);
+
+        int requestCount = 5;
+        CopyOnWriteArrayList<String> statuses = new CopyOnWriteArrayList<>();
+        ExecutorService executor = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch readyLatch = new CountDownLatch(requestCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(requestCount);
+
+        for (int i = 0; i < requestCount; i++) {
+            executor.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+                    RespEnrollmentDto result = enrollmentService.registerEnrollment(userId, new ReqEnrollmentCreateDto(courseId));
+                    statuses.add(result.getStatus());
+                } catch (BusinessException | DuplicateKeyException e) {
+                    statuses.add("400: " + e.getMessage());
+                } catch (Exception e) {
+                    statuses.add("ERROR: [" + e.getClass().getSimpleName() + "] " + e.getMessage());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then
+        long successCount = statuses.stream().filter(s -> EnrollmentStatus.PENDING.equals(s) || EnrollmentStatus.WAITLIST.equals(s)).count();
+        long errorCount   = statuses.stream().filter(s -> s.startsWith("ERROR")).count();
+
+        System.out.println("[결과] 성공: " + successCount + " / 400 처리: " + (requestCount - successCount - errorCount) + " / ERROR(500): " + errorCount);
+
+        assertThat(errorCount).isEqualTo(0);
+        assertThat(successCount).isEqualTo(1);
+
+        Course updated = courseMapper.selectCourseById(courseId);
+        System.out.println("[enrolled_count] " + updated.getEnrolledCount());
+        assertThat(updated.getEnrolledCount()).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/EnrollmentServiceTest.java
@@ -253,7 +253,7 @@ class EnrollmentServiceTest {
         given(courseMapper.selectCourseById(courseId)).willReturn(openCourse);
         given(enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId)).willReturn(cancelled);
         given(courseMapper.updateCourseEnrolledCountPlus(courseId)).willReturn(1);
-        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+        given(enrollmentMapper.updateEnrollmentStatusReEnroll(any())).willReturn(1);
         given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(reEnrolled);
 
         // when
@@ -261,7 +261,7 @@ class EnrollmentServiceTest {
 
         // then
         assertThat(result.getStatus()).isEqualTo("PENDING");
-        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+        then(enrollmentMapper).should().updateEnrollmentStatusReEnroll(any());
         then(enrollmentMapper).should(never()).insertEnrollment(any());
         then(courseMapper).should().updateCourseEnrolledCountPlus(courseId);
     }


### PR DESCRIPTION
  ## 작업 내용
  - updateEnrollmentStatusReEnroll 추가 - AND status = 'CANCELLED' 조건으로 동시 재신청 시 한 건만 UPDATE 성공, 나머지는 0 반환 → BusinessException(400) 처리
  - 재신청 경로에서 반환값 체크 후 예외 처리 - enrolled_count 증가 후 UPDATE 실패 시 트랜잭션 롤백으로 count 정합성 보장
  - selectNextWaitlist에 FOR UPDATE SKIP LOCKED 추가 - 동시 취소 시 각 트랜잭션이 서로 다른 대기열 행을 선점해 불필요한 retry 제거
  - 동시 재신청 통합 테스트 추가 (registerEnrollment_sameUser_concurrentReEnrollments_noDuplicate)

  ## 구현 시 고려한 점
  - 기존 updateEnrollmentStatus는 그대로 유지 - 결제 확정·취소 경로는 조건 없이 업데이트가 맞고, 재신청 경로만 분리
  - FOR UPDATE SKIP LOCKED는 cancelEnrollment의 @Transactional 내에서만 호출되므로 트랜잭션 보장 문제 없음
  - 재신청 실패(reEnrolled == 0) 시 BusinessException throw → @Transactional 롤백으로 enrolled_count 증가분도 함께 되돌림

  ## 테스트 방법
  - ./gradlew test 실행 후 EnrollmentConcurrencyTest, EnrollmentServiceTest 전체 통과 확인
  - 동일 사용자 취소 후 동시 재신청 5건 → 1건만 PENDING, 나머지 4건 400 응답 확인

  ## 연관 이슈
  Closes #54