### PR TITLE
[fix] ADMIN 수강 신청 버튼 비활성화 및 JWT 보안 로그 레벨 개선

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
@@ -47,7 +47,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
                 log.debug("[JwtFilter] 인증 설정 완료 - userId: {}, role: ROLE_{}", userId, role);
             } catch (Exception e) {
-                log.debug("[JwtFilter] 토큰 파싱 실패: {}", e.getMessage());
+                log.warn("[JwtFilter] 토큰 파싱 실패: {}", e.getMessage());
             }
         } else {
             log.debug("[JwtFilter] accessToken 쿠키 없음 - uri: {}", request.getRequestURI());

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -216,6 +216,11 @@ const CourseDetailPage = () => {
                                                 className="w-full mt-8 py-4 font-bold rounded-md transition-all shadow-md cursor-not-allowed bg-gray-200 text-gray-500">
                                                 이미 신청한 강의입니다
                                             </button>
+                                        ) : user?.role === 'ADMIN' ? (
+                                            <button disabled
+                                                className="w-full mt-8 py-4 font-bold rounded-md transition-all shadow-md cursor-not-allowed bg-gray-200 text-gray-500">
+                                                관리자는 수강 신청할 수 없습니다
+                                            </button>
                                         ) : (
                                             <button
                                                 onClick={handleEnroll}


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - user.role === 'ADMIN'이면 수강 신청 버튼 비활성화 처리
  - 토큰 파싱 실패 시 log.debug → log.warn 변경

  ## 구현 시 고려한 점
  - SecurityConfig에서 /api/enrollments/**는 이미 STUDENT/CREATOR만 허용하므로 API 레벨에서는 막혀 있음. 프론트엔드 비활성화는 UX 개선이 주목적
  - log.debug는 프로덕션 환경에서 기본적으로 출력되지 않아 위변조·만료 토큰 수신 이벤트를 모니터링할 수 없는 상태였음. 보안 이벤트는 warn 레벨 이상으로 남겨야 운영 중 감지 가능

  ## 연관 이슈
  Closes #56
