### PR TITLE
[fix] 강의 마감 시 WAITLIST 자동 취소 처리

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -51,4 +51,7 @@ public interface EnrollmentMapper {
 
     /* 확정된 수강 신청 수 조회 */
     int selectConfirmedEnrollmentCount();
+
+    /* 강의 마감 시 대기열 전체 취소 */
+    int updateWaitlistCancelledByCourseId(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -252,6 +252,11 @@ public class CourseService {
 
         courseMapper.updateCourseStatus(Course.builder().id(courseId).status(CourseStatus.CLOSED).build());
 
+        int cancelled = enrollmentMapper.updateWaitlistCancelledByCourseId(courseId);
+        if (cancelled > 0) {
+            log.info("[CourseService] 대기열 자동 취소 - courseId: {}, count: {}", courseId, cancelled);
+        }
+
         log.info("[CourseService] 강의 마감 완료 - courseId: {}", courseId);
 
         return courseMapper.selectCourseDetailById(courseId);

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -137,6 +137,15 @@
          WHERE status = 'CONFIRMED'
     </select>
 
+    <!-- 강의 마감 시 대기열 전체 취소 -->
+    <update id="updateWaitlistCancelledByCourseId" parameterType="Long">
+        UPDATE enrollments
+           SET status = 'CANCELLED'
+             , cancelled_at = NOW()
+         WHERE course_id = #{courseId}
+           AND status = 'WAITLIST'
+    </update>
+
     <!-- 대기열 첫 번째 조회 (자동 승격용, FOR UPDATE SKIP LOCKED으로 동시 취소 경합 방지) -->
     <select id="selectNextWaitlist" parameterType="Long" resultType="Enrollment">
         SELECT id


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - 강의 상태 CLOSED 변경 후 해당 강의의 WAITLIST 전체 CANCELLED 처리
  - EnrollmentMapper - updateWaitlistCancelledByCourseId 메서드 추가
  - EnrollmentMapper.xml — 대응 쿼리 추가
  
  ## 구현 시 고려한 점
  - WAITLIST는 정원 공석 발생 시 자동 승격을 기다리는 상태이므로, 강의가 마감되면 승격 가능성이 없어 유지 의미가 없음
  - PENDING / CONFIRMED는 이미 자리를 확보한 상태이므로 마감 시에도 유지
  - 기존 closeCourse 트랜잭션 안에서 함께 처리하여 상태 변경과 대기열 취소가 원자적으로 반영되도록 함
  
  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - http://localhost:5173 에서 OPEN 상태 강의에 WAITLIST 등록 후 강사 계정으로 강의 마감 → 마이페이지에서 해당 수강 신청이 CANCELLED로 변경되는지 확인

  ## 연관 이슈
  Closes #58 
