### PR TITLE
[fix] 강제 폐강 처리 및 FORCE_CLOSED 상태 분리

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
@@ -16,10 +16,11 @@ public class RespAdminDashboardDto {
     private int draftCount;
     private int openCount;
     private int closedCount;
+    private int forceClosedCount;
     private int totalEnrollments;
 
     /* 통계 집계 결과로 대시보드 응답 생성 */
-    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int totalEnrollments) {
+    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int forceClosedCount, int totalEnrollments) {
         return RespAdminDashboardDto.builder()
                 .totalUsers(totalUsers)
                 .studentCount(studentCount)
@@ -28,6 +29,7 @@ public class RespAdminDashboardDto {
                 .draftCount(draftCount)
                 .openCount(openCount)
                 .closedCount(closedCount)
+                .forceClosedCount(forceClosedCount)
                 .totalEnrollments(totalEnrollments)
                 .build();
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespCourseListDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespCourseListDto.java
@@ -17,6 +17,8 @@ public class RespCourseListDto {
     private int price;
     private int capacity;
     private int enrolledCount;
+    private int confirmedCount;
+    private int pendingCount;
     private String status;
     private LocalDate startDate;
     private LocalDate endDate;

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Course.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Course.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.entity;
 
+import com.yujin.course_enrollment.global.CourseStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,4 +31,28 @@ public class Course {
     private LocalDate endDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    /* 강의 공개 상태 변경용 */
+    public static Course ofOpen(Long id) {
+        return Course.builder()
+                .id(id)
+                .status(CourseStatus.OPEN)
+                .build();
+    }
+
+    /* 강의 마감 상태 변경용 */
+    public static Course ofClosed(Long id) {
+        return Course.builder()
+                .id(id)
+                .status(CourseStatus.CLOSED)
+                .build();
+    }
+
+    /* 강제 폐강 상태 변경용 */
+    public static Course ofForceClosed(Long id) {
+        return Course.builder()
+                .id(id)
+                .status(CourseStatus.FORCE_CLOSED)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/entity/Enrollment.java
@@ -70,4 +70,13 @@ public class Enrollment {
                 .status(EnrollmentStatus.WAITLIST)
                 .build();
     }
+
+    /* 강제 폐강으로 취소할 엔티티 생성 */
+    public static Enrollment ofForceClose(Long id) {
+        return Enrollment.builder()
+                .id(id)
+                .status(EnrollmentStatus.FORCE_CLOSED)
+                .cancelledAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/global/CourseStatus.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/CourseStatus.java
@@ -7,6 +7,7 @@ public class CourseStatus {
     public static final String DRAFT = "DRAFT";
     public static final String OPEN = "OPEN";
     public static final String CLOSED = "CLOSED";
+    public static final String FORCE_CLOSED = "FORCE_CLOSED";
 
     private CourseStatus() {}
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/global/EnrollmentStatus.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/EnrollmentStatus.java
@@ -8,6 +8,7 @@ public class EnrollmentStatus {
     public static final String CONFIRMED = "CONFIRMED";
     public static final String CANCELLED = "CANCELLED";
     public static final String WAITLIST = "WAITLIST";
+    public static final String FORCE_CLOSED = "FORCE_CLOSED";
 
     private EnrollmentStatus() {}
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/CourseMapper.java
@@ -58,4 +58,7 @@ public interface CourseMapper {
 
     /* 상태별 강의 수 조회 */
     int selectCourseCountByStatus(@Param("status") String status);
+
+    /* 수강 인원 초기화 (강제 폐강 시) */
+    void updateCourseEnrolledCountReset(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/EnrollmentMapper.java
@@ -49,9 +49,15 @@ public interface EnrollmentMapper {
     /* 대기열 승격 (WAITLIST 상태일 때만 PENDING으로 변경) */
     int updateEnrollmentStatusPromote(Long id);
 
-    /* 확정된 수강 신청 수 조회 */
-    int selectConfirmedEnrollmentCount();
+    /* 수강 신청 수 조회 (PENDING + CONFIRMED) */
+    int selectActiveEnrollmentCount();
 
     /* 강의 마감 시 대기열 전체 취소 */
     int updateWaitlistCancelledByCourseId(Long courseId);
+
+    /* 강제 폐강 시 CONFIRMED 수강 신청 ID 목록 조회 */
+    List<Long> selectConfirmedEnrollmentIdsByCourseId(Long courseId);
+
+    /* 강제 폐강 시 미결제 수강 신청 취소 (WAITLIST, PENDING → CANCELLED) */
+    int updatePendingWaitlistCancelledByCourseId(Long courseId);
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -5,6 +5,7 @@ import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
+import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
@@ -16,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 
@@ -32,6 +35,8 @@ public class AdminService {
     private final UserMapper userMapper;
     private final CourseMapper courseMapper;
     private final EnrollmentMapper enrollmentMapper;
+    private final PaymentService paymentService;
+    private final TransactionTemplate transactionTemplate;
 
     /**
      * 대시보드 통계 조회
@@ -47,7 +52,7 @@ public class AdminService {
         int draftCount = courseMapper.selectCourseCountByStatus("DRAFT");
         int openCount = courseMapper.selectCourseCountByStatus("OPEN");
         int closedCount = courseMapper.selectCourseCountByStatus("CLOSED");
-        int totalEnrollments = enrollmentMapper.selectConfirmedEnrollmentCount();
+        int totalEnrollments = enrollmentMapper.selectActiveEnrollmentCount();
 
         return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, totalEnrollments);
     }
@@ -103,7 +108,6 @@ public class AdminService {
      * @param courseId 강의 ID
      * @throws BusinessException 강의 없음(404), 이미 폐강(400)
      */
-    @Transactional
     public void forceCloseCourse(Long courseId) {
         log.info("[AdminService] 강의 강제 폐강 - courseId: {}", courseId);
 
@@ -112,10 +116,38 @@ public class AdminService {
             throw new BusinessException(HttpStatus.NOT_FOUND, "존재하지 않는 강의입니다.");
         }
 
-        if (CourseStatus.CLOSED.equals(course.getStatus())) {
+        if (CourseStatus.CLOSED.equals(course.getStatus()) || CourseStatus.FORCE_CLOSED.equals(course.getStatus())) {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 폐강된 강의입니다.");
         }
 
-        courseMapper.updateCourseStatus(Course.builder().id(courseId).status(CourseStatus.CLOSED).build());
+        // 강의 폐강 + WAITLIST/PENDING 즉시 취소 (트랜잭션)
+        // CONFIRMED ID는 트랜잭션 안에서 조회해 일관된 스냅샷 보장
+        List<Long> confirmedIds = transactionTemplate.execute(status -> {
+            List<Long> ids = enrollmentMapper.selectConfirmedEnrollmentIdsByCourseId(courseId);
+            enrollmentMapper.updatePendingWaitlistCancelledByCourseId(courseId);
+            courseMapper.updateCourseEnrolledCountReset(courseId);
+            courseMapper.updateCourseStatus(Course.ofForceClosed(courseId));
+            return ids;
+        });
+
+        if (confirmedIds == null || confirmedIds.isEmpty()) {
+            log.info("[AdminService] 강의 강제 폐강 완료 - courseId: {}, 환불 대상 없음", courseId);
+            return;
+        }
+
+        // CONFIRMED 건별 환불 후 취소 — 실패해도 다음 건으로 진행
+        int successCount = 0;
+        for (Long enrollmentId : confirmedIds) {
+            try {
+                paymentService.refund(enrollmentId, "강의 폐강");
+                transactionTemplate.executeWithoutResult(s ->
+                        enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollmentId)));
+                successCount++;
+            } catch (Exception e) {
+                log.error("[AdminService] 환불 처리 실패 - enrollmentId: {}", enrollmentId, e);
+            }
+        }
+
+        log.info("[AdminService] 강의 강제 폐강 완료 - courseId: {}, 환불 성공: {}/{}", courseId, successCount, confirmedIds.size());
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -52,9 +52,10 @@ public class AdminService {
         int draftCount = courseMapper.selectCourseCountByStatus("DRAFT");
         int openCount = courseMapper.selectCourseCountByStatus("OPEN");
         int closedCount = courseMapper.selectCourseCountByStatus("CLOSED");
+        int forceClosedCount = courseMapper.selectCourseCountByStatus("FORCE_CLOSED");
         int totalEnrollments = enrollmentMapper.selectActiveEnrollmentCount();
 
-        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, totalEnrollments);
+        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, forceClosedCount, totalEnrollments);
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/CourseService.java
@@ -124,17 +124,26 @@ public class CourseService {
     public RespCourseDetailDto findCourseById(Long courseId, Long userId) {
         log.info("[CourseService] 강의 상세 조회 - courseId: {}", courseId);
 
+        // 강의 존재 여부 확인
         RespCourseDetailDto course = courseMapper.selectCourseDetailById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
+        // 비공개 강의: 크리에이터 본인만 접근 가능
         if (CourseStatus.DRAFT.equals(course.getStatus()) && !course.getCreatorId().equals(userId)) {
             log.warn("[CourseService] DRAFT 강의 접근 차단 - courseId: {}, userId: {}", courseId, userId);
             throw new BusinessException(HttpStatus.FORBIDDEN, "접근할 수 없는 강의입니다.");
         }
 
+        // 강제 폐강 강의: 외부 노출 차단
+        if (CourseStatus.FORCE_CLOSED.equals(course.getStatus())) {
+            log.warn("[CourseService] 강제 폐강 강의 접근 차단 - courseId: {}", courseId);
+            throw new BusinessException(HttpStatus.NOT_FOUND, "존재하지 않는 강의입니다.");
+        }
+
+        // 수강 신청 여부 조회
         if (userId != null) {
             Enrollment enrollment = enrollmentMapper.selectEnrollmentByUserIdAndCourseId(userId, courseId);
             course.setEnrolled(enrollment != null && !EnrollmentStatus.CANCELLED.equals(enrollment.getStatus()));
@@ -200,23 +209,26 @@ public class CourseService {
     public RespCourseDetailDto publishCourse(Long creatorId, Long courseId) {
         log.info("[CourseService] 강의 공개 - creatorId: {}, courseId: {}", creatorId, courseId);
 
+        // 강의 존재 여부 확인
         Course course = courseMapper.selectCourseById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
+        // 크리에이터 권한 확인
         if (!course.getCreatorId().equals(creatorId)) {
             log.warn("[CourseService] 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
             throw new BusinessException(HttpStatus.FORBIDDEN, "강의 공개 권한이 없습니다.");
         }
 
+        // DRAFT 상태에서만 공개 가능
         if (!CourseStatus.DRAFT.equals(course.getStatus())) {
             log.warn("[CourseService] DRAFT 상태 아님 - courseId: {}, status: {}", courseId, course.getStatus());
             throw new BusinessException(HttpStatus.BAD_REQUEST, "DRAFT 상태의 강의만 공개할 수 있습니다.");
         }
 
-        courseMapper.updateCourseStatus(Course.builder().id(courseId).status(CourseStatus.OPEN).build());
+        courseMapper.updateCourseStatus(Course.ofOpen(courseId));
 
         log.info("[CourseService] 강의 공개 완료 - courseId: {}", courseId);
 
@@ -234,23 +246,26 @@ public class CourseService {
     public RespCourseDetailDto closeCourse(Long creatorId, Long courseId) {
         log.info("[CourseService] 강의 마감 - creatorId: {}, courseId: {}", creatorId, courseId);
 
+        // 강의 존재 여부 확인
         Course course = courseMapper.selectCourseById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
+        // 크리에이터 권한 확인
         if (!course.getCreatorId().equals(creatorId)) {
             log.warn("[CourseService] 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
             throw new BusinessException(HttpStatus.FORBIDDEN, "강의 마감 권한이 없습니다.");
         }
 
+        // OPEN 상태에서만 마감 가능
         if (!CourseStatus.OPEN.equals(course.getStatus())) {
             log.warn("[CourseService] OPEN 상태 아님 - courseId: {}, status: {}", courseId, course.getStatus());
             throw new BusinessException(HttpStatus.BAD_REQUEST, "OPEN 상태의 강의만 마감할 수 있습니다.");
         }
 
-        courseMapper.updateCourseStatus(Course.builder().id(courseId).status(CourseStatus.CLOSED).build());
+        courseMapper.updateCourseStatus(Course.ofClosed(courseId));
 
         int cancelled = enrollmentMapper.updateWaitlistCancelledByCourseId(courseId);
         if (cancelled > 0) {
@@ -290,12 +305,14 @@ public class CourseService {
     public RespPageDto<RespEnrollmentCreatorDto> findCourseEnrollments(Long creatorId, Long courseId, ReqCourseEnrollmentPageDto reqCourseEnrollmentPageDto) {
         log.info("[CourseService] 강의별 수강생 목록 조회 - creatorId: {}, courseId: {}", creatorId, courseId);
 
+        // 강의 존재 여부 확인
         Course course = courseMapper.selectCourseById(courseId);
         if (course == null) {
             log.warn("[CourseService] 강의 없음 - courseId: {}", courseId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
+        // 크리에이터 권한 확인
         if (!course.getCreatorId().equals(creatorId)) {
             log.warn("[CourseService] 조회 권한 없음 - creatorId: {}, courseId: {}", creatorId, courseId);
             throw new BusinessException(HttpStatus.FORBIDDEN, "본인의 강의만 조회할 수 있습니다.");

--- a/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/EnrollmentService.java
@@ -250,7 +250,7 @@ public class EnrollmentService {
         }
 
         // 이미 취소됨 확인
-        if (EnrollmentStatus.CANCELLED.equals(enrollment.getStatus())) {
+        if (EnrollmentStatus.CANCELLED.equals(enrollment.getStatus()) || EnrollmentStatus.FORCE_CLOSED.equals(enrollment.getStatus())) {
             log.warn("[EnrollmentService] 이미 취소됨 - enrollmentId: {}", enrollmentId);
             throw new BusinessException(HttpStatus.BAD_REQUEST, "이미 취소된 수강 신청입니다.");
         }

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -62,7 +62,7 @@
           FROM courses c
           JOIN users u ON c.creator_id = u.id
           <where>
-              AND c.status != 'DRAFT'
+              AND c.status NOT IN ('DRAFT', 'FORCE_CLOSED')
               <if test="status != null and status != ''">
                   AND c.status = #{status}
               </if>
@@ -94,7 +94,7 @@
           FROM courses c
           JOIN users u ON c.creator_id = u.id
           <where>
-              AND c.status != 'DRAFT'
+              AND c.status NOT IN ('DRAFT', 'FORCE_CLOSED')
               <if test="status != null and status != ''">
                   AND c.status = #{status}
               </if>
@@ -200,6 +200,13 @@
            SET enrolled_count = enrolled_count - 1
          WHERE id = #{courseId}
            AND enrolled_count > 0
+    </update>
+
+    <!-- 수강 인원 초기화 (강제 폐강 시) -->
+    <update id="updateCourseEnrolledCountReset" parameterType="Long">
+        UPDATE courses
+           SET enrolled_count = 0
+         WHERE id = #{courseId}
     </update>
 
     <!-- 관리자 전체 강의 목록 조회 -->

--- a/backend/src/main/resources/mapper/CourseMapper.xml
+++ b/backend/src/main/resources/mapper/CourseMapper.xml
@@ -218,6 +218,14 @@
              , c.price
              , c.capacity
              , c.enrolled_count
+             , (SELECT COUNT(*)
+                  FROM enrollments e
+                 WHERE e.course_id = c.id
+                   AND e.status = 'CONFIRMED') AS confirmeCount
+             , (SELECT COUNT(*)
+                  FROM enrollments e
+                 WHERE e.course_id = c.id
+                   AND e.status = 'PENDING') AS pendingCount
              , c.status
              , c.start_date
              , c.end_date

--- a/backend/src/main/resources/mapper/EnrollmentMapper.xml
+++ b/backend/src/main/resources/mapper/EnrollmentMapper.xml
@@ -130,12 +130,29 @@
            AND status = 'WAITLIST'
     </update>
 
-    <!-- 확정된 수강 신청 수 조회 -->
-    <select id="selectConfirmedEnrollmentCount" resultType="int">
+    <!-- 수강 신청 수 조회 (PENDING + CONFIRMED) -->
+    <select id="selectActiveEnrollmentCount" resultType="int">
         SELECT COUNT(*)
           FROM enrollments
-         WHERE status = 'CONFIRMED'
+         WHERE status IN ('PENDING', 'CONFIRMED')
     </select>
+
+    <!-- 강제 폐강 시 CONFIRMED 수강 신청 ID 목록 조회 -->
+    <select id="selectConfirmedEnrollmentIdsByCourseId" parameterType="Long" resultType="Long">
+        SELECT id
+          FROM enrollments
+         WHERE course_id = #{courseId}
+           AND status = 'CONFIRMED'
+    </select>
+
+    <!-- 강제 폐강 시 미결제 수강 신청 취소 (WAITLIST, PENDING → FORCE_CLOSED) -->
+    <update id="updatePendingWaitlistCancelledByCourseId" parameterType="Long">
+        UPDATE enrollments
+           SET status = 'FORCE_CLOSED'
+             , cancelled_at = NOW()
+         WHERE course_id = #{courseId}
+           AND status IN ('WAITLIST', 'PENDING')
+    </update>
 
     <!-- 강의 마감 시 대기열 전체 취소 -->
     <update id="updateWaitlistCancelledByCourseId" parameterType="Long">

--- a/backend/src/test/java/com/yujin/course_enrollment/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/AdminServiceTest.java
@@ -1,0 +1,173 @@
+package com.yujin.course_enrollment.service;
+
+import com.yujin.course_enrollment.entity.Course;
+import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.global.CourseStatus;
+import com.yujin.course_enrollment.global.EnrollmentStatus;
+import com.yujin.course_enrollment.global.exception.BusinessException;
+import com.yujin.course_enrollment.mapper.CourseMapper;
+import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.UserMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.argThat;
+
+/**
+ * 관리자 서비스 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @Mock
+    private EnrollmentMapper enrollmentMapper;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUpTransactionTemplate() {
+        given(transactionTemplate.execute(any())).willAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+
+        willAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Consumer<org.springframework.transaction.TransactionStatus> consumer = invocation.getArgument(0);
+            consumer.accept(null);
+            return null;
+        }).given(transactionTemplate).executeWithoutResult(any());
+    }
+
+    @Test
+    @DisplayName("강제 폐강 성공 - CONFIRMED 없음")
+    void forceCloseCourse_noConfirmed_closesImmediately() {
+        // given
+        Long courseId = 1L;
+        Course course = Course.builder().id(courseId).status(CourseStatus.OPEN).build();
+
+        given(courseMapper.selectCourseById(courseId)).willReturn(course);
+        given(enrollmentMapper.selectConfirmedEnrollmentIdsByCourseId(courseId)).willReturn(List.of());
+
+        // when
+        adminService.forceCloseCourse(courseId);
+
+        // then
+        then(enrollmentMapper).should().updatePendingWaitlistCancelledByCourseId(courseId);
+        then(courseMapper).should().updateCourseEnrolledCountReset(courseId);
+        then(courseMapper).should().updateCourseStatus(argThat(c ->
+                courseId.equals(c.getId()) && CourseStatus.FORCE_CLOSED.equals(c.getStatus())));
+        then(paymentService).should(never()).refund(any(), any());
+    }
+
+    @Test
+    @DisplayName("강제 폐강 성공 - CONFIRMED 2건 환불 후 FORCE_CLOSED 처리")
+    void forceCloseCourse_withConfirmed_refundsAndForceCloses() {
+        // given
+        Long courseId = 1L;
+        Course course = Course.builder().id(courseId).status(CourseStatus.OPEN).build();
+        List<Long> confirmedIds = List.of(10L, 11L);
+
+        given(courseMapper.selectCourseById(courseId)).willReturn(course);
+        given(enrollmentMapper.selectConfirmedEnrollmentIdsByCourseId(courseId)).willReturn(confirmedIds);
+
+        // when
+        adminService.forceCloseCourse(courseId);
+
+        // then
+        then(paymentService).should(times(2)).refund(any(), eq("강의 폐강"));
+        then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
+                Long.valueOf(10L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+        then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
+                Long.valueOf(11L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+    }
+
+    @Test
+    @DisplayName("강제 폐강 - 환불 실패한 건은 로그 후 다음 건으로 진행")
+    void forceCloseCourse_refundFails_continuesOtherEnrollments() {
+        // given
+        Long courseId = 1L;
+        Course course = Course.builder().id(courseId).status(CourseStatus.OPEN).build();
+        List<Long> confirmedIds = List.of(10L, 11L);
+
+        given(courseMapper.selectCourseById(courseId)).willReturn(course);
+        given(enrollmentMapper.selectConfirmedEnrollmentIdsByCourseId(courseId)).willReturn(confirmedIds);
+        willThrow(new RuntimeException("토스 API 오류")).given(paymentService).refund(eq(10L), any());
+
+        // when
+        assertThatCode(() -> adminService.forceCloseCourse(courseId)).doesNotThrowAnyException();
+
+        // then: 10L 실패해도 11L 처리됨
+        then(paymentService).should().refund(eq(11L), eq("강의 폐강"));
+        then(enrollmentMapper).should(never()).updateEnrollmentStatus(argThat(e ->
+                Long.valueOf(10L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+        then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
+                Long.valueOf(11L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+    }
+
+    @Test
+    @DisplayName("강제 폐강 실패 - 강의 없음 404")
+    void forceCloseCourse_courseNotFound_throws404() {
+        // given
+        given(courseMapper.selectCourseById(any())).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.forceCloseCourse(99L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("존재하지 않는 강의");
+    }
+
+    @Test
+    @DisplayName("강제 폐강 실패 - 이미 마감된 강의 400")
+    void forceCloseCourse_alreadyClosed_throws400() {
+        // given
+        Course course = Course.builder().id(1L).status(CourseStatus.CLOSED).build();
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.forceCloseCourse(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이미 폐강");
+    }
+
+    @Test
+    @DisplayName("강제 폐강 실패 - 이미 강제 폐강된 강의 400")
+    void forceCloseCourse_alreadyForceClosed_throws400() {
+        // given
+        Course course = Course.builder().id(1L).status(CourseStatus.FORCE_CLOSED).build();
+        given(courseMapper.selectCourseById(1L)).willReturn(course);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.forceCloseCourse(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이미 폐강");
+    }
+}

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -25,10 +25,10 @@ const CourseDetailPage = () => {
     /* 현재 로그인한 사용자가 강의 소유자인지 여부 */
     const isOwner = course?.creatorId === user?.id;
 
-    /* 강의 조회 실패 시 목록으로 이동 */
+    /* 강의 조회 실패 또는 강제 폐강된 강의는 목록으로 이동 */
     useEffect(() => {
-        if (isError) navigate('/courses', { replace: true });
-    }, [isError, navigate]);
+        if (isError || course?.status === 'FORCE_CLOSED') navigate('/courses', { replace: true });
+    }, [isError, course, navigate]);
 
     /* 목록으로 돌아가기 */
     const handleBackToList = () => {

--- a/frontend/src/pages/admin/CourseManagementTab.jsx
+++ b/frontend/src/pages/admin/CourseManagementTab.jsx
@@ -81,7 +81,13 @@ const CourseManagementTab = () => {
                                         {COURSE_STATUS_LABEL[course.status]}
                                     </span>
                                 </td>
-                                <td className="py-4 pr-6 text-gray-500">{course.enrolledCount} / {course.capacity}</td>
+                                <td className="py-4 pr-6 text-gray-500">
+                                    {course.confirmedCount}명
+                                    {course.pendingCount > 0 && (
+                                        <span className="text-amber-500"> (결제 대기 {course.pendingCount}명)</span>
+                                    )}
+                                    {' '}/ {course.capacity}명
+                                </td>
                                 <td className="py-4 pr-6 text-gray-500">{course.createdAt?.substring(0, 10)}</td>
                                 <td className="py-4">
                                     {course.status !== 'CLOSED' && course.status !== 'FORCE_CLOSED' && (

--- a/frontend/src/pages/admin/CourseManagementTab.jsx
+++ b/frontend/src/pages/admin/CourseManagementTab.jsx
@@ -40,7 +40,7 @@ const CourseManagementTab = () => {
 
         try {
             await forceCloseCourse(courseId);
-            setCourses(prev => prev.map(c => c.id === courseId ? { ...c, status: 'CLOSED' } : c));
+            setCourses(prev => prev.map(c => c.id === courseId ? { ...c, status: 'FORCE_CLOSED' } : c));
         } catch (err) {
             alert(err.response?.data?.message || '강제 폐강에 실패했습니다.');
         }
@@ -84,7 +84,7 @@ const CourseManagementTab = () => {
                                 <td className="py-4 pr-6 text-gray-500">{course.enrolledCount} / {course.capacity}</td>
                                 <td className="py-4 pr-6 text-gray-500">{course.createdAt?.substring(0, 10)}</td>
                                 <td className="py-4">
-                                    {course.status !== 'CLOSED' && (
+                                    {course.status !== 'CLOSED' && course.status !== 'FORCE_CLOSED' && (
                                         <button
                                             onClick={() => handleForceClose(course.id, course.title)}
                                             className="px-3 py-1 text-xs font-semibold text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"

--- a/frontend/src/pages/admin/DashboardTab.jsx
+++ b/frontend/src/pages/admin/DashboardTab.jsx
@@ -4,7 +4,7 @@ import { getAdminDashboard } from '../../api/admin';
 
 /* 사용자 역할별 레이블 및 색상 설정 */
 const USER_COLORS = ['#4F46E5', '#8B5CF6'];
-const COURSE_COLORS = ['#10B981', '#9ca3af', '#F87171'];
+const COURSE_COLORS = ['#10B981', '#9ca3af', '#F87171', '#DC2626'];
 
 /* 도넛 차트 중앙 라벨 */
 const DonutCenter = ({ viewBox, total }) => {
@@ -57,7 +57,7 @@ const DashboardTab = () => {
     const cards = [
         { label: '전체 사용자', value: stats?.totalUsers ?? 0, unit: '명', icon: <IconUsers /> },
         { label: '전체 강의', value: stats?.totalCourses ?? 0, unit: '개', icon: <IconBook /> },
-        { label: '확정 수강 신청', value: stats?.totalEnrollments ?? 0, unit: '건', icon: <IconCheck /> },
+        { label: '수강 신청 현황', value: stats?.totalEnrollments ?? 0, unit: '건', icon: <IconCheck /> },
     ];
 
     /* 사용자 역할 분포 차트 데이터 */
@@ -71,6 +71,7 @@ const DashboardTab = () => {
         { name: '모집 중', value: stats?.openCount ?? 0 },
         { name: '준비 중', value: stats?.draftCount ?? 0 },
         { name: '마감', value: stats?.closedCount ?? 0 },
+        { name: '강제 폐강', value: stats?.forceClosedCount ?? 0 },
     ];
 
     /* 전체 사용자 수 계산 (도넛 차트 중앙 라벨용) */

--- a/frontend/src/pages/mypage/EnrollmentTab.jsx
+++ b/frontend/src/pages/mypage/EnrollmentTab.jsx
@@ -48,8 +48,8 @@ const EnrollmentTab = () => {
                             <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-2 mb-1">
                                     <span
-                                        onClick={() => navigate(`/courses/${enrollment.courseId}`, { state: { from: 'my-page', tab: 'enrollments' } })}
-                                        className="text-base font-bold text-gray-900 truncate cursor-pointer hover:text-blue-600 transition-colors"
+                                        onClick={() => enrollment.courseStatus !== 'FORCE_CLOSED' && navigate(`/courses/${enrollment.courseId}`, { state: { from: 'my-page', tab: 'enrollments' } })}
+                                        className={`text-base font-bold text-gray-900 truncate transition-colors ${enrollment.courseStatus !== 'FORCE_CLOSED' ? 'cursor-pointer hover:text-blue-600' : 'cursor-default'}`}
                                     >
                                         {enrollment.courseTitle}
                                     </span>
@@ -74,6 +74,11 @@ const EnrollmentTab = () => {
                                 {enrollment.status === 'CANCELLED' && enrollment.cancelledAt && (
                                     <p className="text-xs text-gray-400 mt-1">
                                         취소일 {enrollment.cancelledAt.substring(0, 10)}
+                                    </p>
+                                )}
+                                {enrollment.status === 'FORCE_CLOSED' && enrollment.cancelledAt && (
+                                    <p className="text-xs text-red-400 mt-1">
+                                        폐강일 {enrollment.cancelledAt.substring(0, 10)}
                                     </p>
                                 )}
                                 {enrollment.status === 'WAITLIST' && enrollment.waitlistPosition && (

--- a/frontend/src/pages/mypage/MyCourseTab.jsx
+++ b/frontend/src/pages/mypage/MyCourseTab.jsx
@@ -28,8 +28,8 @@ const MyCourseTab = () => {
             <div className="flex flex-col gap-4">
                 {myCourseData.content.map(course => (
                     <div key={course.id}
-                        onClick={() => navigate(`/courses/${course.id}`, { state: { from: 'my-page' } })}
-                        className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4 cursor-pointer hover:shadow-md transition-shadow">
+                        onClick={() => course.status !== 'FORCE_CLOSED' && navigate(`/courses/${course.id}`, { state: { from: 'my-page' } })}
+                        className={`bg-white border border-gray-200 rounded-lg p-6 shadow-sm flex flex-col sm:flex-row sm:items-center justify-between gap-4 transition-shadow ${course.status !== 'FORCE_CLOSED' ? 'cursor-pointer hover:shadow-md' : 'cursor-default'}`}>
                         <div className="flex-1 min-w-0">
                             {/* 강의 제목과 상태 배지 */}
                             <div className="flex items-center gap-2 mb-1">

--- a/frontend/src/pages/mypage/StudentTab.jsx
+++ b/frontend/src/pages/mypage/StudentTab.jsx
@@ -38,7 +38,7 @@ const StudentTab = () => {
                     className="w-full sm:w-80 border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                     <option value="">강의를 선택하세요</option>
-                    {myCourseData.content.map(course => (
+                    {myCourseData.content.filter(course => course.status !== 'FORCE_CLOSED').map(course => (
                         <option key={course.id} value={course.id}>{course.title}</option>
                     ))}
                 </select>

--- a/frontend/src/utils/statusConfig.js
+++ b/frontend/src/utils/statusConfig.js
@@ -3,6 +3,7 @@ export const COURSE_STATUS_LABEL = {
     DRAFT: '준비 중',
     OPEN: '모집 중',
     CLOSED: '마감',
+    FORCE_CLOSED: '강제 폐강',
 };
 
 /* 강의 상태 뱃지 스타일 - 카드 썸네일용 (채워진 스타일) */
@@ -10,6 +11,7 @@ export const COURSE_STATUS_CARD_STYLE = {
     DRAFT: 'bg-gray-500 text-white',
     OPEN: 'bg-green-500 text-white',
     CLOSED: 'bg-gray-500 text-white',
+    FORCE_CLOSED: 'bg-red-600 text-white',
 };
 
 /* 강의 상태 뱃지 스타일 - 인라인 뱃지용 (테두리 스타일) */
@@ -17,6 +19,7 @@ export const COURSE_STATUS_BADGE_STYLE = {
     DRAFT: 'bg-gray-50 text-gray-500 border-gray-200',
     OPEN: 'bg-green-50 text-green-600 border-green-200',
     CLOSED: 'bg-red-50 text-red-500 border-red-200',
+    FORCE_CLOSED: 'bg-red-50 text-red-600 border-red-300',
 };
 
 /* 수강 신청 상태 레이블 */
@@ -25,6 +28,7 @@ export const ENROLLMENT_STATUS_LABEL = {
     CONFIRMED: '수강 확정',
     CANCELLED: '취소됨',
     WAITLIST: '대기 중',
+    FORCE_CLOSED: '강의 폐강',
 };
 
 /* 수강 신청 상태 뱃지 스타일 */
@@ -33,4 +37,5 @@ export const ENROLLMENT_STATUS_BADGE_STYLE = {
     CONFIRMED: 'bg-green-50 text-green-600 border-green-100',
     CANCELLED: 'bg-gray-50 text-gray-400 border-gray-200',
     WAITLIST: 'bg-purple-50 text-purple-600 border-purple-100',
+    FORCE_CLOSED: 'bg-red-50 text-red-500 border-red-100',
 };


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - 강의/수강 신청에 FORCE_CLOSED 상태 추가 - 일반 마감(CLOSED)과 구분
  - 마감 시 WAITLIST 자동 취소 누락 수정
  - 강제 폐강 시 WAITLIST/PENDING 즉시 취소, CONFIRMED 건별 환불 후 취소 및 enrolled_count 초기화
  - 공개 강의 목록에서 FORCE_CLOSED 강의 숨김 (일반 마감은 유지)
  - 강제 폐강 강의 상세 접근 차단 (백엔드 404, 프론트 리다이렉트)
  - 마이페이지(수강 목록/강의 목록/강의별 수강생) 강제 폐강 강의 네비게이션 차단
  - 관리자 강의 관리 탭 수강 인원: 확정 N명 (결제 대기 N명) / 정원 N명 형식으로 개선
  - 관리자 대시보드 강제 폐강 통계 차트 항목 추가 및 레이블 변경 (확정 수강 신청 → 수강 신청 현황)

  ## 구현 시 고려한 점
  - 강제 폐강은 2단계로 처리 — 1단계(WAITLIST/PENDING 취소 + 상태 변경)는 단일 트랜잭션으로 원자적 처리, 2단계(CONFIRMED 건별 환불)는 실패해도 다음 건으로 진행
  - 강의 상태를 CLOSED가 아닌 FORCE_CLOSED로 분리해 일반 마감과 구분, 공개 목록 노출 여부도 별도 처리
  - 수강 인원 집계는 서브쿼리로 CONFIRMED/PENDING 각각 집계 - JOIN 방식 사용 시 행이 곱해지는 문제 방지
  
  ## 테스트 방법
  - 백엔드: IDE에서 `CourseEnrollmentApplication` 실행 (Port: 8080)
  - 프론트: `npm run dev` (Port: 5173)
  - 관리자 계정 로그인 → 강의 관리 탭 → 강제 폐강 버튼 클릭
  - 관리자 페이지 강제 폐강 버튼 클릭 시 상태 "강제 폐강"으로 즉시 변경 확인
  - 강제 폐강 후 공개 강의 목록 미노출 확인
  - /courses/:id 직접 접근 시 목록으로 리다이렉트 확인
  - 관리자 강의 관리 탭 확정/결제 대기 분리 표시 확인
  - 대시보드 강의 상태 분포 차트 "강제 폐강" 항목 확인
  - 해당 강의 수강 신청 학생 마이페이지에서 강의 폐강 상태 및 폐강일 확인
  - ./gradlew test --tests "com.yujin.course_enrollment.service.AdminServiceTest" 실행 후 6개 테스트 전체 통과 확인
  
 ## 연관 이슈
 Closes #60 