### PR TITLE
[feat] 로컬 개발 환경 DB H2 → MySQL 전환

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5'
@@ -36,7 +37,6 @@ dependencies {
 	testImplementation 'org.testcontainers:mysql'
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testRuntimeOnly 'com.mysql:mysql-connector-j'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -3,21 +3,14 @@ spring:
     name: course-enrollment
 
   datasource:
-    url: jdbc:h2:mem:course_enrollment;MODE=MySQL;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:course_enrollment}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:password}
 
   sql:
     init:
-      mode: always
-      schema-locations: classpath:sql/schema.sql
-      data-locations: classpath:sql/data.sql
+      mode: never
 
   data:
     redis:

--- a/backend/src/main/resources/sql/data.sql
+++ b/backend/src/main/resources/sql/data.sql
@@ -16,7 +16,7 @@ INSERT INTO courses (creator_id, title, description, price, capacity, enrolled_c
 VALUES
     (1, 'React 실전 마스터',           'Vite와 최신 React 라이브러리를 활용한 실무 프로젝트',   45000,  30, 2, 'OPEN', '2026-05-01', '2026-07-31', '2026-04-01 09:00:00'),
     (1, 'Spring Boot 완전 정복',       '스프링 부트로 RESTful API 서버 설계부터 배포까지',     49000,  50, 2, 'OPEN', '2026-06-01', '2026-08-31', '2026-04-05 10:00:00'),
-    (1, '자바 최적화(GC의 이해)',       'JVM 성능을 극대화하는 GC 튜닝 비법',                  80000,   2, 2, 'OPEN', '2026-05-01', '2026-06-30', '2026-04-08 11:00:00'),
+    (1, '자바 최적화(GC의 이해)',       'JVM 성능을 극대화하는 GC 튜닝 비법',                  80000,   2, 1, 'OPEN', '2026-05-01', '2026-06-30', '2026-04-08 11:00:00'),
     (2, 'Next.js 14 완벽 가이드',      'App Router와 SSR의 핵심 원리 파헤치기',               60000,  40, 2, 'OPEN', '2026-05-15', '2026-08-15', '2026-04-03 09:30:00'),
     (2, 'AWS 클라우드 기초',            'EC2부터 S3까지 클라우드 인프라 시작하기',                  0,  50, 1, 'OPEN', '2026-05-01', '2026-08-01', '2026-04-10 14:00:00'),
     (3, 'TypeScript 핵심 문법',        '자바스크립트 개발자를 위한 타입 시스템 정복',          25000,  60, 1, 'OPEN', '2026-04-15', '2026-07-15', '2026-04-02 08:30:00'),
@@ -66,7 +66,6 @@ VALUES
 -- 수강 신청 - 수강생A (user_id=4)
 INSERT INTO enrollments (user_id, course_id, status, confirmed_at, cancelled_at, created_at)
 VALUES
-    (4,  3, 'WAITLIST',  NULL,                  NULL,                  '2026-04-25 10:15:00'),
     (4,  4, 'PENDING',   NULL,                  NULL,                  '2026-04-24 11:20:00'),
     (4,  5, 'PENDING',   NULL,                  NULL,                  '2026-04-23 15:40:00'),
     (4,  2, 'CONFIRMED', '2026-04-22 14:30:00', NULL,                  '2026-04-20 10:00:00'),
@@ -100,7 +99,6 @@ VALUES
 -- 수강 신청 - 수강생C (user_id=6)
 INSERT INTO enrollments (user_id, course_id, status, confirmed_at, cancelled_at, created_at)
 VALUES
-    (6,  3, 'PENDING',   NULL,                  NULL,                  '2026-04-22 09:30:00'),
     (6,  2, 'CONFIRMED', '2026-04-24 10:00:00', NULL,                  '2026-04-23 09:00:00'),
     (6,  4, 'CONFIRMED', '2026-04-13 10:00:00', NULL,                  '2026-04-10 15:30:00'),
     (6,  6, 'CANCELLED', NULL,                  '2026-04-10 16:00:00', '2026-04-03 09:00:00'),

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -1,0 +1,6 @@
+spring:
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:sql/schema.sql
+      data-locations: classpath:sql/data.sql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: course_enrollment
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
  ## 작업 내용
  - docker-compose.yaml 추가 — MySQL 8.0 + Redis 7 로컬 환경 구성
  - application.yaml 데이터소스 H2 인메모리 → MySQL 전환
  - sql.init.mode: never 로 변경 — MySQL은 데이터가 유지되므로 매 실행마다 초기화 비활성화
  - src/test/resources/application.yaml 추가 — 테스트 실행 시 schema + data 자동 초기화
  - build.gradle MySQL 드라이버 testRuntimeOnly → runtimeOnly 변경

  ## 구현 시 고려한 점
  - Testcontainers 동시성 테스트는 유지 — 테스트마다 격리된 MySQL 환경이 필요하고 CI에서도 동작해야 하므로
  - DB 접속 정보는 env var + 기본값 조합 (DB_HOST, DB_USERNAME, DB_PASSWORD) — docker-compose 기본값과 맞춰 별도 설정 없이 바로 실행 가능

  ## 테스트 방법
  - `docker compose up -d` 실행 (Redis 구동)
  - IntelliJ 환경변수 `DB_PASSWORD`, `JWT_SECRET` 설정 후 앱 실행
  - 로그인 / 강의 목록 조회 등 정상 작동 확인
  
  ## 연관 이슈
  Closes #62