### PR TITLE
[fix] AuthRefreshIntegrationTest MySQL 전환으로 인한 500 에러 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-starter-devtools'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/backend/src/test/java/com/yujin/course_enrollment/security/AuthRefreshIntegrationTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/security/AuthRefreshIntegrationTest.java
@@ -8,8 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 import java.util.Set;
@@ -24,9 +28,14 @@ import org.springframework.http.MediaType;
  * /api/auth/refresh 엔드포인트 통합 테스트
  * 실제 Redis 연결로 token rotation 동작 검증
  */
+@Testcontainers
 @SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 @AutoConfigureMockMvc
 class AuthRefreshIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -4,3 +4,22 @@ spring:
       mode: always
       schema-locations: classpath:sql/schema.sql
       data-locations: classpath:sql/data.sql
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+mybatis:
+  mapper-locations: classpath:mapper/**/*.xml
+  type-aliases-package: com.yujin.course_enrollment.entity, com.yujin.course_enrollment.dto.resp, com.yujin.course_enrollment.dto.req
+  configuration:
+    map-underscore-to-camel-case: true
+
+jwt:
+  secret: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  expiration: 900000
+
+toss:
+  secret-key: ""
+  confirm-url: https://api.tosspayments.com/v1/payments/confirm
+  cancel-url-template: https://api.tosspayments.com/v1/payments/%s/cancel


### PR DESCRIPTION
  ## 작업 내용
  - AuthRefreshIntegrationTest에 Testcontainers MySQLContainer 추가
  - test/resources/application.yaml에 누락된 프로퍼티 추가 (jwt, mybatis, toss, redis)

  ## 구현 시 고려한 점
  - H2 → MySQL 전환 이후 AuthRefreshIntegrationTest가 로컬 MySQL 연결을 시도하면서 비밀번호 불일치로 컨텍스트 로드 실패 → 500 에러 발생
  - EnrollmentConcurrencyTest와 동일한 패턴(@Testcontainers + @ServiceConnection)으로 격리된 MySQL 환경 구성                                                      
  - test yaml이 main yaml을 완전히 대체하기 때문에 필요한 프로퍼티 전체 포함 (jwt.expiration 등)
  - Redis는 실제 컨테이너 연결 유지 - token rotation 동작 검증이 목적이므로 mock 대체 불가

  ## 테스트 방법
  - `docker compose up -d` 실행 (Redis 구동)
  - `./gradlew test`  전체 통과 확인

  ## 연관 이슈
  Closes #64