### PR TITLE
[feat] Toss 웹훅 연동으로 환불 트랜잭션 일관성 보장

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         /* H2 콘솔, 인증 엔드포인트는 인증 없이 허용 */
                         .requestMatchers("/h2-console/**", "/error").permitAll()
+                        .requestMatchers("/api/webhooks/**").permitAll()
                         .requestMatchers("/api/auth/login").permitAll()
                         .requestMatchers("/api/auth/signup").anonymous()
                         .requestMatchers("/api/auth/logout", "/api/auth/refresh", "/api/auth/check-username", "/api/auth/check-email").permitAll()

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/TossWebhookController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/TossWebhookController.java
@@ -1,0 +1,50 @@
+package com.yujin.course_enrollment.controller;
+
+import com.yujin.course_enrollment.dto.req.ReqTossWebhookDto;
+import com.yujin.course_enrollment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Toss 웹훅 컨트롤러
+ * 결제 상태 변경 이벤트를 수신해 DB 상태를 동기화
+ * refund() 인라인 업데이트 실패 시 결제 상태를 복구하는 안전망
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/webhooks")
+@RequiredArgsConstructor
+public class TossWebhookController {
+
+    @Value("${toss.webhook-secret:}")
+    private String webhookSecret;
+
+    private final PaymentService paymentService;
+
+    /**
+     * Toss 웹훅 수신
+     * POST /api/webhooks/toss
+     * @param secret Toss 대시보드에서 설정한 웹훅 시크릿 (헤더)
+     * @param reqTossWebhookDto 웹훅 페이로드
+     */
+    @PostMapping("/toss")
+    public ResponseEntity<Void> handleTossWebhook(@RequestHeader(value = "secret", required = false) String secret, @RequestBody ReqTossWebhookDto reqTossWebhookDto) {
+
+        // 시크릿 설정된 경우에만 검증
+        if (StringUtils.hasText(webhookSecret) && !webhookSecret.equals(secret)) {
+            log.warn("[TossWebhookController] 웹훅 시크릿 불일치");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        log.info("[TossWebhookController] 웹훅 수신 - eventType: {}", reqTossWebhookDto.getEventType());
+
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqTossWebhookDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqTossWebhookDto.java
@@ -1,0 +1,25 @@
+package com.yujin.course_enrollment.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Toss 웹훅 수신 DTO
+ * 결제 상태 변경 이벤트 (PAYMENT_STATUS_CHANGED) 처리
+ */
+@Getter
+@NoArgsConstructor
+public class ReqTossWebhookDto {
+    private String eventType;
+    private String createdAt;
+    private TossPaymentData data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class TossPaymentData {
+        private String paymentKey;
+        private String orderId;
+        private String status;
+    }
+
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.req.ReqTossWebhookDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.entity.Course;
@@ -69,13 +70,14 @@ public class PaymentService {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "PENDING 상태의 수강 신청만 결제할 수 있습니다.");
         }
 
-        // 결제 금액 검증 (프론트 조작 방지)
+        // 강의 존재 여부 확인
         Course course = courseMapper.selectCourseById(enrollment.getCourseId());
         if (course == null) {
             log.warn("[PaymentService] 강의 없음 - courseId: {}", enrollment.getCourseId());
             throw new BusinessException(HttpStatus.BAD_REQUEST, "존재하지 않는 강의입니다.");
         }
 
+        // 결제 금액 검증 (프론트 조작 방지)
         int coursePrice = course.getPrice();
         if (coursePrice != reqPaymentConfirmDto.getAmount()) {
             log.warn("[PaymentService] 금액 불일치 - enrollmentId: {}, coursePrice: {}, reqAmount: {}", reqPaymentConfirmDto.getEnrollmentId(), coursePrice, reqPaymentConfirmDto.getAmount());
@@ -146,6 +148,44 @@ public class PaymentService {
     }
 
     /**
+     * Toss 웹훅 처리
+     * PAYMENT_STATUS_CHANGED + CANCELED 이벤트 수신 시 결제 상태를 CANCELLED로 업데이트
+     * refund() 인라인 업데이트 실패로 인한 불일치를 복구하는 안전망
+     * @param reqTossWebhookDto 웹훅 페이로드
+     */
+    @Transactional
+    public void handleTossWebhook(ReqTossWebhookDto reqTossWebhookDto) {
+        // 결제 상태 변경 이벤트만 처리
+        if (!"PAYMENT_STATUS_CHANGED".equals(reqTossWebhookDto.getEventType())) {
+            return;
+        }
+
+        ReqTossWebhookDto.TossPaymentData data = reqTossWebhookDto.getData();
+
+        // 취소 상태만 처리
+        if (!"CANCELED".equals(data.getStatus())) {
+            return;
+        }
+
+        // 결제 내역 없음
+        Payment payment = paymentMapper.selectPaymentByOrderId(data.getOrderId());
+        if (payment == null) {
+            log.warn("[PaymentService] 웹훅 - 결제 내역 없음 - orderId: {}", data.getOrderId());
+            return;
+        }
+
+        // 이미 CANCELLED 상태면 무시
+        if (PaymentStatus.CANCELLED.equals(payment.getStatus())) {
+            log.info("[PaymentService] 웹훅 - 이미 취소된 결제 - orderId: {}", data.getOrderId());
+            return;
+        }
+
+        paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), "Toss 웹훅 취소"));
+
+        log.info("[PaymentService] 웹훅 - 결제 취소 처리 완료 - orderId: {}", data.getOrderId());
+    }
+
+    /**
      * 사용자 결제 내역 조회
      * @param userId 사용자 ID
      * @param reqMyPaymentPageDto 페이징 조건 DTO
@@ -159,6 +199,7 @@ public class PaymentService {
         List<RespPaymentDto> content = paymentMapper.selectPaymentListByUserId(reqMyPaymentPageDto).stream()
                 .map(RespPaymentDto::of)
                 .collect(Collectors.toList());
+
         int totalCount = paymentMapper.selectPaymentListByUserIdCount(userId);
 
         return RespPageDto.of(content, reqMyPaymentPageDto.getPage(), reqMyPaymentPageDto.getSize(), totalCount);

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -37,5 +37,6 @@ jwt:
 
 toss:
   secret-key: ${TOSS_SECRET_KEY:}
+  webhook-secret: ${TOSS_WEBHOOK_SECRET:}
   confirm-url: https://api.tosspayments.com/v1/payments/confirm
   cancel-url-template: https://api.tosspayments.com/v1/payments/%s/cancel


### PR DESCRIPTION
  ## 작업 내용
  - POST /api/webhooks/toss 엔드포인트 추가
  - PAYMENT_STATUS_CHANGED + CANCELED 이벤트 수신 시 payments 테이블 상태 CANCELLED 업데이트
  - TOSS_WEBHOOK_SECRET 환경변수 설정 시 secret 헤더 검증 활성화
  - /api/webhooks/** Security permitAll 추가

  ## 구현 시 고려한 점
  - refund()의 인라인 DB 업데이트는 유지 - 웹훅은 롤백 등으로 인라인 업데이트 실패 시 복구하는 안전망으로 동작
  - 이미 CANCELLED 상태면 웹훅 수신 시 스킵
  - TOSS_WEBHOOK_SECRET 미설정 시 시크릿 검증 스킵 - 로컬 개발 환경

  ## 테스트 방법
  - `docker compose up -d` 실행 (Redis 구동)
  - ngrok으로 로컬 서버 외부 노출 후 Toss 대시보드 웹훅 URL 등록
  - 결제 취소 후 서버 로그에서 `[TossWebhookController] 웹훅 수신` 확인
  - 정상 케이스: 이미 CANCELLED → `웹훅 - 이미 취소된 결제` 로그 확인

  ## 연관 이슈
  Closes #66 