### PR TITLE
[fix] Toss 웹훅 코드 리뷰 반영 및 단위 테스트 추가

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/TossWebhookController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/TossWebhookController.java
@@ -10,6 +10,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
 /**
  * Toss 웹훅 컨트롤러
  * 결제 상태 변경 이벤트를 수신해 DB 상태를 동기화
@@ -35,15 +38,24 @@ public class TossWebhookController {
     @PostMapping("/toss")
     public ResponseEntity<Void> handleTossWebhook(@RequestHeader(value = "secret", required = false) String secret, @RequestBody ReqTossWebhookDto reqTossWebhookDto) {
 
-        // 시크릿 설정된 경우에만 검증
-        if (StringUtils.hasText(webhookSecret) && !webhookSecret.equals(secret)) {
-            log.warn("[TossWebhookController] 웹훅 시크릿 불일치");
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        // 시크릿 설정된 경우에만 검증 (상수 시간 비교로 타이밍 공격 방어)
+        if (StringUtils.hasText(webhookSecret)) {
+            byte[] expected = webhookSecret.getBytes(StandardCharsets.UTF_8);
+            byte[] actual = (secret != null ? secret : "").getBytes(StandardCharsets.UTF_8);
+
+            if (!MessageDigest.isEqual(expected, actual)) {
+                log.warn("[TossWebhookController] 웹훅 시크릿 불일치");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
         }
 
         log.info("[TossWebhookController] 웹훅 수신 - eventType: {}", reqTossWebhookDto.getEventType());
 
-        paymentService.handleTossWebhook(reqTossWebhookDto);
+        try {
+            paymentService.handleTossWebhook(reqTossWebhookDto);
+        } catch (Exception e) {
+            log.error("[TossWebhookController] 웹훅 처리 실패 - eventType: {}", reqTossWebhookDto.getEventType(), e);
+        }
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqTossWebhookDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqTossWebhookDto.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.dto.req;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReqTossWebhookDto {
     private String eventType;
     private String createdAt;
@@ -16,10 +18,10 @@ public class ReqTossWebhookDto {
 
     @Getter
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class TossPaymentData {
         private String paymentKey;
         private String orderId;
         private String status;
     }
-
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -162,6 +162,12 @@ public class PaymentService {
 
         ReqTossWebhookDto.TossPaymentData data = reqTossWebhookDto.getData();
 
+        // data 누락 방어
+        if (data == null || data.getOrderId() == null) {
+            log.warn("[PaymentService] 웹훅 - data 누락 - eventType: {}", reqTossWebhookDto.getEventType());
+            return;
+        }
+
         // 취소 상태만 처리
         if (!"CANCELED".equals(data.getStatus())) {
             return;
@@ -174,13 +180,27 @@ public class PaymentService {
             return;
         }
 
+        // paymentKey 교차 검증
+        if (!payment.getPaymentKey().equals(data.getPaymentKey())) {
+            log.warn("[PaymentService] 웹훅 - paymentKey 불일치 - orderId: {}", data.getOrderId());
+            return;
+        }
+
         // 이미 CANCELLED 상태면 무시
         if (PaymentStatus.CANCELLED.equals(payment.getStatus())) {
             log.info("[PaymentService] 웹훅 - 이미 취소된 결제 - orderId: {}", data.getOrderId());
             return;
         }
 
+        // 결제 CANCELLED 처리
         paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), "Toss 웹훅 취소"));
+
+        // enrollment 상태 동기화 (CONFIRMED → CANCELLED)
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentById(payment.getEnrollmentId());
+        if (enrollment != null && EnrollmentStatus.CONFIRMED.equals(enrollment.getStatus())) {
+            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(payment.getEnrollmentId()));
+            log.info("[PaymentService] 웹훅 - enrollment 취소 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+        }
 
         log.info("[PaymentService] 웹훅 - 결제 취소 처리 완료 - orderId: {}", data.getOrderId());
     }

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -89,6 +89,7 @@
              , canceled_at = #{canceledAt}
              , cancel_reason = #{cancelReason}
          WHERE id = #{id}
+           AND status = 'DONE'
     </update>
 
     <!-- 사용자 결제 내역 조회 (DONE, CANCELLED) -->

--- a/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
@@ -2,6 +2,7 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqPaymentConfirmDto;
+import com.yujin.course_enrollment.dto.req.ReqTossWebhookDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.entity.Course;
@@ -292,6 +293,132 @@ class PaymentServiceTest {
 
         // then
         then(tossPaymentClient).should(never()).cancel(any(), any());
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - 정상 취소 처리 - payment CANCELLED + enrollment CANCELLED 동기화")
+    void handleTossWebhook_success() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "CANCELED"));
+        Payment done = Payment.builder()
+                .id(1L)
+                .enrollmentId(1L)
+                .paymentKey("tgen_abc123")
+                .orderId("order_001")
+                .status("DONE")
+                .build();
+        Enrollment confirmed = Enrollment.builder()
+                .id(1L)
+                .status("CONFIRMED")
+                .build();
+
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(done);
+        given(enrollmentMapper.selectEnrollmentById(1L)).willReturn(confirmed);
+        willDoNothing().given(paymentMapper).updatePaymentCancelled(any());
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should().updatePaymentCancelled(any());
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - PAYMENT_STATUS_CHANGED 아닌 이벤트 무시")
+    void handleTossWebhook_ignore_otherEvent() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_BILLING_KEY_ISSUED", "2026-05-21T00:00:00+09:00", null);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).selectPaymentByOrderId(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - CANCELED 아닌 상태 무시")
+    void handleTossWebhook_ignore_nonCanceledStatus() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "DONE"));
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - 이미 CANCELLED 상태면 멱등성 스킵")
+    void handleTossWebhook_idempotent_alreadyCancelled() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "CANCELED"));
+        Payment cancelled = Payment.builder()
+                .id(1L)
+                .paymentKey("tgen_abc123")
+                .orderId("order_001")
+                .status("CANCELLED")
+                .build();
+
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(cancelled);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - 결제 내역 없음 - 처리 스킵")
+    void handleTossWebhook_skip_paymentNotFound() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_999", "CANCELED"));
+
+        given(paymentMapper.selectPaymentByOrderId("order_999")).willReturn(null);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - paymentKey 불일치 - 처리 스킵")
+    void handleTossWebhook_skip_paymentKeyMismatch() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_WRONG", "order_001", "CANCELED"));
+        Payment done = Payment.builder()
+                .id(1L)
+                .paymentKey("tgen_abc123")
+                .orderId("order_001")
+                .status("DONE")
+                .build();
+
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(done);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - data null - 처리 스킵")
+    void handleTossWebhook_skip_dataNull() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", null);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
         then(paymentMapper).should(never()).updatePaymentCancelled(any());
     }
 


### PR DESCRIPTION
  ## 작업 내용
  - 웹훅 시크릿 검증에 MessageDigest.isEqual() 상수 시간 비교 적용                                
  - updatePaymentCancelled 쿼리에 `AND status = 'DONE'` 상태 가드 추가
  - handleTossWebhook 단위 테스트 7개 추가

  ## 구현 시 고려한 점
  - 문자열 직접 비교는 첫 불일치 시 즉시 종료되어 응답 시간으로 시크릿 추측 가능 → 상수 시간 비교로 타이밍 공격 방어
  - AND status = 'DONE' 상태 가드로 이미 CANCELLED된 결제에 대한 중복 업데이트 방지
  - Toss는 200 외 응답 시 웹훅 재전송 → 처리 실패 시에도 200 반환하도록 컨트롤러에서 예외 흡수
  - 이미 CANCELLED 상태면 재처리 스킵

  ## 테스트 방법
  - `./gradlew test --tests "com.yujin.course_enrollment.service.PaymentServiceTest"`

  ## 연관 이슈
  Closes #68