### PR TITLE
[feat] 로그아웃 시 AccessToken Redis 블랙리스트로 즉시 무효화

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.config;
 
+import com.yujin.course_enrollment.service.TokenBlacklistService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -26,6 +27,7 @@ import java.util.List;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final TokenBlacklistService tokenBlacklistService;
 
     /* 요청마다 실행 — 쿠키에서 토큰 추출 후 유효하면 SecurityContext에 인증 정보 설정 */
     @Override
@@ -36,6 +38,12 @@ public class JwtFilter extends OncePerRequestFilter {
 
         if (token != null) {
             try {
+                // 블랙리스트(로그아웃) 토큰 차단
+                if (tokenBlacklistService.isBlacklisted(token)) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 Claims claims = jwtUtil.parseToken(token);
                 Long userId = Long.parseLong(claims.getSubject());
                 String role = claims.get("role", String.class);

--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtUtil.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtUtil.java
@@ -12,7 +12,7 @@ import java.util.Date;
 
 /**
  * JWT 유틸리티
- * AccessToken 생성 및 파싱을 담당
+ * AccessToken 생성, 파싱 및 만료 시각 조회를 담당
  */
 @Component
 public class JwtUtil {
@@ -50,6 +50,15 @@ public class JwtUtil {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    /**
+     * 토큰 만료 시각 반환
+     * @param token JWT 문자열
+     * @return 만료 시각
+     */
+    public Date getExpiration(String token) {
+        return parseToken(token).getExpiration();
     }
 
     /* Base64 디코딩된 secret으로 HMAC-SHA 서명 키 생성 */

--- a/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.config;
 
+import com.yujin.course_enrollment.service.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final TokenBlacklistService tokenBlacklistService;
 
     /* 비밀번호 암호화 빈 */
     @Bean
@@ -72,7 +74,7 @@ public class SecurityConfig {
                                 response.sendError(HttpServletResponse.SC_FORBIDDEN)))
                 /* H2 콘솔 iframe 허용 */
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
-                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtFilter(jwtUtil, tokenBlacklistService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
@@ -87,6 +87,7 @@ public class AuthController {
         log.debug("[AuthController] 로그아웃 요청");
 
         authService.deleteRefreshToken(extractRefreshToken(request));
+        authService.blacklistAccessToken(extractAccessToken(request));
 
         response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie("accessToken").toString());
         response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie("refreshToken").toString());
@@ -213,6 +214,21 @@ public class AuthController {
 
         for (Cookie cookie : request.getCookies()) {
             if ("refreshToken".equals(cookie.getName())) return cookie.getValue();
+        }
+
+        return null;
+    }
+
+    /**
+     * 요청 쿠키에서 accessToken 추출
+     * @param request HTTP 요청
+     * @return accessToken 값, 없으면 null
+     */
+    private String extractAccessToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("accessToken".equals(cookie.getName())) return cookie.getValue();
         }
 
         return null;

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AuthService.java
@@ -4,6 +4,7 @@ import com.yujin.course_enrollment.config.JwtUtil;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.UserMapper;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,6 +27,7 @@ public class AuthService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     /**
      * AccessToken 생성
@@ -85,6 +87,21 @@ public class AuthService {
     public void deleteRefreshToken(String refreshToken) {
         if (refreshToken != null) {
             refreshTokenService.delete(refreshToken);
+        }
+    }
+
+    /**
+     * AccessToken 블랙리스트 등록 (로그아웃)
+     * @param accessToken 무효화할 accessToken (null이거나 만료된 경우 무시)
+     */
+    public void blacklistAccessToken(String accessToken) {
+        if (accessToken == null) return;
+
+        try {
+            tokenBlacklistService.add(accessToken, jwtUtil.getExpiration(accessToken));
+        } catch (JwtException e) {
+            // 이미 만료된 토큰은 블랙리스트 불필요
+            log.debug("[AuthService] AccessToken 블랙리스트 등록 생략 - 이미 만료된 토큰");
         }
     }
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/TokenBlacklistService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/TokenBlacklistService.java
@@ -1,0 +1,46 @@
+package com.yujin.course_enrollment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Date;
+
+/**
+ * AccessToken 블랙리스트 서비스
+ * 로그아웃한 accessToken을 Redis에 저장해 잔여 TTL 동안 재사용 차단
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String PREFIX = "BL:";
+
+    /**
+     * AccessToken을 블랙리스트에 추가
+     * @param token 무효화할 accessToken
+     * @param expiration 토큰 만료 시각
+     */
+    public void add(String token, Date expiration) {
+        long remaining = expiration.getTime() - System.currentTimeMillis();
+
+        if (remaining > 0) {
+            redisTemplate.opsForValue().set(PREFIX + token, "1", Duration.ofMillis(remaining));
+            log.debug("[TokenBlacklistService] AccessToken 블랙리스트 추가 - 잔여 TTL: {}ms", remaining);
+        }
+    }
+
+    /**
+     * AccessToken 블랙리스트 여부 확인
+     * @param token 확인할 accessToken
+     * @return 블랙리스트에 등록된 경우 true
+     */
+    public boolean isBlacklisted(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + token));
+    }
+}

--- a/backend/src/test/java/com/yujin/course_enrollment/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/security/SecurityIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -99,5 +100,18 @@ class SecurityIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"username\":\"newuser\",\"password\":\"pass\",\"name\":\"테스트\",\"email\":\"test@test.com\"}"))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("블랙리스트 토큰 - 보호된 엔드포인트 접근 시 401")
+    void blacklistedToken_protectedEndpoint_returns401() throws Exception {
+        // given
+        String token = jwtUtil.generateToken(1L, "STUDENT");
+        given(stringRedisTemplate.hasKey("BL:" + token)).willReturn(true);
+
+        // when & then
+        mockMvc.perform(get("/api/enrollments")
+                        .cookie(new Cookie("accessToken", token)))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/backend/src/test/java/com/yujin/course_enrollment/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.yujin.course_enrollment.config.JwtUtil;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.UserMapper;
+import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -35,6 +38,9 @@ class AuthServiceTest {
 
     @Mock
     private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private TokenBlacklistService tokenBlacklistService;
 
     @Test
     @DisplayName("로그인 성공")
@@ -177,5 +183,42 @@ class AuthServiceTest {
 
         // then
         then(refreshTokenService).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("AccessToken 블랙리스트 등록 - 유효한 토큰")
+    void blacklistAccessToken_validToken() {
+        // given
+        Date expiration = new Date(System.currentTimeMillis() + 60_000);
+        given(jwtUtil.getExpiration("valid-token")).willReturn(expiration);
+
+        // when
+        authService.blacklistAccessToken("valid-token");
+
+        // then
+        then(tokenBlacklistService).should().add("valid-token", expiration);
+    }
+
+    @Test
+    @DisplayName("AccessToken 블랙리스트 등록 - 만료된 토큰은 생략")
+    void blacklistAccessToken_expiredToken_skips() {
+        // given
+        given(jwtUtil.getExpiration("expired-token")).willThrow(new JwtException("expired"));
+
+        // when
+        authService.blacklistAccessToken("expired-token");
+
+        // then
+        then(tokenBlacklistService).should(never()).add(any(), any());
+    }
+
+    @Test
+    @DisplayName("AccessToken 블랙리스트 등록 - null이면 생략")
+    void blacklistAccessToken_null_skips() {
+        // when
+        authService.blacklistAccessToken(null);
+
+        // then
+        then(tokenBlacklistService).should(never()).add(any(), any());
     }
 }

--- a/backend/src/test/java/com/yujin/course_enrollment/service/TokenBlacklistServiceIntegrationTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/TokenBlacklistServiceIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.yujin.course_enrollment.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Date;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * TokenBlacklist 서비스 Redis 통합 테스트
+ * 실제 Redis 연결로 저장/확인/TTL 동작 검증
+ */
+@SpringBootTest(properties = "jwt.secret=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+class TokenBlacklistServiceIntegrationTest {
+
+    @Autowired
+    private TokenBlacklistService tokenBlacklistService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @AfterEach
+    void cleanup() {
+        Set<String> keys = redisTemplate.keys("BL:*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("블랙리스트 등록 - Redis에 정상 저장")
+    void add_storesTokenInRedis() {
+        // given
+        String token = "test.access.token";
+        Date expiration = new Date(System.currentTimeMillis() + 60_000);
+
+        // when
+        tokenBlacklistService.add(token, expiration);
+
+        // then
+        assertThat(redisTemplate.opsForValue().get("BL:" + token)).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("블랙리스트 확인 - 등록된 토큰 true 반환")
+    void isBlacklisted_registeredToken_returnsTrue() {
+        // given
+        String token = "test.access.token";
+        tokenBlacklistService.add(token, new Date(System.currentTimeMillis() + 60_000));
+
+        // when & then
+        assertThat(tokenBlacklistService.isBlacklisted(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("블랙리스트 확인 - 미등록 토큰 false 반환")
+    void isBlacklisted_unknownToken_returnsFalse() {
+        assertThat(tokenBlacklistService.isBlacklisted("nonexistent.token")).isFalse();
+    }
+
+    @Test
+    @DisplayName("블랙리스트 등록 - 만료된 토큰은 Redis 저장 생략")
+    void add_expiredToken_skipsStorage() {
+        // given
+        String token = "expired.access.token";
+        Date expiration = new Date(System.currentTimeMillis() - 1_000);
+
+        // when
+        tokenBlacklistService.add(token, expiration);
+
+        // then
+        assertThat(redisTemplate.opsForValue().get("BL:" + token)).isNull();
+    }
+
+    @Test
+    @DisplayName("블랙리스트 등록 - TTL이 잔여 만료 시간 이하로 설정")
+    void add_setsTtlBasedOnExpiration() {
+        // given
+        String token = "test.access.token";
+        Date expiration = new Date(System.currentTimeMillis() + 60_000);
+
+        // when
+        tokenBlacklistService.add(token, expiration);
+
+        // then
+        Long ttl = redisTemplate.getExpire("BL:" + token);
+        assertThat(ttl)
+                .isGreaterThan(0)
+                .isLessThanOrEqualTo(60);
+    }
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -6,8 +6,19 @@ import instance, { plainAxios } from '../api/axios';
 /* 인증 컨텍스트 */
 const AuthContext = createContext(null);
 
-/* StrictMode 이중 실행 방지 — useRef는 remount 시 초기화되므로 모듈 레벨 변수 사용 */
+/* StrictMode 이중 실행 방지 - useRef는 remount 시 초기화되므로 모듈 레벨 변수 사용 */
 let didAuthInit = false;
+
+/* 토큰 갱신 상태 플래그 */
+let isRefreshing = false;
+/* 토큰 갱신 대기 중인 요청 큐 */
+let failedQueue = [];
+
+/* 토큰 갱신 완료 후 대기 중인 요청 처리 */
+const processQueue = (error) => {
+    failedQueue.forEach(({ resolve, reject }) => error ? reject(error) : resolve());
+    failedQueue = [];
+};
 
 export const AuthProvider = ({ children }) => {
     /* 네비게이션 훅 */
@@ -18,7 +29,8 @@ export const AuthProvider = ({ children }) => {
     const [isInitializing, setIsInitializing] = useState(true);
 
     /* 응답 인터셉터: 401 Unauthorized 응답 시 자동으로 토큰 갱신 시도
-     * - refresh/login 요청 자체거나 이미 재시도한 경우는 그대로 reject
+     * - refresh/login 요청 자체인 경우는 그대로 reject
+     * - refresh 진행 중이면 대기 큐에 추가 후 완료 시 재시도
      * - refresh 성공 시 원래 요청 재시도
      * - refresh 실패 시 로컬 스토리지에서 사용자 정보 제거 후 로그인 페이지로 리다이렉트 */
     useEffect(() => {
@@ -29,23 +41,34 @@ export const AuthProvider = ({ children }) => {
 
                 if (
                     error.response?.status !== 401 ||
-                    original._retry ||
                     original.url === '/api/auth/refresh' ||
                     original.url === '/api/auth/login'
                 ) {
                     return Promise.reject(error);
                 }
 
-                original._retry = true;
+                /* refresh 진행 중이면 큐에 대기 */
+                if (isRefreshing) {
+                    return new Promise((resolve, reject) => {
+                        failedQueue.push({ resolve, reject });
+                    }).then(() => instance(original))
+                      .catch(err => Promise.reject(err));
+                }
+
+                isRefreshing = true;
 
                 try {
                     await instance.post('/api/auth/refresh');
+                    processQueue(null);
                     return instance(original);
-                } catch {
+                } catch (err) {
+                    processQueue(err);
                     localStorage.removeItem('user');
                     setUser(null);
                     navigate('/login', { replace: true });
-                    return Promise.reject(error);
+                    return Promise.reject(err);
+                } finally {
+                    isRefreshing = false;
                 }
             }
         );

--- a/frontend/src/pages/admin/DashboardTab.jsx
+++ b/frontend/src/pages/admin/DashboardTab.jsx
@@ -8,7 +8,8 @@ const COURSE_COLORS = ['#10B981', '#9ca3af', '#F87171', '#DC2626'];
 
 /* 도넛 차트 중앙 라벨 */
 const DonutCenter = ({ viewBox, total }) => {
-    const { cx, cy } = viewBox;
+    const { cx, cy } = viewBox || {};
+    if (cx == null || cy == null) return null;
     return (
         <g>
             <text x={cx} y={cy - 5} textAnchor="middle" fill="#111827" style={{ fontSize: 22, fontWeight: 700 }}>


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - TokenBlacklistService 추가 - 로그아웃한 accessToken을 Redis BL: 키로 저장 (잔여 TTL 기준)
  - JwtUtil.getExpiration() 추가
  - JwtFilter 블랙리스트 체크 추가 - 등록된 토큰은 인증 없이 통과
  - SecurityConfig: JwtFilter에 TokenBlacklistService 주입
  - AuthService.blacklistAccessToken() 추가
  - POST /api/auth/logout: accessToken 블랙리스트 등록 처리 추가
  - AuthContext.jsx: 동시 401 발생 시 /api/auth/refresh 중복 요청 방지 (큐 방식)

  ## 구현 시 고려한 점
  - JWT는 stateless 특성상 발급 후 서버에서 제어가 어렵고 로그아웃 후에도 15분간 탈취된 토큰으로 API 호출이 가능했음 - Redis 블랙리스트로 즉시 무효화
  - 블랙리스트 키 TTL을 토큰 잔여 만료 시간으로 설정해 만료된 키는 Redis가 자동 삭제
  - 이미 만료된 토큰은 파싱 시 JwtException이 발생하므로 블랙리스트 등록 생략
  - 동시에 여러 요청이 401을 받으면 refresh가 중복 호출되던 문제 - isRefreshing 플래그와 failedQueue로 방어
  
  ## 테스트 방법
  - ./gradlew test --tests "com.yujin.course_enrollment.service.TokenBlacklistServiceIntegrationTest"
  - ./gradlew test --tests "com.yujin.course_enrollment.service.AuthServiceTest"
  - ./gradlew test --tests "com.yujin.course_enrollment.security.SecurityIntegrationTest"
  
  ## 연관 이슈
  Closes #70