### PR TITLE
[fix] refresh 재시도 요청 무한 루프 방지

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -41,6 +41,7 @@ export const AuthProvider = ({ children }) => {
 
                 if (
                     error.response?.status !== 401 ||
+                    original._retry ||
                     original.url === '/api/auth/refresh' ||
                     original.url === '/api/auth/login'
                 ) {
@@ -49,12 +50,14 @@ export const AuthProvider = ({ children }) => {
 
                 /* refresh 진행 중이면 큐에 대기 */
                 if (isRefreshing) {
+                    original._retry = true;
                     return new Promise((resolve, reject) => {
                         failedQueue.push({ resolve, reject });
                     }).then(() => instance(original))
                       .catch(err => Promise.reject(err));
                 }
 
+                original._retry = true;
                 isRefreshing = true;
 
                 try {


### PR DESCRIPTION
  ## 작업 내용
  - 인터셉터 조건에 _retry 체크 추가
  - 직접 재시도 및 큐 대기 요청 모두 _retry = true 설정

  ## 구현 시 고려한 점
  - refresh 성공 후 재시도 요청이 다시 401을 반환하는 경우 refresh → 재시도 → 401 → refresh 무한 루프 가능성 존재
  - 큐에 대기 중인 요청도 재시도 시 동일한 문제가 발생하므로 큐 진입 시점에도 _retry 설정

  ## 연관 이슈
  #70