### PR TITLE
[refactor] 하드코딩 상수 추출 및 코드 정리

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/config/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.yujin.course_enrollment.config;
 
+import com.yujin.course_enrollment.global.CookieConstants;
 import com.yujin.course_enrollment.service.TokenBlacklistService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -69,7 +70,7 @@ public class JwtFilter extends OncePerRequestFilter {
         if (request.getCookies() == null) return null;
 
         for (Cookie cookie : request.getCookies()) {
-            if ("accessToken".equals(cookie.getName())) {
+            if (CookieConstants.ACCESS_TOKEN.equals(cookie.getName())) {
                 return cookie.getValue();
             }
         }

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqLoginDto;
+import com.yujin.course_enrollment.global.CookieConstants;
 import com.yujin.course_enrollment.dto.resp.RespLoginDto;
 import com.yujin.course_enrollment.entity.User;
 import com.yujin.course_enrollment.global.exception.BusinessException;
@@ -89,8 +90,8 @@ public class AuthController {
         authService.deleteRefreshToken(extractRefreshToken(request));
         authService.blacklistAccessToken(extractAccessToken(request));
 
-        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie("accessToken").toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie("refreshToken").toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie(CookieConstants.ACCESS_TOKEN).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie(CookieConstants.REFRESH_TOKEN).toString());
 
         return ResponseEntity.ok(ApiResponse.success());
     }
@@ -168,7 +169,7 @@ public class AuthController {
      * @return Set-Cookie 헤더용 ResponseCookie
      */
     private ResponseCookie buildAccessTokenCookie(String value) {
-        return ResponseCookie.from("accessToken", value)
+        return ResponseCookie.from(CookieConstants.ACCESS_TOKEN, value)
                 .httpOnly(true)
                 .path("/")
                 .maxAge(Duration.ofMinutes(15))
@@ -182,7 +183,7 @@ public class AuthController {
      * @return Set-Cookie 헤더용 ResponseCookie
      */
     private ResponseCookie buildRefreshTokenCookie(String value) {
-        return ResponseCookie.from("refreshToken", value)
+        return ResponseCookie.from(CookieConstants.REFRESH_TOKEN, value)
                 .httpOnly(true)
                 .path("/")
                 .maxAge(Duration.ofDays(7))
@@ -213,7 +214,7 @@ public class AuthController {
         if (request.getCookies() == null) return null;
 
         for (Cookie cookie : request.getCookies()) {
-            if ("refreshToken".equals(cookie.getName())) return cookie.getValue();
+            if (CookieConstants.REFRESH_TOKEN.equals(cookie.getName())) return cookie.getValue();
         }
 
         return null;
@@ -228,7 +229,7 @@ public class AuthController {
         if (request.getCookies() == null) return null;
 
         for (Cookie cookie : request.getCookies()) {
-            if ("accessToken".equals(cookie.getName())) return cookie.getValue();
+            if (CookieConstants.ACCESS_TOKEN.equals(cookie.getName())) return cookie.getValue();
         }
 
         return null;

--- a/backend/src/main/java/com/yujin/course_enrollment/global/CookieConstants.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/CookieConstants.java
@@ -1,0 +1,11 @@
+package com.yujin.course_enrollment.global;
+
+/**
+ * 쿠키 이름 상수 관리 클래스
+ */
+public class CookieConstants {
+    public static final String ACCESS_TOKEN = "accessToken";
+    public static final String REFRESH_TOKEN = "refreshToken";
+
+    private CookieConstants() {}
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 결제 서비스
@@ -32,6 +31,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PaymentService {
+
+    private static final String TOSS_EVENT_PAYMENT_STATUS_CHANGED = "PAYMENT_STATUS_CHANGED";
+    private static final String TOSS_STATUS_CANCELED = "CANCELED";
+    private static final String WEBHOOK_CANCEL_REASON = "Toss 웹훅 취소";
 
     private final PaymentMapper paymentMapper;
     private final EnrollmentMapper enrollmentMapper;
@@ -156,7 +159,7 @@ public class PaymentService {
     @Transactional
     public void handleTossWebhook(ReqTossWebhookDto reqTossWebhookDto) {
         // 결제 상태 변경 이벤트만 처리
-        if (!"PAYMENT_STATUS_CHANGED".equals(reqTossWebhookDto.getEventType())) {
+        if (!TOSS_EVENT_PAYMENT_STATUS_CHANGED.equals(reqTossWebhookDto.getEventType())) {
             return;
         }
 
@@ -169,7 +172,7 @@ public class PaymentService {
         }
 
         // 취소 상태만 처리
-        if (!"CANCELED".equals(data.getStatus())) {
+        if (!TOSS_STATUS_CANCELED.equals(data.getStatus())) {
             return;
         }
 
@@ -193,7 +196,7 @@ public class PaymentService {
         }
 
         // 결제 CANCELLED 처리
-        paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), "Toss 웹훅 취소"));
+        paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), WEBHOOK_CANCEL_REASON));
 
         // enrollment 상태 동기화 (CONFIRMED → CANCELLED)
         Enrollment enrollment = enrollmentMapper.selectEnrollmentById(payment.getEnrollmentId());
@@ -218,7 +221,7 @@ public class PaymentService {
 
         List<RespPaymentDto> content = paymentMapper.selectPaymentListByUserId(reqMyPaymentPageDto).stream()
                 .map(RespPaymentDto::of)
-                .collect(Collectors.toList());
+                .toList();
 
         int totalCount = paymentMapper.selectPaymentListByUserIdCount(userId);
 

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -20,6 +20,18 @@ const processQueue = (error) => {
     failedQueue = [];
 };
 
+/* 사용자 정보 저장 및 상태 업데이트 헬퍼 */
+const saveUser = (userInfo, setUser) => {
+    localStorage.setItem('user', JSON.stringify(userInfo));
+    setUser(userInfo);
+};
+
+/* 사용자 정보 제거 및 상태 초기화 헬퍼 */
+const clearUser = (setUser) => {
+    localStorage.removeItem('user');
+    setUser(null);
+};
+
 export const AuthProvider = ({ children }) => {
     /* 네비게이션 훅 */
     const navigate = useNavigate();
@@ -66,8 +78,7 @@ export const AuthProvider = ({ children }) => {
                     return instance(original);
                 } catch (err) {
                     processQueue(err);
-                    localStorage.removeItem('user');
-                    setUser(null);
+                    clearUser(setUser);
                     navigate('/login', { replace: true });
                     return Promise.reject(err);
                 } finally {
@@ -114,8 +125,7 @@ export const AuthProvider = ({ children }) => {
                 }
 
                 if (res.status === 200) {
-                    setUser(res.data.data);
-                    localStorage.setItem('user', JSON.stringify(res.data.data));
+                    saveUser(res.data.data, setUser);
                 }
             } catch {
                 /* network error — user stays null */
@@ -130,24 +140,18 @@ export const AuthProvider = ({ children }) => {
     /* 로그인: API 호출 후 응답에서 사용자 정보 저장 */
     const login = async (username, password) => {
         const res = await loginApi({ username, password });
-        const userInfo = res.data;
-
-        localStorage.setItem('user', JSON.stringify(userInfo));
-        setUser(userInfo);
+        saveUser(res.data, setUser);
     };
 
     /* 로그아웃: API 호출 후 상태 및 localStorage 초기화 */
     const logout = async () => {
         await logoutApi();
-
-        localStorage.removeItem('user');
-        setUser(null);
+        clearUser(setUser);
     };
 
     /* 프로필 수정 후 사용자 정보 갱신 */
     const updateUser = (newUserInfo) => {
-        localStorage.setItem('user', JSON.stringify(newUserInfo));
-        setUser(newUserInfo);
+        saveUser(newUserInfo, setUser);
     };
 
     return (


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - CookieConstants 클래스 추가 후 JwtFilter, AuthController 쿠키 이름 상수 적용
  - PaymentService Toss 웹훅 이벤트 타입/상태 매직 스트링 상수 추출
  - PaymentService Collectors.toList() → toList() 전환
  - AuthContext 중복 localStorage 로직 saveUser / clearUser 함수로 분리
  
  ## 구현 시 고려한 점
  - 동작 변경 없음
  - "accessToken", "refreshToken" 쿠키 이름이 JwtFilter와 AuthController에 걸쳐 분산되어 있어 변경 시 누락 가능성 존재 → 단일 상수 클래스로 관리
  - Toss 웹훅 문자열은 오타 시 런타임에서만 발견되는 구조 → 상수로 추출해 컴파일 타임 안전성 확보
  
 ## 연관 이슈
 Closes #74 
