### PR TITLE
[fix] 강제 폐강 API가 RDS 환경에서 실패하는 문제 수정

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.springframework.transaction.support.TransactionTemplate;
@@ -109,6 +110,7 @@ public class AdminService {
      * @param courseId 강의 ID
      * @throws BusinessException 강의 없음(404), 이미 폐강(400)
      */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void forceCloseCourse(Long courseId) {
         log.info("[AdminService] 강의 강제 폐강 - courseId: {}", courseId);
 


### PR DESCRIPTION
  ## 작업 내용
  - forceCloseCourse()에 @Transactional(propagation = NOT_SUPPORTED) 추가

  ## 구현 시 고려한 점
  - 단순 @Transactional을 추가하면 paymentService.refund() 실패 시 rollbackOnly가 외부 트랜잭션에 전파되어 다른 건도 롤백됨
  - NOT_SUPPORTED로 외부 트랜잭션을 차단해 TransactionTemplate이 건별 독립 트랜잭션을 유지하도록 함
  - 로컬 Docker MySQL은 readOnly 플래그를 힌트로만 처리해 쓰기가 허용됐으나 RDS MySQL 8.4는 실제로 강제해 배포 환경에서만 재현됨

  ## 연관 이슈
  #79 