### PR TITLE
[feat] Toss 웹훅 DONE 이벤트 결제 완료 보정 처리 추가

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqTossWebhookDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqTossWebhookDto.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
 /**
  * Toss 웹훅 수신 DTO
  * 결제 상태 변경 이벤트 (PAYMENT_STATUS_CHANGED) 처리
@@ -23,5 +26,14 @@ public class ReqTossWebhookDto {
         private String paymentKey;
         private String orderId;
         private String status;
+        private String method;
+        private String approvedAt;
+
+        /* ISO 8601 문자열 → LocalDateTime 변환 (e.g. "2024-01-01T10:00:00+09:00") */
+        public LocalDateTime getApprovedAtAsLocalDateTime() {
+            if (approvedAt == null) return null;
+
+            return OffsetDateTime.parse(approvedAt).toLocalDateTime();
+        }
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class PaymentService {
 
     private static final String TOSS_EVENT_PAYMENT_STATUS_CHANGED = "PAYMENT_STATUS_CHANGED";
+    private static final String TOSS_STATUS_DONE = "DONE";
     private static final String TOSS_STATUS_CANCELED = "CANCELED";
     private static final String WEBHOOK_CANCEL_REASON = "Toss 웹훅 취소";
 
@@ -152,8 +153,9 @@ public class PaymentService {
 
     /**
      * Toss 웹훅 처리
-     * PAYMENT_STATUS_CHANGED + CANCELED 이벤트 수신 시 결제 상태를 CANCELLED로 업데이트
-     * refund() 인라인 업데이트 실패로 인한 불일치를 복구하는 안전망
+     * PAYMENT_STATUS_CHANGED 이벤트 수신 시 상태별로 DB 동기화
+     * - DONE: confirmPayment() DB 업데이트 실패 시 결제 완료 보정
+     * - CANCELED: refund() 인라인 업데이트 실패 시 결제 취소 보정
      * @param reqTossWebhookDto 웹훅 페이로드
      */
     @Transactional
@@ -171,7 +173,33 @@ public class PaymentService {
             return;
         }
 
-        // 취소 상태만 처리
+        // DONE: confirmPayment() DB 업데이트 실패 시 결제 완료 보정
+        if (TOSS_STATUS_DONE.equals(data.getStatus())) {
+            Payment payment = paymentMapper.selectPaymentByOrderId(data.getOrderId());
+            if (payment == null) {
+                log.warn("[PaymentService] 웹훅 - 결제 내역 없음 - orderId: {}", data.getOrderId());
+                return;
+            }
+
+            if (PaymentStatus.DONE.equals(payment.getStatus())) {
+                log.info("[PaymentService] 웹훅 - 이미 완료된 결제 - orderId: {}", data.getOrderId());
+                return;
+            }
+
+            if (!PaymentStatus.PENDING.equals(payment.getStatus())) {
+                log.warn("[PaymentService] 웹훅 - 처리 불가 상태 - orderId: {}, status: {}", data.getOrderId(), payment.getStatus());
+                return;
+            }
+
+            paymentMapper.updatePaymentDone(Payment.ofDone(payment.getId(), data.getPaymentKey(), data.getMethod(), data.getApprovedAtAsLocalDateTime()));
+            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofConfirm(payment.getEnrollmentId()));
+
+            log.info("[PaymentService] 웹훅 - 결제 완료 보정 - orderId: {}", data.getOrderId());
+
+            return;
+        }
+
+        // CANCELED: refund() 인라인 업데이트 실패 시 결제 취소 보정
         if (!TOSS_STATUS_CANCELED.equals(data.getStatus())) {
             return;
         }

--- a/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/PaymentServiceTest.java
@@ -20,7 +20,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -297,10 +296,10 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("웹훅 - 정상 취소 처리 - payment CANCELLED + enrollment CANCELLED 동기화")
-    void handleTossWebhook_success() {
+    @DisplayName("웹훅 - CANCELED 이벤트 - payment CANCELLED + enrollment CANCELLED 동기화")
+    void handleTossWebhook_canceled_success() {
         // given
-        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "CANCELED"));
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "CANCELED", null, null));
         Payment done = Payment.builder()
                 .id(1L)
                 .enrollmentId(1L)
@@ -327,6 +326,70 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("웹훅 - DONE 이벤트 - PENDING 결제 완료 보정 (payment DONE + enrollment CONFIRMED)")
+    void handleTossWebhook_done_보정_성공() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "DONE", "카드", "2024-01-01T10:00:00+09:00"));
+        Payment pending = Payment.builder()
+                .id(1L)
+                .enrollmentId(1L)
+                .orderId("order_001")
+                .status("PENDING")
+                .build();
+
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(pending);
+        willDoNothing().given(paymentMapper).updatePaymentDone(any());
+        willDoNothing().given(enrollmentMapper).updateEnrollmentStatus(any());
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should().updatePaymentDone(any());
+        then(enrollmentMapper).should().updateEnrollmentStatus(any());
+        then(paymentMapper).should(never()).updatePaymentCancelled(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - DONE 이벤트 - 이미 DONE 상태면 멱등성 스킵")
+    void handleTossWebhook_done_이미완료_스킵() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "DONE", "카드", "2024-01-01T10:00:00+09:00"));
+        Payment done = Payment.builder()
+                .id(1L)
+                .enrollmentId(1L)
+                .paymentKey("tgen_abc123")
+                .orderId("order_001")
+                .status("DONE")
+                .build();
+
+        given(paymentMapper.selectPaymentByOrderId("order_001")).willReturn(done);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).updatePaymentDone(any());
+        then(enrollmentMapper).should(never()).updateEnrollmentStatus(any());
+    }
+
+    @Test
+    @DisplayName("웹훅 - DONE 이벤트 - 결제 내역 없음 - 처리 스킵")
+    void handleTossWebhook_done_결제없음_스킵() {
+        // given
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_999", "DONE", "카드", "2024-01-01T10:00:00+09:00"));
+
+        given(paymentMapper.selectPaymentByOrderId("order_999")).willReturn(null);
+
+        // when
+        paymentService.handleTossWebhook(reqTossWebhookDto);
+
+        // then
+        then(paymentMapper).should(never()).updatePaymentDone(any());
+        then(enrollmentMapper).should(never()).updateEnrollmentStatus(any());
+    }
+
+    @Test
     @DisplayName("웹훅 - PAYMENT_STATUS_CHANGED 아닌 이벤트 무시")
     void handleTossWebhook_ignore_otherEvent() {
         // given
@@ -340,15 +403,16 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("웹훅 - CANCELED 아닌 상태 무시")
-    void handleTossWebhook_ignore_nonCanceledStatus() {
+    @DisplayName("웹훅 - DONE/CANCELED 외 상태(ABORTED 등) 무시")
+    void handleTossWebhook_ignore_unknownStatus() {
         // given
-        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "DONE"));
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "ABORTED", null, null));
 
         // when
         paymentService.handleTossWebhook(reqTossWebhookDto);
 
         // then
+        then(paymentMapper).should(never()).updatePaymentDone(any());
         then(paymentMapper).should(never()).updatePaymentCancelled(any());
     }
 
@@ -356,7 +420,7 @@ class PaymentServiceTest {
     @DisplayName("웹훅 - 이미 CANCELLED 상태면 멱등성 스킵")
     void handleTossWebhook_idempotent_alreadyCancelled() {
         // given
-        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "CANCELED"));
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_001", "CANCELED", null, null));
         Payment cancelled = Payment.builder()
                 .id(1L)
                 .paymentKey("tgen_abc123")
@@ -377,7 +441,7 @@ class PaymentServiceTest {
     @DisplayName("웹훅 - 결제 내역 없음 - 처리 스킵")
     void handleTossWebhook_skip_paymentNotFound() {
         // given
-        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_999", "CANCELED"));
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_abc123", "order_999", "CANCELED", null, null));
 
         given(paymentMapper.selectPaymentByOrderId("order_999")).willReturn(null);
 
@@ -392,7 +456,7 @@ class PaymentServiceTest {
     @DisplayName("웹훅 - paymentKey 불일치 - 처리 스킵")
     void handleTossWebhook_skip_paymentKeyMismatch() {
         // given
-        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_WRONG", "order_001", "CANCELED"));
+        ReqTossWebhookDto reqTossWebhookDto = new ReqTossWebhookDto("PAYMENT_STATUS_CHANGED", "2026-05-21T00:00:00+09:00", new ReqTossWebhookDto.TossPaymentData("tgen_WRONG", "order_001", "CANCELED", null, null));
         Payment done = Payment.builder()
                 .id(1L)
                 .paymentKey("tgen_abc123")

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -23,3 +23,6 @@ toss:
   secret-key: ""
   confirm-url: https://api.tosspayments.com/v1/payments/confirm
   cancel-url-template: https://api.tosspayments.com/v1/payments/%s/cancel
+
+cors:
+  allowed-origins: "*"


### PR DESCRIPTION
## 작업 내용
  - Toss 웹훅 DONE 이벤트 처리 추가
  - confirmPayment에서 토스 API 승인 후 DB 업데이트 실패 시 웹훅으로 보정
  - PENDING 상태 결제를 DONE으로 업데이트하고 enrollment CONFIRMED 처리
  - ReqTossWebhookDto TossPaymentData에 method, approvedAt 필드 추가
  - PaymentServiceTest DONE 이벤트 테스트 3건 추가
  - 테스트 application.yaml cors.allowed-origins 설정 추가

  ## 구현 시 고려한 점
  - 기존 웹훅은 CANCELED만 처리 → 토스 API 승인 성공 후 DB 업데이트 실패 시 결제는 완료됐지만 DB는 PENDING으로 남는 케이스 미처리
  - DONE 이벤트 수신 시 이미 DONE이면 스킵, PENDING이 아니면 경고 로그 후 리턴으로 중복 처리 방지
  - approvedAt은 ISO 8601 문자열(+09:00)로 수신 → OffsetDateTime.parse()로 LocalDateTime 변환

  ## 테스트 방법
  - `./gradlew test --tests "com.yujin.course_enrollment.service.PaymentServiceTest"`

  ## 연관 이슈
  Closes #82