### PR TITLE
[feat] 관리자 결제 내역 조회 및 대시보드 결제 통계 추가

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -1,9 +1,11 @@
 package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
+import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqAdminRoleUpdateDto;
 import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.User;
@@ -103,6 +105,19 @@ public class AdminController {
         adminService.forceCloseCourse(courseId);
 
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 전체 결제 내역 조회
+     * GET /api/admin/payments
+     * @param reqAdminPaymentPageDto 페이징 조건 (status 필터 선택)
+     * @return 전체 결제 내역 (DONE, CANCELLED)
+     */
+    @GetMapping("/payments")
+    public ResponseEntity<ApiResponse<RespPageDto<RespAdminPaymentDto>>> getPaymentList(ReqAdminPaymentPageDto reqAdminPaymentPageDto) {
+        log.debug("[AdminController] 전체 결제 내역 조회 요청");
+
+        return ResponseEntity.ok(ApiResponse.success(adminService.findAdminPayments(reqAdminPaymentPageDto)));
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminPaymentPageDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminPaymentPageDto.java
@@ -1,0 +1,22 @@
+package com.yujin.course_enrollment.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 관리자 결제 내역 페이징 조건 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqAdminPaymentPageDto {
+    private int page = 0;
+    private int size = 10;
+    private String status;
+
+    /* offset 계산 */
+    public int getOffset() {
+        return page * size;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
@@ -18,9 +18,12 @@ public class RespAdminDashboardDto {
     private int closedCount;
     private int forceClosedCount;
     private int totalEnrollments;
+    private Long totalRevenue;
+    private Long totalRefund;
+    private Long monthlyRevenue;
 
     /* 통계 집계 결과로 대시보드 응답 생성 */
-    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int forceClosedCount, int totalEnrollments) {
+    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int forceClosedCount, int totalEnrollments, Long totalRevenue, Long totalRefund, Long monthlyRevenue) {
         return RespAdminDashboardDto.builder()
                 .totalUsers(totalUsers)
                 .studentCount(studentCount)
@@ -31,6 +34,9 @@ public class RespAdminDashboardDto {
                 .closedCount(closedCount)
                 .forceClosedCount(forceClosedCount)
                 .totalEnrollments(totalEnrollments)
+                .totalRevenue(totalRevenue)
+                .totalRefund(totalRefund)
+                .monthlyRevenue(monthlyRevenue)
                 .build();
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminPaymentDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminPaymentDto.java
@@ -1,0 +1,25 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 결제 내역 응답 DTO
+ */
+@Getter
+public class RespAdminPaymentDto {
+    private Long id;
+    private Long enrollmentId;
+    private String userName;
+    private String courseName;
+    private String orderId;
+    private String orderName;
+    private int amount;
+    private String method;
+    private String status;
+    private LocalDateTime paidAt;
+    private LocalDateTime canceledAt;
+    private String cancelReason;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -1,6 +1,8 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.entity.Payment;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -35,4 +37,19 @@ public interface PaymentMapper {
 
     /* 사용자 결제 내역 전체 수 조회 (페이징용) */
     int selectPaymentListByUserIdCount(Long userId);
+
+    /* 관리자 전체 결제 내역 조회 */
+    List<RespAdminPaymentDto> selectAdminPaymentList(ReqAdminPaymentPageDto reqAdminPaymentPageDto);
+
+    /* 관리자 전체 결제 내역 수 조회 (페이징용) */
+    int selectAdminPaymentListCount(ReqAdminPaymentPageDto reqAdminPaymentPageDto);
+
+    /* 전체 결제 금액 (DONE) */
+    Long selectTotalRevenue();
+
+    /* 전체 환불 금액 (CANCELLED) */
+    Long selectTotalRefund();
+
+    /* 이번 달 매출 (DONE, paid_at 기준) */
+    Long selectMonthlyRevenue();
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -1,7 +1,9 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
+import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
@@ -11,6 +13,7 @@ import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.PaymentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,12 +39,13 @@ public class AdminService {
     private final UserMapper userMapper;
     private final CourseMapper courseMapper;
     private final EnrollmentMapper enrollmentMapper;
+    private final PaymentMapper paymentMapper;
     private final PaymentService paymentService;
     private final TransactionTemplate transactionTemplate;
 
     /**
      * 대시보드 통계 조회
-     * @return 전체 사용자 수, 강의 수, 확정 수강 신청 수
+     * @return 전체 사용자 수, 강의 수, 확정 수강 신청 수, 결제 통계
      */
     public RespAdminDashboardDto getDashboardStats() {
         log.info("[AdminService] 대시보드 통계 조회");
@@ -55,8 +59,11 @@ public class AdminService {
         int closedCount = courseMapper.selectCourseCountByStatus("CLOSED");
         int forceClosedCount = courseMapper.selectCourseCountByStatus("FORCE_CLOSED");
         int totalEnrollments = enrollmentMapper.selectActiveEnrollmentCount();
+        Long totalRevenue = paymentMapper.selectTotalRevenue();
+        Long totalRefund = paymentMapper.selectTotalRefund();
+        Long monthlyRevenue = paymentMapper.selectMonthlyRevenue();
 
-        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, forceClosedCount, totalEnrollments);
+        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, forceClosedCount, totalEnrollments, totalRevenue, totalRefund, monthlyRevenue);
     }
 
     /**
@@ -103,6 +110,20 @@ public class AdminService {
         int totalCount = courseMapper.selectAdminCourseListCount();
 
         return RespPageDto.of(content, reqAdminCoursePageDto.getPage(), reqAdminCoursePageDto.getSize(), totalCount);
+    }
+
+    /**
+     * 관리자 전체 결제 내역 조회
+     * @param reqAdminPaymentPageDto 페이징 조건 (status 필터 선택)
+     * @return 페이징된 결제 내역 (DONE, CANCELLED)
+     */
+    public RespPageDto<RespAdminPaymentDto> findAdminPayments(ReqAdminPaymentPageDto reqAdminPaymentPageDto) {
+        log.info("[AdminService] 전체 결제 내역 조회 - page: {}, size: {}, status: {}", reqAdminPaymentPageDto.getPage(), reqAdminPaymentPageDto.getSize(), reqAdminPaymentPageDto.getStatus());
+
+        List<RespAdminPaymentDto> content = paymentMapper.selectAdminPaymentList(reqAdminPaymentPageDto);
+        int totalCount = paymentMapper.selectAdminPaymentListCount(reqAdminPaymentPageDto);
+
+        return RespPageDto.of(content, reqAdminPaymentPageDto.getPage(), reqAdminPaymentPageDto.getSize(), totalCount);
     }
 
     /**

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -124,4 +124,63 @@
            AND p.status IN ('DONE', 'CANCELLED')
     </select>
 
+    <!-- 관리자 전체 결제 내역 조회 -->
+    <select id="selectAdminPaymentList" parameterType="ReqAdminPaymentPageDto" resultType="RespAdminPaymentDto">
+        SELECT p.id
+             , p.enrollment_id
+             , u.name AS userName
+             , c.title AS courseName
+             , p.order_id
+             , p.order_name
+             , p.amount
+             , p.method
+             , p.status
+             , p.paid_at
+             , p.canceled_at
+             , p.cancel_reason
+             , p.created_at
+          FROM payments p
+          JOIN enrollments e ON p.enrollment_id = e.id
+          JOIN users u ON e.user_id = u.id
+          JOIN courses c ON e.course_id = c.id
+         WHERE p.status IN ('DONE', 'CANCELLED')
+        <if test="status != null and status != ''">
+           AND p.status = #{status}
+        </if>
+        ORDER BY p.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 관리자 전체 결제 내역 수 조회 (페이징용) -->
+    <select id="selectAdminPaymentListCount" parameterType="ReqAdminPaymentPageDto" resultType="int">
+        SELECT COUNT(*)
+          FROM payments
+         WHERE status IN ('DONE', 'CANCELLED')
+        <if test="status != null and status != ''">
+           AND status = #{status}
+        </if>
+    </select>
+
+    <!-- 전체 결제 금액 (DONE) -->
+    <select id="selectTotalRevenue" resultType="Long">
+        SELECT IFNULL(SUM(amount), 0)
+          FROM payments
+         WHERE status = 'DONE'
+    </select>
+
+    <!-- 전체 환불 금액 (CANCELLED) -->
+    <select id="selectTotalRefund" resultType="Long">
+        SELECT IFNULL(SUM(amount), 0)
+          FROM payments
+         WHERE status = 'CANCELLED'
+    </select>
+
+    <!-- 이번 달 매출 (DONE, paid_at 기준) -->
+    <select id="selectMonthlyRevenue" resultType="Long">
+        SELECT IFNULL(SUM(amount), 0)
+          FROM payments
+         WHERE status = 'DONE'
+           AND DATE_FORMAT(paid_at, '%Y-%m') = DATE_FORMAT(NOW(), '%Y-%m')
+    </select>
+
 </mapper>

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -25,6 +25,11 @@ export const forceCloseCourse = (courseId) => {
     return instance.patch(`/api/admin/courses/${courseId}/close`).then(res => res.data);
 };
 
+/* 전체 결제 내역 조회 */
+export const getAdminPayments = (page = 0, size = 10, status = '') => {
+    return instance.get('/api/admin/payments', { params: { page, size, status: status || undefined } }).then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -3,6 +3,7 @@ import CreatorRequestTab from './admin/CreatorRequestTab';
 import DashboardTab from './admin/DashboardTab';
 import UserManagementTab from './admin/UserManagementTab';
 import CourseManagementTab from './admin/CourseManagementTab';
+import PaymentManagementTab from './admin/PaymentManagementTab';
 import { updateAdminPassword } from '../api/admin';
 
 /* 관리자 페이지 */
@@ -22,6 +23,7 @@ const AdminPage = () => {
         { key: 'creator-requests', label: '강사 신청 관리' },
         { key: 'users', label: '사용자 관리' },
         { key: 'courses', label: '강의 관리' },
+        { key: 'payments', label: '결제 관리' },
     ];
 
     /* 모달 닫기 */
@@ -87,6 +89,7 @@ const AdminPage = () => {
             {activeTab === 'creator-requests' && <CreatorRequestTab />}
             {activeTab === 'users' && <UserManagementTab />}
             {activeTab === 'courses' && <CourseManagementTab />}
+            {activeTab === 'payments' && <PaymentManagementTab />}
 
             {/* 비밀번호 변경 모달 */}
             {showPasswordModal && (

--- a/frontend/src/pages/admin/DashboardTab.jsx
+++ b/frontend/src/pages/admin/DashboardTab.jsx
@@ -38,6 +38,11 @@ const IconCheck = () => (
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
 );
+const IconWon = () => (
+    <svg className="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+);
 
 /* 관리자 대시보드 탭 */
 const DashboardTab = () => {
@@ -80,11 +85,34 @@ const DashboardTab = () => {
 
     if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
+    /* 결제 통계 카드 데이터 */
+    const paymentCards = [
+        { label: '총 결제금액', value: stats?.totalRevenue ?? 0, unit: '원', icon: <IconWon /> },
+        { label: '총 환불금액', value: stats?.totalRefund ?? 0, unit: '원', icon: <IconWon /> },
+        { label: '이번 달 매출', value: stats?.monthlyRevenue ?? 0, unit: '원', icon: <IconWon /> },
+    ];
+
     return (
         <div className="space-y-8">
             {/* 요약 카드 */}
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
                 {cards.map(card => (
+                    <div key={card.label} className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
+                        <div className="flex items-start justify-between mb-1">
+                            <p className="text-xs font-semibold text-gray-400 tracking-wide uppercase">{card.label}</p>
+                            {card.icon}
+                        </div>
+                        <p className="text-4xl font-extrabold text-gray-900">
+                            {card.value.toLocaleString()}
+                            <span className="text-sm font-medium text-gray-400 ml-1">{card.unit}</span>
+                        </p>
+                    </div>
+                ))}
+            </div>
+
+            {/* 결제 통계 카드 */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
+                {paymentCards.map(card => (
                     <div key={card.label} className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
                         <div className="flex items-start justify-between mb-1">
                             <p className="text-xs font-semibold text-gray-400 tracking-wide uppercase">{card.label}</p>

--- a/frontend/src/pages/admin/PaymentManagementTab.jsx
+++ b/frontend/src/pages/admin/PaymentManagementTab.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { getAdminPayments } from '../../api/admin';
+
+/* 결제 상태 배지 스타일 */
+const PAYMENT_STATUS_BADGE_STYLE = {
+    DONE: 'bg-green-50 text-green-700 border-green-200',
+    CANCELLED: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+/* 결제 상태 레이블 */
+const PAYMENT_STATUS_LABEL = {
+    DONE: '결제완료',
+    CANCELLED: '환불완료',
+};
+
+/* 상태 필터 목록 */
+const STATUS_FILTERS = [
+    { key: '', label: '전체' },
+    { key: 'DONE', label: '결제완료' },
+    { key: 'CANCELLED', label: '환불완료' },
+];
+
+/* 관리자 결제 관리 탭 */
+const PaymentManagementTab = () => {
+    /* 결제 목록 상태 */
+    const [payments, setPayments] = useState([]);
+    /* 페이징 상태 */
+    const [page, setPage] = useState(0);
+    /* 전체 페이지 수 상태 */
+    const [totalPages, setTotalPages] = useState(0);
+    /* 마지막 페이지 여부 상태 */
+    const [isLast, setIsLast] = useState(false);
+    /* 상태 필터 */
+    const [status, setStatus] = useState('');
+    /* 로딩 상태 */
+    const [isLoading, setIsLoading] = useState(true);
+
+    /* 결제 목록 조회 */
+    const fetchPayments = (p, s) => {
+        setIsLoading(true);
+
+        getAdminPayments(p, 10, s)
+            .then(res => {
+                setPayments(res.data.content);
+                setTotalPages(res.data.totalPages);
+                setIsLast(res.data.last);
+            })
+            .catch(() => alert('결제 내역 조회에 실패했습니다.'))
+            .finally(() => setIsLoading(false));
+    };
+
+    /* 페이지 또는 상태 필터 변경 시 재조회 */
+    useEffect(() => {
+        fetchPayments(page, status);
+    }, [page, status]);
+
+    /* 상태 필터 변경 시 페이지 초기화 */
+    const handleStatusChange = (newStatus) => {
+        setStatus(newStatus);
+        setPage(0);
+    };
+
+    return (
+        <>
+            {/* 상태 필터 */}
+            <div className="flex gap-2 mb-6">
+                {STATUS_FILTERS.map(filter => (
+                    <button
+                        key={filter.key}
+                        onClick={() => handleStatusChange(filter.key)}
+                        className={`px-4 py-1.5 text-sm font-semibold rounded-full border transition-colors cursor-pointer ${
+                            status === filter.key
+                                ? 'bg-blue-600 text-white border-blue-600'
+                                : 'text-gray-500 border-gray-300 hover:border-gray-400'
+                        }`}
+                    >
+                        {filter.label}
+                    </button>
+                ))}
+            </div>
+
+            {isLoading ? (
+                <div className="text-center py-20 text-gray-400">로딩 중...</div>
+            ) : payments.length === 0 ? (
+                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                    결제 내역이 없습니다.
+                </div>
+            ) : (
+                <>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm text-left">
+                            {/* 테이블 헤더 */}
+                            <thead>
+                                <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
+                                    <th className="pb-3 pr-6 font-semibold">사용자명</th>
+                                    <th className="pb-3 pr-6 font-semibold">강의명</th>
+                                    <th className="pb-3 pr-6 font-semibold">금액</th>
+                                    <th className="pb-3 pr-6 font-semibold">상태</th>
+                                    <th className="pb-3 pr-6 font-semibold">결제일</th>
+                                    <th className="pb-3 font-semibold">환불일</th>
+                                </tr>
+                            </thead>
+                            {/* 테이블 바디 */}
+                            <tbody className="divide-y divide-gray-100">
+                                {payments.map(payment => (
+                                    <tr key={payment.id} className="hover:bg-gray-50">
+                                        <td className="py-4 pr-6 font-medium text-gray-900">{payment.userName}</td>
+                                        <td className="py-4 pr-6 text-gray-700 max-w-xs truncate">{payment.courseName}</td>
+                                        <td className="py-4 pr-6 font-semibold text-gray-900">{payment.amount.toLocaleString()}원</td>
+                                        <td className="py-4 pr-6">
+                                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${PAYMENT_STATUS_BADGE_STYLE[payment.status]}`}>
+                                                {PAYMENT_STATUS_LABEL[payment.status]}
+                                            </span>
+                                        </td>
+                                        <td className="py-4 pr-6 text-gray-500">{payment.paidAt?.substring(0, 10) ?? '-'}</td>
+                                        <td className="py-4 text-gray-500">{payment.canceledAt?.substring(0, 10) ?? '-'}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* 페이징 */}
+                    {totalPages > 1 && (
+                        <div className="flex justify-center items-center gap-4 mt-8">
+                            <button disabled={page === 0}
+                                onClick={() => setPage(prev => prev - 1)}
+                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                                </svg>
+                            </button>
+                            <span className="text-sm font-medium text-gray-700">
+                                <span className="text-blue-600">{page + 1}</span> / {totalPages}
+                            </span>
+                            <button disabled={isLast}
+                                onClick={() => setPage(prev => prev + 1)}
+                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                                </svg>
+                            </button>
+                        </div>
+                    )}
+                </>
+            )}
+        </>
+    );
+};
+
+export default PaymentManagementTab;


### PR DESCRIPTION
  ## 작업 내용
  - 전체 결제 내역 조회 엔드포인트 추가 (GET /api/admin/payments, 상태 필터·페이지네이션)
  - 대시보드 통계에 총 결제금액·환불금액·이번 달 매출 조회 추가
  - 관리자 결제 내역 조회 요청·응답 DTO 추가 (페이징 조건, 사용자명·강의명 포함 결제 정보)
  - 결제 관리 탭 추가 (상태 필터, 페이지네이션)
  - 대시보드에 결제 통계 카드 추가 (총 결제금액·환불금액·이번 달 매출)

  ## 구현 시 고려한 점
  - 결제 내역은 DONE·CANCELLED만 노출 (PENDING·FAILED는 미완료 상태로 관리자 조회 대상 외)
  - 상태 필터 미선택 시 전체 조회, 선택 시 해당 상태만 필터링
  - 금액 통계는 IFNULL(SUM, 0)으로 데이터 없을 때 null 대신 0 반환

  ## 테스트 방법
  - 관리자 계정으로 로그인 후 결제 관리 탭에서 전체·상태별 필터 조회 확인
  - 대시보드에서 결제 통계 카드 확인

  ## 연관 이슈
  Closes #85