### PR TITLE
[feat] 강제 폐강 환불 실패 처리 구현

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -121,6 +121,21 @@ public class AdminController {
     }
 
     /**
+     * 환불 실패 건 수동 재시도
+     * PATCH /api/admin/enrollments/{enrollmentId}/refund-retry
+     * @param enrollmentId 수강 신청 ID
+     * @return 200 OK
+     */
+    @PatchMapping("/enrollments/{enrollmentId}/refund-retry")
+    public ResponseEntity<ApiResponse<Void>> retryRefund(@PathVariable Long enrollmentId) {
+        log.debug("[AdminController] 환불 재시도 - enrollmentId: {}", enrollmentId);
+
+        adminService.retryRefund(enrollmentId);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
      * 관리자 비밀번호 변경
      * PATCH /api/admin/me/password
      * @param userId SecurityContext에서 추출된 관리자 ID

--- a/backend/src/main/java/com/yujin/course_enrollment/global/PaymentStatus.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/PaymentStatus.java
@@ -8,6 +8,7 @@ public class PaymentStatus {
     public static final String DONE = "DONE";
     public static final String FAILED = "FAILED";
     public static final String CANCELLED = "CANCELLED";
+    public static final String REFUND_FAILED = "REFUND_FAILED";
 
     private PaymentStatus() {}
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -29,6 +29,9 @@ public interface PaymentMapper {
     /* 수강 신청 ID로 DONE 상태 결제 조회 */
     Payment selectPaymentByEnrollmentId(Long enrollmentId);
 
+    /* 환불 실패 마킹 (REFUND_FAILED 업데이트) */
+    void updatePaymentRefundFailed(Long enrollmentId);
+
     /* 결제 취소 상태 업데이트 */
     void updatePaymentCancelled(Payment payment);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -5,6 +5,8 @@ import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
+import com.yujin.course_enrollment.entity.Payment;
+import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
@@ -35,6 +37,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminService {
+
+    private static final int MAX_REFUND_RETRIES = 2;
 
     private final UserMapper userMapper;
     private final CourseMapper courseMapper;
@@ -159,19 +163,65 @@ public class AdminService {
             return;
         }
 
-        // CONFIRMED 건별 환불 후 취소 — 실패해도 다음 건으로 진행
+        // CONFIRMED 건별 환불 후 취소 — 실패 시 재시도 후 REFUND_FAILED 마킹
         int successCount = 0;
         for (Long enrollmentId : confirmedIds) {
-            try {
-                paymentService.refund(enrollmentId, "강의 폐강");
+            boolean refunded = false;
+
+            for (int attempt = 1; attempt <= MAX_REFUND_RETRIES; attempt++) {
+                try {
+                    paymentService.refund(enrollmentId, "강의 폐강");
+                    refunded = true;
+                    break;
+                } catch (Exception e) {
+                    log.warn("[AdminService] 환불 시도 {}/{} 실패 - enrollmentId: {}", attempt, MAX_REFUND_RETRIES, enrollmentId, e);
+                }
+            }
+
+            // 재시도 성공
+            if (refunded) {
                 transactionTemplate.executeWithoutResult(s ->
                         enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollmentId)));
                 successCount++;
-            } catch (Exception e) {
-                log.error("[AdminService] 환불 처리 실패 - enrollmentId: {}", enrollmentId, e);
+            // 재시도 최종 실패 → REFUND_FAILED 마킹
+            } else {
+                log.error("[AdminService] 환불 최종 실패 - REFUND_FAILED 마킹 - enrollmentId: {}", enrollmentId);
+                transactionTemplate.executeWithoutResult(s ->
+                        paymentMapper.updatePaymentRefundFailed(enrollmentId));
             }
         }
 
         log.info("[AdminService] 강의 강제 폐강 완료 - courseId: {}, 환불 성공: {}/{}", courseId, successCount, confirmedIds.size());
+    }
+
+    /**
+     * 환불 실패 건 수동 재시도
+     * REFUND_FAILED 상태 수강 신청에 대해 Toss 환불 API 재호출
+     * @param enrollmentId 수강 신청 ID
+     * @throws BusinessException 수강 신청 없음(404), REFUND_FAILED 상태 아님(400)
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void retryRefund(Long enrollmentId) {
+        log.info("[AdminService] 환불 재시도 - enrollmentId: {}", enrollmentId);
+
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentById(enrollmentId);
+        if (enrollment == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "존재하지 않는 수강 신청입니다.");
+        }
+
+        Payment payment = paymentMapper.selectPaymentByEnrollmentId(enrollmentId);
+        if (payment == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "결제 내역이 없습니다.");
+        }
+
+        if (!PaymentStatus.REFUND_FAILED.equals(payment.getStatus())) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "환불 실패 상태의 결제만 재시도할 수 있습니다.");
+        }
+
+        paymentService.refund(enrollmentId, "강의 폐강");
+        transactionTemplate.executeWithoutResult(s ->
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollmentId)));
+
+        log.info("[AdminService] 환불 재시도 성공 - enrollmentId: {}", enrollmentId);
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -8,6 +8,7 @@ import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.Payment;
+import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.EnrollmentStatus;
 import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
@@ -229,11 +230,18 @@ public class PaymentService {
         // 결제 CANCELLED 처리
         paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), WEBHOOK_CANCEL_REASON));
 
-        // enrollment 상태 동기화 (CONFIRMED → CANCELLED)
+        // enrollment 상태 동기화 — 강제 폐강 강의이면 FORCE_CLOSED, 아니면 CANCELLED
         Enrollment enrollment = enrollmentMapper.selectEnrollmentById(payment.getEnrollmentId());
         if (enrollment != null && EnrollmentStatus.CONFIRMED.equals(enrollment.getStatus())) {
-            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(payment.getEnrollmentId()));
-            log.info("[PaymentService] 웹훅 - enrollment 취소 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+            Course course = courseMapper.selectCourseById(enrollment.getCourseId());
+
+            if (course != null && CourseStatus.FORCE_CLOSED.equals(course.getStatus())) {
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollment.getId()));
+                log.info("[PaymentService] 웹훅 - enrollment 강제 폐강 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+            } else {
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(enrollment.getId()));
+                log.info("[PaymentService] 웹훅 - enrollment 취소 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+            }
         }
 
         log.info("[PaymentService] 웹훅 - 결제 취소 처리 완료 - orderId: {}", data.getOrderId());

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -62,7 +62,7 @@
          WHERE order_id = #{orderId}
     </select>
 
-    <!-- 수강 신청 ID로 DONE 상태 결제 조회 -->
+    <!-- 수강 신청 ID로 DONE/REFUND_FAILED 상태 결제 조회 -->
     <select id="selectPaymentByEnrollmentId" parameterType="Long" resultType="Payment">
         SELECT id
              , enrollment_id
@@ -79,8 +79,16 @@
              , updated_at
           FROM payments
          WHERE enrollment_id = #{enrollmentId}
-           AND status = 'DONE'
+           AND status IN ('DONE', 'REFUND_FAILED')
     </select>
+
+    <!-- 환불 실패 마킹 (REFUND_FAILED 업데이트) -->
+    <update id="updatePaymentRefundFailed" parameterType="Long">
+        UPDATE payments
+           SET status = 'REFUND_FAILED'
+         WHERE enrollment_id = #{enrollmentId}
+           AND status = 'DONE'
+    </update>
 
     <!-- 결제 취소 상태 업데이트 -->
     <update id="updatePaymentCancelled" parameterType="Payment">
@@ -89,7 +97,7 @@
              , canceled_at = #{canceledAt}
              , cancel_reason = #{cancelReason}
          WHERE id = #{id}
-           AND status = 'DONE'
+           AND status IN ('DONE', 'REFUND_FAILED')
     </update>
 
     <!-- 사용자 결제 내역 조회 (DONE, CANCELLED) -->
@@ -143,7 +151,7 @@
           JOIN enrollments e ON p.enrollment_id = e.id
           JOIN users u ON e.user_id = u.id
           JOIN courses c ON e.course_id = c.id
-         WHERE p.status IN ('DONE', 'CANCELLED')
+         WHERE p.status IN ('DONE', 'CANCELLED', 'FAILED', 'REFUND_FAILED')
         <if test="status != null and status != ''">
            AND p.status = #{status}
         </if>
@@ -155,7 +163,7 @@
     <select id="selectAdminPaymentListCount" parameterType="ReqAdminPaymentPageDto" resultType="int">
         SELECT COUNT(*)
           FROM payments
-         WHERE status IN ('DONE', 'CANCELLED')
+         WHERE status IN ('DONE', 'CANCELLED', 'FAILED', 'REFUND_FAILED')
         <if test="status != null and status != ''">
            AND status = #{status}
         </if>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/AdminServiceTest.java
@@ -2,11 +2,14 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.entity.Payment;
 import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.EnrollmentStatus;
+import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.PaymentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +48,9 @@ class AdminServiceTest {
 
     @Mock
     private EnrollmentMapper enrollmentMapper;
+
+    @Mock
+    private PaymentMapper paymentMapper;
 
     @Mock
     private PaymentService paymentService;
@@ -111,8 +117,8 @@ class AdminServiceTest {
     }
 
     @Test
-    @DisplayName("강제 폐강 - 환불 실패한 건은 로그 후 다음 건으로 진행")
-    void forceCloseCourse_refundFails_continuesOtherEnrollments() {
+    @DisplayName("강제 폐강 - 환불 최종 실패 시 payment REFUND_FAILED 마킹 후 다음 건 진행")
+    void forceCloseCourse_refundFails_marksPaymentRefundFailed() {
         // given
         Long courseId = 1L;
         Course course = Course.builder().id(courseId).status(CourseStatus.OPEN).build();
@@ -125,10 +131,11 @@ class AdminServiceTest {
         // when
         assertThatCode(() -> adminService.forceCloseCourse(courseId)).doesNotThrowAnyException();
 
-        // then: 10L 실패해도 11L 처리됨
-        then(paymentService).should().refund(eq(11L), eq("강의 폐강"));
+        // then: 10L 실패 → REFUND_FAILED 마킹, 11L은 정상 처리
+        then(paymentMapper).should().updatePaymentRefundFailed(10L);
         then(enrollmentMapper).should(never()).updateEnrollmentStatus(argThat(e ->
                 Long.valueOf(10L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+        then(paymentService).should().refund(eq(11L), eq("강의 폐강"));
         then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
                 Long.valueOf(11L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
     }
@@ -169,5 +176,70 @@ class AdminServiceTest {
         assertThatThrownBy(() -> adminService.forceCloseCourse(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("이미 폐강");
+    }
+
+    @Test
+    @DisplayName("환불 재시도 성공")
+    void retryRefund_success() {
+        // given
+        Long enrollmentId = 10L;
+        Enrollment enrollment = Enrollment.builder().id(enrollmentId).status(EnrollmentStatus.CONFIRMED).build();
+        Payment payment = Payment.builder().id(1L).status(PaymentStatus.REFUND_FAILED).build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(enrollment);
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(payment);
+
+        // when
+        adminService.retryRefund(enrollmentId);
+
+        // then
+        then(paymentService).should().refund(enrollmentId, "강의 폐강");
+        then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
+                enrollmentId.equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+    }
+
+    @Test
+    @DisplayName("환불 재시도 실패 - 수강 신청 없음 404")
+    void retryRefund_enrollmentNotFound_throws404() {
+        // given
+        given(enrollmentMapper.selectEnrollmentById(any())).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.retryRefund(99L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("존재하지 않는 수강 신청");
+    }
+
+    @Test
+    @DisplayName("환불 재시도 실패 - REFUND_FAILED 상태 아님 400")
+    void retryRefund_paymentNotRefundFailed_throws400() {
+        // given
+        Long enrollmentId = 10L;
+        Enrollment enrollment = Enrollment.builder().id(enrollmentId).status(EnrollmentStatus.CONFIRMED).build();
+        Payment payment = Payment.builder().id(1L).status(PaymentStatus.DONE).build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(enrollment);
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(payment);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.retryRefund(enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("환불 실패 상태의 결제만 재시도");
+    }
+
+    @Test
+    @DisplayName("환불 재시도 실패 - 결제 내역 없음 404")
+    void retryRefund_paymentNotFound_throws404() {
+        // given
+        Long enrollmentId = 10L;
+        Enrollment enrollment = Enrollment.builder().id(enrollmentId).status(EnrollmentStatus.CONFIRMED).build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(enrollment);
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.retryRefund(enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("결제 내역이 없습니다");
     }
 }

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -30,6 +30,11 @@ export const getAdminPayments = (page = 0, size = 10, status = '') => {
     return instance.get('/api/admin/payments', { params: { page, size, status: status || undefined } }).then(res => res.data);
 };
 
+/* 환불 실패 건 재시도 */
+export const retryRefund = (enrollmentId) => {
+    return instance.patch(`/api/admin/enrollments/${enrollmentId}/refund-retry`).then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/pages/admin/PaymentManagementTab.jsx
+++ b/frontend/src/pages/admin/PaymentManagementTab.jsx
@@ -1,15 +1,19 @@
 import { useEffect, useState } from 'react';
-import { getAdminPayments } from '../../api/admin';
+import { getAdminPayments, retryRefund } from '../../api/admin';
 
 /* 결제 상태 배지 스타일 */
 const PAYMENT_STATUS_BADGE_STYLE = {
     DONE: 'bg-green-50 text-green-700 border-green-200',
     CANCELLED: 'bg-gray-50 text-gray-500 border-gray-200',
+    FAILED: 'bg-orange-50 text-orange-600 border-orange-200',
+    REFUND_FAILED: 'bg-red-50 text-red-600 border-red-200',
 };
 /* 결제 상태 레이블 */
 const PAYMENT_STATUS_LABEL = {
     DONE: '결제완료',
     CANCELLED: '환불완료',
+    FAILED: '결제실패',
+    REFUND_FAILED: '환불실패',
 };
 
 /* 상태 필터 목록 */
@@ -17,6 +21,8 @@ const STATUS_FILTERS = [
     { key: '', label: '전체' },
     { key: 'DONE', label: '결제완료' },
     { key: 'CANCELLED', label: '환불완료' },
+    { key: 'FAILED', label: '결제실패' },
+    { key: 'REFUND_FAILED', label: '환불실패' },
 ];
 
 /* 관리자 결제 관리 탭 */
@@ -33,6 +39,8 @@ const PaymentManagementTab = () => {
     const [status, setStatus] = useState('');
     /* 로딩 상태 */
     const [isLoading, setIsLoading] = useState(true);
+    /* 재시도 중인 enrollmentId 목록 */
+    const [retrying, setRetrying] = useState(new Set());
 
     /* 결제 목록 조회 */
     const fetchPayments = (p, s) => {
@@ -59,6 +67,23 @@ const PaymentManagementTab = () => {
         setPage(0);
     };
 
+    /* 환불 재시도 */
+    const handleRetry = (enrollmentId) => {
+        setRetrying(prev => new Set(prev).add(enrollmentId));
+
+        retryRefund(enrollmentId)
+            .then(() => {
+                alert('환불 재시도가 완료되었습니다.');
+                fetchPayments(page, status);
+            })
+            .catch(err => alert(err.response?.data?.message || '환불 재시도에 실패했습니다.'))
+            .finally(() => setRetrying(prev => {
+                const next = new Set(prev);
+                next.delete(enrollmentId);
+                return next;
+            }));
+    };
+
     return (
         <>
             {/* 상태 필터 */}
@@ -82,7 +107,7 @@ const PaymentManagementTab = () => {
                 <div className="text-center py-20 text-gray-400">로딩 중...</div>
             ) : payments.length === 0 ? (
                 <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                    결제 내역이 없습니다.
+                    {PAYMENT_STATUS_LABEL[status] ? `${PAYMENT_STATUS_LABEL[status]} 내역이 없습니다.` : '결제 내역이 없습니다.'}
                 </div>
             ) : (
                 <>
@@ -112,7 +137,18 @@ const PaymentManagementTab = () => {
                                             </span>
                                         </td>
                                         <td className="py-4 pr-6 text-gray-500">{payment.paidAt?.substring(0, 10) ?? '-'}</td>
-                                        <td className="py-4 text-gray-500">{payment.canceledAt?.substring(0, 10) ?? '-'}</td>
+                                        <td className="py-4 text-gray-500">
+                                            {payment.canceledAt?.substring(0, 10) ?? '-'}
+                                            {payment.status === 'REFUND_FAILED' && (
+                                                <button
+                                                    onClick={() => handleRetry(payment.enrollmentId)}
+                                                    disabled={retrying.has(payment.enrollmentId)}
+                                                    className="ml-3 px-2 py-0.5 text-xs font-semibold text-white bg-red-500 rounded hover:bg-red-600 disabled:opacity-50 cursor-pointer transition-colors"
+                                                >
+                                                    {retrying.has(payment.enrollmentId) ? '재시도 중...' : '재시도'}
+                                                </button>
+                                            )}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>


### PR DESCRIPTION
  ## 작업 내용
  - 강제 폐강 환불 최종 실패 시 payment status를 REFUND_FAILED로 마킹 (재시도 2회 후)
  - 환불 실패 건 수동 재시도 엔드포인트 추가 (PATCH /api/admin/enrollments/{enrollmentId}/refund-retry)
  - REFUND_FAILED를 EnrollmentStatus에서 PaymentStatus로 이동
  - 관리자 결제 내역 조회에 FAILED·REFUND_FAILED 상태 포함             
  - 결제 관리 탭 상태 배지·필터에 결제실패·환불실패 추가, 재시도 버튼 제공
  - AdminServiceTest 환불 실패 마킹 검증 수정, retryRefund 테스트 4건 추가

  ## 구현 시 고려한 점
  - REFUND_FAILED는 결제 작업 실패이므로 EnrollmentStatus가 아닌 PaymentStatus에서 관리
  - 환불 실패 시 enrollment는 CONFIRMED 유지, payment만 REFUND_FAILED로 마킹
  - retryRefund 재시도 성공 후 Toss 웹훅 CANCELED 수신 시에도 enrollment가 CONFIRMED 상태이면 FORCE_CLOSED로 보정 가능
  - selectPaymentByEnrollmentId·updatePaymentCancelled에 REFUND_FAILED 포함하여 재시도 시 환불 처리 가능

  ## 테스트 방법
  - 강제 폐강 시 환불 실패 발생 시나리오에서 payment status REFUND_FAILED 확인
  - 관리자 결제 관리 탭에서 환불실패 필터 및 재시도 버튼 동작 확인
  - 재시도 성공 후 enrollment FORCE_CLOSED 전환 확인

  ## 연관 이슈
  Closes #87