### PR TITLE
[feat] 테스트 계정 빠른 로그인 기능 추가

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -2,6 +2,13 @@ import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
+/* 테스트 계정 목록 */
+const TEST_ACCOUNTS = [
+    { label: '관리자', username: 'admin',     password: 'Test1234!' },
+    { label: '수강생', username: 'student_a', password: 'Test1234!' },
+    { label: '강사',   username: 'creator_a', password: 'Test1234!' },
+];
+
 const LoginPage = () => {
     /* 페이지 이동을 위한 네비게이트 함수 */
     const navigate = useNavigate();
@@ -28,6 +35,18 @@ const LoginPage = () => {
             navigate(redirect, { replace: true });
         } catch (err) {
             setError(err.response?.data?.message || '아이디 또는 비밀번호가 올바르지 않습니다.');
+        }
+    };
+
+    /* 테스트 계정 빠른 로그인 */
+    const handleQuickLogin = async (testUsername, testPassword) => {
+        setError('');
+
+        try {
+            await login(testUsername, testPassword);
+            navigate(redirect, { replace: true });
+        } catch (err) {
+            setError(err.response?.data?.message || '로그인에 실패했습니다.');
         }
     };
 
@@ -83,6 +102,22 @@ const LoginPage = () => {
                     계정이 없으신가요?{' '}
                     <Link to="/signup" className="text-blue-600 font-medium hover:underline">회원가입</Link>
                 </p>
+
+                {/* 테스트 계정 빠른 로그인 */}
+                <div className="mt-8 border border-dashed border-gray-200 rounded-xl p-5">
+                    <p className="text-xs font-semibold text-gray-400 text-center mb-3">테스트 계정으로 바로 로그인</p>
+                    <div className="flex gap-2">
+                        {TEST_ACCOUNTS.map(account => (
+                            <button
+                                key={account.username}
+                                onClick={() => handleQuickLogin(account.username, account.password)}
+                                className="flex-1 py-2 text-sm font-medium text-gray-600 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                            >
+                                {account.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                      
  - 로그인 페이지 하단에 테스트 계정 빠른 로그인 버튼 추가 (관리자/수강생/강사)                                                                                                     
  - 버튼 클릭 시 해당 계정으로 즉시 로그인 처리                                                                                                                                     
                                                                                                                                                                                    
  ## 구현 시 고려한 점                                                                                                                                                              
  - 아이디/비번 자동 입력 방식이 아닌 클릭 한 번으로 바로 로그인 처리하여 편의성 향상                                                                        
                                                                                                                                                                                    
  ## 테스트 방법                                                                                                                                                                    
  - 로그인 페이지 하단 점선 박스에서 관리자/수강생/강사 버튼 클릭 후 각 역할 페이지 진입 확인                                                                                       
                                                                                                                                                                                    
  ## 연관 이슈                                                                                                                                                                      
  Closes #89