### PR TITLE
[feat] 관리자 결제 내역 조회 및 환불 실패 처리 개선

### DIFF
--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -1,9 +1,11 @@
 package com.yujin.course_enrollment.controller;
 
 import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
+import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqAdminRoleUpdateDto;
 import com.yujin.course_enrollment.dto.req.ReqUpdatePasswordDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.User;
@@ -103,6 +105,19 @@ public class AdminController {
         adminService.forceCloseCourse(courseId);
 
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 전체 결제 내역 조회
+     * GET /api/admin/payments
+     * @param reqAdminPaymentPageDto 페이징 조건 (status 필터 선택)
+     * @return 전체 결제 내역 (DONE, CANCELLED)
+     */
+    @GetMapping("/payments")
+    public ResponseEntity<ApiResponse<RespPageDto<RespAdminPaymentDto>>> getPaymentList(ReqAdminPaymentPageDto reqAdminPaymentPageDto) {
+        log.debug("[AdminController] 전체 결제 내역 조회 요청");
+
+        return ResponseEntity.ok(ApiResponse.success(adminService.findAdminPayments(reqAdminPaymentPageDto)));
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/controller/AdminController.java
@@ -121,6 +121,21 @@ public class AdminController {
     }
 
     /**
+     * 환불 실패 건 수동 재시도
+     * PATCH /api/admin/enrollments/{enrollmentId}/refund-retry
+     * @param enrollmentId 수강 신청 ID
+     * @return 200 OK
+     */
+    @PatchMapping("/enrollments/{enrollmentId}/refund-retry")
+    public ResponseEntity<ApiResponse<Void>> retryRefund(@PathVariable Long enrollmentId) {
+        log.debug("[AdminController] 환불 재시도 - enrollmentId: {}", enrollmentId);
+
+        adminService.retryRefund(enrollmentId);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
      * 관리자 비밀번호 변경
      * PATCH /api/admin/me/password
      * @param userId SecurityContext에서 추출된 관리자 ID

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminPaymentPageDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/req/ReqAdminPaymentPageDto.java
@@ -1,0 +1,22 @@
+package com.yujin.course_enrollment.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 관리자 결제 내역 페이징 조건 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReqAdminPaymentPageDto {
+    private int page = 0;
+    private int size = 10;
+    private String status;
+
+    /* offset 계산 */
+    public int getOffset() {
+        return page * size;
+    }
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminDashboardDto.java
@@ -18,9 +18,12 @@ public class RespAdminDashboardDto {
     private int closedCount;
     private int forceClosedCount;
     private int totalEnrollments;
+    private Long totalRevenue;
+    private Long totalRefund;
+    private Long monthlyRevenue;
 
     /* 통계 집계 결과로 대시보드 응답 생성 */
-    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int forceClosedCount, int totalEnrollments) {
+    public static RespAdminDashboardDto of(int totalUsers, int studentCount, int creatorCount, int totalCourses, int draftCount, int openCount, int closedCount, int forceClosedCount, int totalEnrollments, Long totalRevenue, Long totalRefund, Long monthlyRevenue) {
         return RespAdminDashboardDto.builder()
                 .totalUsers(totalUsers)
                 .studentCount(studentCount)
@@ -31,6 +34,9 @@ public class RespAdminDashboardDto {
                 .closedCount(closedCount)
                 .forceClosedCount(forceClosedCount)
                 .totalEnrollments(totalEnrollments)
+                .totalRevenue(totalRevenue)
+                .totalRefund(totalRefund)
+                .monthlyRevenue(monthlyRevenue)
                 .build();
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminPaymentDto.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/dto/resp/RespAdminPaymentDto.java
@@ -1,0 +1,25 @@
+package com.yujin.course_enrollment.dto.resp;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 결제 내역 응답 DTO
+ */
+@Getter
+public class RespAdminPaymentDto {
+    private Long id;
+    private Long enrollmentId;
+    private String userName;
+    private String courseName;
+    private String orderId;
+    private String orderName;
+    private int amount;
+    private String method;
+    private String status;
+    private LocalDateTime paidAt;
+    private LocalDateTime canceledAt;
+    private String cancelReason;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/yujin/course_enrollment/global/PaymentStatus.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/global/PaymentStatus.java
@@ -8,6 +8,7 @@ public class PaymentStatus {
     public static final String DONE = "DONE";
     public static final String FAILED = "FAILED";
     public static final String CANCELLED = "CANCELLED";
+    public static final String REFUND_FAILED = "REFUND_FAILED";
 
     private PaymentStatus() {}
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -29,6 +29,9 @@ public interface PaymentMapper {
     /* 수강 신청 ID로 DONE 상태 결제 조회 */
     Payment selectPaymentByEnrollmentId(Long enrollmentId);
 
+    /* 환불 실패 마킹 (REFUND_FAILED 업데이트) */
+    void updatePaymentRefundFailed(Long enrollmentId);
+
     /* 결제 취소 상태 업데이트 */
     void updatePaymentCancelled(Payment payment);
 

--- a/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/mapper/PaymentMapper.java
@@ -1,6 +1,8 @@
 package com.yujin.course_enrollment.mapper;
 
+import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.req.ReqMyPaymentPageDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.entity.Payment;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -35,4 +37,19 @@ public interface PaymentMapper {
 
     /* 사용자 결제 내역 전체 수 조회 (페이징용) */
     int selectPaymentListByUserIdCount(Long userId);
+
+    /* 관리자 전체 결제 내역 조회 */
+    List<RespAdminPaymentDto> selectAdminPaymentList(ReqAdminPaymentPageDto reqAdminPaymentPageDto);
+
+    /* 관리자 전체 결제 내역 수 조회 (페이징용) */
+    int selectAdminPaymentListCount(ReqAdminPaymentPageDto reqAdminPaymentPageDto);
+
+    /* 전체 결제 금액 (DONE) */
+    Long selectTotalRevenue();
+
+    /* 전체 환불 금액 (CANCELLED) */
+    Long selectTotalRefund();
+
+    /* 이번 달 매출 (DONE, paid_at 기준) */
+    Long selectMonthlyRevenue();
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -5,6 +5,8 @@ import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
+import com.yujin.course_enrollment.entity.Payment;
+import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
@@ -35,6 +37,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminService {
+
+    private static final int MAX_REFUND_RETRIES = 2;
 
     private final UserMapper userMapper;
     private final CourseMapper courseMapper;
@@ -159,19 +163,65 @@ public class AdminService {
             return;
         }
 
-        // CONFIRMED 건별 환불 후 취소 — 실패해도 다음 건으로 진행
+        // CONFIRMED 건별 환불 후 취소 — 실패 시 재시도 후 REFUND_FAILED 마킹
         int successCount = 0;
         for (Long enrollmentId : confirmedIds) {
-            try {
-                paymentService.refund(enrollmentId, "강의 폐강");
+            boolean refunded = false;
+
+            for (int attempt = 1; attempt <= MAX_REFUND_RETRIES; attempt++) {
+                try {
+                    paymentService.refund(enrollmentId, "강의 폐강");
+                    refunded = true;
+                    break;
+                } catch (Exception e) {
+                    log.warn("[AdminService] 환불 시도 {}/{} 실패 - enrollmentId: {}", attempt, MAX_REFUND_RETRIES, enrollmentId, e);
+                }
+            }
+
+            // 재시도 성공
+            if (refunded) {
                 transactionTemplate.executeWithoutResult(s ->
                         enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollmentId)));
                 successCount++;
-            } catch (Exception e) {
-                log.error("[AdminService] 환불 처리 실패 - enrollmentId: {}", enrollmentId, e);
+            // 재시도 최종 실패 → REFUND_FAILED 마킹
+            } else {
+                log.error("[AdminService] 환불 최종 실패 - REFUND_FAILED 마킹 - enrollmentId: {}", enrollmentId);
+                transactionTemplate.executeWithoutResult(s ->
+                        paymentMapper.updatePaymentRefundFailed(enrollmentId));
             }
         }
 
         log.info("[AdminService] 강의 강제 폐강 완료 - courseId: {}, 환불 성공: {}/{}", courseId, successCount, confirmedIds.size());
+    }
+
+    /**
+     * 환불 실패 건 수동 재시도
+     * REFUND_FAILED 상태 수강 신청에 대해 Toss 환불 API 재호출
+     * @param enrollmentId 수강 신청 ID
+     * @throws BusinessException 수강 신청 없음(404), REFUND_FAILED 상태 아님(400)
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void retryRefund(Long enrollmentId) {
+        log.info("[AdminService] 환불 재시도 - enrollmentId: {}", enrollmentId);
+
+        Enrollment enrollment = enrollmentMapper.selectEnrollmentById(enrollmentId);
+        if (enrollment == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "존재하지 않는 수강 신청입니다.");
+        }
+
+        Payment payment = paymentMapper.selectPaymentByEnrollmentId(enrollmentId);
+        if (payment == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "결제 내역이 없습니다.");
+        }
+
+        if (!PaymentStatus.REFUND_FAILED.equals(payment.getStatus())) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "환불 실패 상태의 결제만 재시도할 수 있습니다.");
+        }
+
+        paymentService.refund(enrollmentId, "강의 폐강");
+        transactionTemplate.executeWithoutResult(s ->
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollmentId)));
+
+        log.info("[AdminService] 환불 재시도 성공 - enrollmentId: {}", enrollmentId);
     }
 }

--- a/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/AdminService.java
@@ -1,7 +1,9 @@
 package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.dto.req.ReqAdminCoursePageDto;
+import com.yujin.course_enrollment.dto.req.ReqAdminPaymentPageDto;
 import com.yujin.course_enrollment.dto.resp.RespAdminDashboardDto;
+import com.yujin.course_enrollment.dto.resp.RespAdminPaymentDto;
 import com.yujin.course_enrollment.dto.resp.RespCourseListDto;
 import com.yujin.course_enrollment.dto.resp.RespPageDto;
 import com.yujin.course_enrollment.entity.Course;
@@ -11,6 +13,7 @@ import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.PaymentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,12 +39,13 @@ public class AdminService {
     private final UserMapper userMapper;
     private final CourseMapper courseMapper;
     private final EnrollmentMapper enrollmentMapper;
+    private final PaymentMapper paymentMapper;
     private final PaymentService paymentService;
     private final TransactionTemplate transactionTemplate;
 
     /**
      * 대시보드 통계 조회
-     * @return 전체 사용자 수, 강의 수, 확정 수강 신청 수
+     * @return 전체 사용자 수, 강의 수, 확정 수강 신청 수, 결제 통계
      */
     public RespAdminDashboardDto getDashboardStats() {
         log.info("[AdminService] 대시보드 통계 조회");
@@ -55,8 +59,11 @@ public class AdminService {
         int closedCount = courseMapper.selectCourseCountByStatus("CLOSED");
         int forceClosedCount = courseMapper.selectCourseCountByStatus("FORCE_CLOSED");
         int totalEnrollments = enrollmentMapper.selectActiveEnrollmentCount();
+        Long totalRevenue = paymentMapper.selectTotalRevenue();
+        Long totalRefund = paymentMapper.selectTotalRefund();
+        Long monthlyRevenue = paymentMapper.selectMonthlyRevenue();
 
-        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, forceClosedCount, totalEnrollments);
+        return RespAdminDashboardDto.of(totalUsers, studentCount, creatorCount, totalCourses, draftCount, openCount, closedCount, forceClosedCount, totalEnrollments, totalRevenue, totalRefund, monthlyRevenue);
     }
 
     /**
@@ -103,6 +110,20 @@ public class AdminService {
         int totalCount = courseMapper.selectAdminCourseListCount();
 
         return RespPageDto.of(content, reqAdminCoursePageDto.getPage(), reqAdminCoursePageDto.getSize(), totalCount);
+    }
+
+    /**
+     * 관리자 전체 결제 내역 조회
+     * @param reqAdminPaymentPageDto 페이징 조건 (status 필터 선택)
+     * @return 페이징된 결제 내역 (DONE, CANCELLED)
+     */
+    public RespPageDto<RespAdminPaymentDto> findAdminPayments(ReqAdminPaymentPageDto reqAdminPaymentPageDto) {
+        log.info("[AdminService] 전체 결제 내역 조회 - page: {}, size: {}, status: {}", reqAdminPaymentPageDto.getPage(), reqAdminPaymentPageDto.getSize(), reqAdminPaymentPageDto.getStatus());
+
+        List<RespAdminPaymentDto> content = paymentMapper.selectAdminPaymentList(reqAdminPaymentPageDto);
+        int totalCount = paymentMapper.selectAdminPaymentListCount(reqAdminPaymentPageDto);
+
+        return RespPageDto.of(content, reqAdminPaymentPageDto.getPage(), reqAdminPaymentPageDto.getSize(), totalCount);
     }
 
     /**

--- a/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
+++ b/backend/src/main/java/com/yujin/course_enrollment/service/PaymentService.java
@@ -8,6 +8,7 @@ import com.yujin.course_enrollment.dto.resp.RespPaymentDto;
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
 import com.yujin.course_enrollment.entity.Payment;
+import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.EnrollmentStatus;
 import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
@@ -229,11 +230,18 @@ public class PaymentService {
         // 결제 CANCELLED 처리
         paymentMapper.updatePaymentCancelled(Payment.ofCancelled(payment.getId(), WEBHOOK_CANCEL_REASON));
 
-        // enrollment 상태 동기화 (CONFIRMED → CANCELLED)
+        // enrollment 상태 동기화 — 강제 폐강 강의이면 FORCE_CLOSED, 아니면 CANCELLED
         Enrollment enrollment = enrollmentMapper.selectEnrollmentById(payment.getEnrollmentId());
         if (enrollment != null && EnrollmentStatus.CONFIRMED.equals(enrollment.getStatus())) {
-            enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(payment.getEnrollmentId()));
-            log.info("[PaymentService] 웹훅 - enrollment 취소 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+            Course course = courseMapper.selectCourseById(enrollment.getCourseId());
+
+            if (course != null && CourseStatus.FORCE_CLOSED.equals(course.getStatus())) {
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofForceClose(enrollment.getId()));
+                log.info("[PaymentService] 웹훅 - enrollment 강제 폐강 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+            } else {
+                enrollmentMapper.updateEnrollmentStatus(Enrollment.ofCancel(enrollment.getId()));
+                log.info("[PaymentService] 웹훅 - enrollment 취소 동기화 - enrollmentId: {}", payment.getEnrollmentId());
+            }
         }
 
         log.info("[PaymentService] 웹훅 - 결제 취소 처리 완료 - orderId: {}", data.getOrderId());

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -124,4 +124,63 @@
            AND p.status IN ('DONE', 'CANCELLED')
     </select>
 
+    <!-- 관리자 전체 결제 내역 조회 -->
+    <select id="selectAdminPaymentList" parameterType="ReqAdminPaymentPageDto" resultType="RespAdminPaymentDto">
+        SELECT p.id
+             , p.enrollment_id
+             , u.name AS userName
+             , c.title AS courseName
+             , p.order_id
+             , p.order_name
+             , p.amount
+             , p.method
+             , p.status
+             , p.paid_at
+             , p.canceled_at
+             , p.cancel_reason
+             , p.created_at
+          FROM payments p
+          JOIN enrollments e ON p.enrollment_id = e.id
+          JOIN users u ON e.user_id = u.id
+          JOIN courses c ON e.course_id = c.id
+         WHERE p.status IN ('DONE', 'CANCELLED')
+        <if test="status != null and status != ''">
+           AND p.status = #{status}
+        </if>
+        ORDER BY p.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 관리자 전체 결제 내역 수 조회 (페이징용) -->
+    <select id="selectAdminPaymentListCount" parameterType="ReqAdminPaymentPageDto" resultType="int">
+        SELECT COUNT(*)
+          FROM payments
+         WHERE status IN ('DONE', 'CANCELLED')
+        <if test="status != null and status != ''">
+           AND status = #{status}
+        </if>
+    </select>
+
+    <!-- 전체 결제 금액 (DONE) -->
+    <select id="selectTotalRevenue" resultType="Long">
+        SELECT IFNULL(SUM(amount), 0)
+          FROM payments
+         WHERE status = 'DONE'
+    </select>
+
+    <!-- 전체 환불 금액 (CANCELLED) -->
+    <select id="selectTotalRefund" resultType="Long">
+        SELECT IFNULL(SUM(amount), 0)
+          FROM payments
+         WHERE status = 'CANCELLED'
+    </select>
+
+    <!-- 이번 달 매출 (DONE, paid_at 기준) -->
+    <select id="selectMonthlyRevenue" resultType="Long">
+        SELECT IFNULL(SUM(amount), 0)
+          FROM payments
+         WHERE status = 'DONE'
+           AND DATE_FORMAT(paid_at, '%Y-%m') = DATE_FORMAT(NOW(), '%Y-%m')
+    </select>
+
 </mapper>

--- a/backend/src/main/resources/mapper/PaymentMapper.xml
+++ b/backend/src/main/resources/mapper/PaymentMapper.xml
@@ -62,7 +62,7 @@
          WHERE order_id = #{orderId}
     </select>
 
-    <!-- 수강 신청 ID로 DONE 상태 결제 조회 -->
+    <!-- 수강 신청 ID로 DONE/REFUND_FAILED 상태 결제 조회 -->
     <select id="selectPaymentByEnrollmentId" parameterType="Long" resultType="Payment">
         SELECT id
              , enrollment_id
@@ -79,8 +79,16 @@
              , updated_at
           FROM payments
          WHERE enrollment_id = #{enrollmentId}
-           AND status = 'DONE'
+           AND status IN ('DONE', 'REFUND_FAILED')
     </select>
+
+    <!-- 환불 실패 마킹 (REFUND_FAILED 업데이트) -->
+    <update id="updatePaymentRefundFailed" parameterType="Long">
+        UPDATE payments
+           SET status = 'REFUND_FAILED'
+         WHERE enrollment_id = #{enrollmentId}
+           AND status = 'DONE'
+    </update>
 
     <!-- 결제 취소 상태 업데이트 -->
     <update id="updatePaymentCancelled" parameterType="Payment">
@@ -89,7 +97,7 @@
              , canceled_at = #{canceledAt}
              , cancel_reason = #{cancelReason}
          WHERE id = #{id}
-           AND status = 'DONE'
+           AND status IN ('DONE', 'REFUND_FAILED')
     </update>
 
     <!-- 사용자 결제 내역 조회 (DONE, CANCELLED) -->
@@ -143,7 +151,7 @@
           JOIN enrollments e ON p.enrollment_id = e.id
           JOIN users u ON e.user_id = u.id
           JOIN courses c ON e.course_id = c.id
-         WHERE p.status IN ('DONE', 'CANCELLED')
+         WHERE p.status IN ('DONE', 'CANCELLED', 'FAILED', 'REFUND_FAILED')
         <if test="status != null and status != ''">
            AND p.status = #{status}
         </if>
@@ -155,7 +163,7 @@
     <select id="selectAdminPaymentListCount" parameterType="ReqAdminPaymentPageDto" resultType="int">
         SELECT COUNT(*)
           FROM payments
-         WHERE status IN ('DONE', 'CANCELLED')
+         WHERE status IN ('DONE', 'CANCELLED', 'FAILED', 'REFUND_FAILED')
         <if test="status != null and status != ''">
            AND status = #{status}
         </if>

--- a/backend/src/test/java/com/yujin/course_enrollment/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/yujin/course_enrollment/service/AdminServiceTest.java
@@ -2,11 +2,14 @@ package com.yujin.course_enrollment.service;
 
 import com.yujin.course_enrollment.entity.Course;
 import com.yujin.course_enrollment.entity.Enrollment;
+import com.yujin.course_enrollment.entity.Payment;
 import com.yujin.course_enrollment.global.CourseStatus;
 import com.yujin.course_enrollment.global.EnrollmentStatus;
+import com.yujin.course_enrollment.global.PaymentStatus;
 import com.yujin.course_enrollment.global.exception.BusinessException;
 import com.yujin.course_enrollment.mapper.CourseMapper;
 import com.yujin.course_enrollment.mapper.EnrollmentMapper;
+import com.yujin.course_enrollment.mapper.PaymentMapper;
 import com.yujin.course_enrollment.mapper.UserMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +48,9 @@ class AdminServiceTest {
 
     @Mock
     private EnrollmentMapper enrollmentMapper;
+
+    @Mock
+    private PaymentMapper paymentMapper;
 
     @Mock
     private PaymentService paymentService;
@@ -111,8 +117,8 @@ class AdminServiceTest {
     }
 
     @Test
-    @DisplayName("강제 폐강 - 환불 실패한 건은 로그 후 다음 건으로 진행")
-    void forceCloseCourse_refundFails_continuesOtherEnrollments() {
+    @DisplayName("강제 폐강 - 환불 최종 실패 시 payment REFUND_FAILED 마킹 후 다음 건 진행")
+    void forceCloseCourse_refundFails_marksPaymentRefundFailed() {
         // given
         Long courseId = 1L;
         Course course = Course.builder().id(courseId).status(CourseStatus.OPEN).build();
@@ -125,10 +131,11 @@ class AdminServiceTest {
         // when
         assertThatCode(() -> adminService.forceCloseCourse(courseId)).doesNotThrowAnyException();
 
-        // then: 10L 실패해도 11L 처리됨
-        then(paymentService).should().refund(eq(11L), eq("강의 폐강"));
+        // then: 10L 실패 → REFUND_FAILED 마킹, 11L은 정상 처리
+        then(paymentMapper).should().updatePaymentRefundFailed(10L);
         then(enrollmentMapper).should(never()).updateEnrollmentStatus(argThat(e ->
                 Long.valueOf(10L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+        then(paymentService).should().refund(eq(11L), eq("강의 폐강"));
         then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
                 Long.valueOf(11L).equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
     }
@@ -169,5 +176,70 @@ class AdminServiceTest {
         assertThatThrownBy(() -> adminService.forceCloseCourse(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("이미 폐강");
+    }
+
+    @Test
+    @DisplayName("환불 재시도 성공")
+    void retryRefund_success() {
+        // given
+        Long enrollmentId = 10L;
+        Enrollment enrollment = Enrollment.builder().id(enrollmentId).status(EnrollmentStatus.CONFIRMED).build();
+        Payment payment = Payment.builder().id(1L).status(PaymentStatus.REFUND_FAILED).build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(enrollment);
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(payment);
+
+        // when
+        adminService.retryRefund(enrollmentId);
+
+        // then
+        then(paymentService).should().refund(enrollmentId, "강의 폐강");
+        then(enrollmentMapper).should().updateEnrollmentStatus(argThat(e ->
+                enrollmentId.equals(e.getId()) && EnrollmentStatus.FORCE_CLOSED.equals(e.getStatus())));
+    }
+
+    @Test
+    @DisplayName("환불 재시도 실패 - 수강 신청 없음 404")
+    void retryRefund_enrollmentNotFound_throws404() {
+        // given
+        given(enrollmentMapper.selectEnrollmentById(any())).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.retryRefund(99L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("존재하지 않는 수강 신청");
+    }
+
+    @Test
+    @DisplayName("환불 재시도 실패 - REFUND_FAILED 상태 아님 400")
+    void retryRefund_paymentNotRefundFailed_throws400() {
+        // given
+        Long enrollmentId = 10L;
+        Enrollment enrollment = Enrollment.builder().id(enrollmentId).status(EnrollmentStatus.CONFIRMED).build();
+        Payment payment = Payment.builder().id(1L).status(PaymentStatus.DONE).build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(enrollment);
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(payment);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.retryRefund(enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("환불 실패 상태의 결제만 재시도");
+    }
+
+    @Test
+    @DisplayName("환불 재시도 실패 - 결제 내역 없음 404")
+    void retryRefund_paymentNotFound_throws404() {
+        // given
+        Long enrollmentId = 10L;
+        Enrollment enrollment = Enrollment.builder().id(enrollmentId).status(EnrollmentStatus.CONFIRMED).build();
+
+        given(enrollmentMapper.selectEnrollmentById(enrollmentId)).willReturn(enrollment);
+        given(paymentMapper.selectPaymentByEnrollmentId(enrollmentId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> adminService.retryRefund(enrollmentId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("결제 내역이 없습니다");
     }
 }

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -30,6 +30,11 @@ export const getAdminPayments = (page = 0, size = 10, status = '') => {
     return instance.get('/api/admin/payments', { params: { page, size, status: status || undefined } }).then(res => res.data);
 };
 
+/* 환불 실패 건 재시도 */
+export const retryRefund = (enrollmentId) => {
+    return instance.patch(`/api/admin/enrollments/${enrollmentId}/refund-retry`).then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -25,6 +25,11 @@ export const forceCloseCourse = (courseId) => {
     return instance.patch(`/api/admin/courses/${courseId}/close`).then(res => res.data);
 };
 
+/* 전체 결제 내역 조회 */
+export const getAdminPayments = (page = 0, size = 10, status = '') => {
+    return instance.get('/api/admin/payments', { params: { page, size, status: status || undefined } }).then(res => res.data);
+};
+
 /* 관리자 비밀번호 변경 */
 export const updateAdminPassword = (currentPassword, newPassword) => {
     return instance.patch('/api/admin/me/password', { currentPassword, newPassword }).then(res => res.data);

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -3,6 +3,7 @@ import CreatorRequestTab from './admin/CreatorRequestTab';
 import DashboardTab from './admin/DashboardTab';
 import UserManagementTab from './admin/UserManagementTab';
 import CourseManagementTab from './admin/CourseManagementTab';
+import PaymentManagementTab from './admin/PaymentManagementTab';
 import { updateAdminPassword } from '../api/admin';
 
 /* 관리자 페이지 */
@@ -22,6 +23,7 @@ const AdminPage = () => {
         { key: 'creator-requests', label: '강사 신청 관리' },
         { key: 'users', label: '사용자 관리' },
         { key: 'courses', label: '강의 관리' },
+        { key: 'payments', label: '결제 관리' },
     ];
 
     /* 모달 닫기 */
@@ -87,6 +89,7 @@ const AdminPage = () => {
             {activeTab === 'creator-requests' && <CreatorRequestTab />}
             {activeTab === 'users' && <UserManagementTab />}
             {activeTab === 'courses' && <CourseManagementTab />}
+            {activeTab === 'payments' && <PaymentManagementTab />}
 
             {/* 비밀번호 변경 모달 */}
             {showPasswordModal && (

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -2,6 +2,13 @@ import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
+/* 테스트 계정 목록 */
+const TEST_ACCOUNTS = [
+    { label: '관리자', username: 'admin',     password: 'Test1234!' },
+    { label: '수강생', username: 'student_a', password: 'Test1234!' },
+    { label: '강사',   username: 'creator_a', password: 'Test1234!' },
+];
+
 const LoginPage = () => {
     /* 페이지 이동을 위한 네비게이트 함수 */
     const navigate = useNavigate();
@@ -28,6 +35,18 @@ const LoginPage = () => {
             navigate(redirect, { replace: true });
         } catch (err) {
             setError(err.response?.data?.message || '아이디 또는 비밀번호가 올바르지 않습니다.');
+        }
+    };
+
+    /* 테스트 계정 빠른 로그인 */
+    const handleQuickLogin = async (testUsername, testPassword) => {
+        setError('');
+
+        try {
+            await login(testUsername, testPassword);
+            navigate(redirect, { replace: true });
+        } catch (err) {
+            setError(err.response?.data?.message || '로그인에 실패했습니다.');
         }
     };
 
@@ -83,6 +102,22 @@ const LoginPage = () => {
                     계정이 없으신가요?{' '}
                     <Link to="/signup" className="text-blue-600 font-medium hover:underline">회원가입</Link>
                 </p>
+
+                {/* 테스트 계정 빠른 로그인 */}
+                <div className="mt-8 border border-dashed border-gray-200 rounded-xl p-5">
+                    <p className="text-xs font-semibold text-gray-400 text-center mb-3">테스트 계정으로 바로 로그인</p>
+                    <div className="flex gap-2">
+                        {TEST_ACCOUNTS.map(account => (
+                            <button
+                                key={account.username}
+                                onClick={() => handleQuickLogin(account.username, account.password)}
+                                className="flex-1 py-2 text-sm font-medium text-gray-600 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                            >
+                                {account.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/pages/admin/DashboardTab.jsx
+++ b/frontend/src/pages/admin/DashboardTab.jsx
@@ -38,6 +38,11 @@ const IconCheck = () => (
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
 );
+const IconWon = () => (
+    <svg className="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+);
 
 /* 관리자 대시보드 탭 */
 const DashboardTab = () => {
@@ -80,11 +85,34 @@ const DashboardTab = () => {
 
     if (isLoading) return <div className="text-center py-20 text-gray-400">로딩 중...</div>;
 
+    /* 결제 통계 카드 데이터 */
+    const paymentCards = [
+        { label: '총 결제금액', value: stats?.totalRevenue ?? 0, unit: '원', icon: <IconWon /> },
+        { label: '총 환불금액', value: stats?.totalRefund ?? 0, unit: '원', icon: <IconWon /> },
+        { label: '이번 달 매출', value: stats?.monthlyRevenue ?? 0, unit: '원', icon: <IconWon /> },
+    ];
+
     return (
         <div className="space-y-8">
             {/* 요약 카드 */}
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
                 {cards.map(card => (
+                    <div key={card.label} className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
+                        <div className="flex items-start justify-between mb-1">
+                            <p className="text-xs font-semibold text-gray-400 tracking-wide uppercase">{card.label}</p>
+                            {card.icon}
+                        </div>
+                        <p className="text-4xl font-extrabold text-gray-900">
+                            {card.value.toLocaleString()}
+                            <span className="text-sm font-medium text-gray-400 ml-1">{card.unit}</span>
+                        </p>
+                    </div>
+                ))}
+            </div>
+
+            {/* 결제 통계 카드 */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
+                {paymentCards.map(card => (
                     <div key={card.label} className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
                         <div className="flex items-start justify-between mb-1">
                             <p className="text-xs font-semibold text-gray-400 tracking-wide uppercase">{card.label}</p>

--- a/frontend/src/pages/admin/PaymentManagementTab.jsx
+++ b/frontend/src/pages/admin/PaymentManagementTab.jsx
@@ -1,15 +1,19 @@
 import { useEffect, useState } from 'react';
-import { getAdminPayments } from '../../api/admin';
+import { getAdminPayments, retryRefund } from '../../api/admin';
 
 /* 결제 상태 배지 스타일 */
 const PAYMENT_STATUS_BADGE_STYLE = {
     DONE: 'bg-green-50 text-green-700 border-green-200',
     CANCELLED: 'bg-gray-50 text-gray-500 border-gray-200',
+    FAILED: 'bg-orange-50 text-orange-600 border-orange-200',
+    REFUND_FAILED: 'bg-red-50 text-red-600 border-red-200',
 };
 /* 결제 상태 레이블 */
 const PAYMENT_STATUS_LABEL = {
     DONE: '결제완료',
     CANCELLED: '환불완료',
+    FAILED: '결제실패',
+    REFUND_FAILED: '환불실패',
 };
 
 /* 상태 필터 목록 */
@@ -17,6 +21,8 @@ const STATUS_FILTERS = [
     { key: '', label: '전체' },
     { key: 'DONE', label: '결제완료' },
     { key: 'CANCELLED', label: '환불완료' },
+    { key: 'FAILED', label: '결제실패' },
+    { key: 'REFUND_FAILED', label: '환불실패' },
 ];
 
 /* 관리자 결제 관리 탭 */
@@ -33,6 +39,8 @@ const PaymentManagementTab = () => {
     const [status, setStatus] = useState('');
     /* 로딩 상태 */
     const [isLoading, setIsLoading] = useState(true);
+    /* 재시도 중인 enrollmentId 목록 */
+    const [retrying, setRetrying] = useState(new Set());
 
     /* 결제 목록 조회 */
     const fetchPayments = (p, s) => {
@@ -59,6 +67,23 @@ const PaymentManagementTab = () => {
         setPage(0);
     };
 
+    /* 환불 재시도 */
+    const handleRetry = (enrollmentId) => {
+        setRetrying(prev => new Set(prev).add(enrollmentId));
+
+        retryRefund(enrollmentId)
+            .then(() => {
+                alert('환불 재시도가 완료되었습니다.');
+                fetchPayments(page, status);
+            })
+            .catch(err => alert(err.response?.data?.message || '환불 재시도에 실패했습니다.'))
+            .finally(() => setRetrying(prev => {
+                const next = new Set(prev);
+                next.delete(enrollmentId);
+                return next;
+            }));
+    };
+
     return (
         <>
             {/* 상태 필터 */}
@@ -82,7 +107,7 @@ const PaymentManagementTab = () => {
                 <div className="text-center py-20 text-gray-400">로딩 중...</div>
             ) : payments.length === 0 ? (
                 <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
-                    결제 내역이 없습니다.
+                    {PAYMENT_STATUS_LABEL[status] ? `${PAYMENT_STATUS_LABEL[status]} 내역이 없습니다.` : '결제 내역이 없습니다.'}
                 </div>
             ) : (
                 <>
@@ -112,7 +137,18 @@ const PaymentManagementTab = () => {
                                             </span>
                                         </td>
                                         <td className="py-4 pr-6 text-gray-500">{payment.paidAt?.substring(0, 10) ?? '-'}</td>
-                                        <td className="py-4 text-gray-500">{payment.canceledAt?.substring(0, 10) ?? '-'}</td>
+                                        <td className="py-4 text-gray-500">
+                                            {payment.canceledAt?.substring(0, 10) ?? '-'}
+                                            {payment.status === 'REFUND_FAILED' && (
+                                                <button
+                                                    onClick={() => handleRetry(payment.enrollmentId)}
+                                                    disabled={retrying.has(payment.enrollmentId)}
+                                                    className="ml-3 px-2 py-0.5 text-xs font-semibold text-white bg-red-500 rounded hover:bg-red-600 disabled:opacity-50 cursor-pointer transition-colors"
+                                                >
+                                                    {retrying.has(payment.enrollmentId) ? '재시도 중...' : '재시도'}
+                                                </button>
+                                            )}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>

--- a/frontend/src/pages/admin/PaymentManagementTab.jsx
+++ b/frontend/src/pages/admin/PaymentManagementTab.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { getAdminPayments } from '../../api/admin';
+
+/* 결제 상태 배지 스타일 */
+const PAYMENT_STATUS_BADGE_STYLE = {
+    DONE: 'bg-green-50 text-green-700 border-green-200',
+    CANCELLED: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+/* 결제 상태 레이블 */
+const PAYMENT_STATUS_LABEL = {
+    DONE: '결제완료',
+    CANCELLED: '환불완료',
+};
+
+/* 상태 필터 목록 */
+const STATUS_FILTERS = [
+    { key: '', label: '전체' },
+    { key: 'DONE', label: '결제완료' },
+    { key: 'CANCELLED', label: '환불완료' },
+];
+
+/* 관리자 결제 관리 탭 */
+const PaymentManagementTab = () => {
+    /* 결제 목록 상태 */
+    const [payments, setPayments] = useState([]);
+    /* 페이징 상태 */
+    const [page, setPage] = useState(0);
+    /* 전체 페이지 수 상태 */
+    const [totalPages, setTotalPages] = useState(0);
+    /* 마지막 페이지 여부 상태 */
+    const [isLast, setIsLast] = useState(false);
+    /* 상태 필터 */
+    const [status, setStatus] = useState('');
+    /* 로딩 상태 */
+    const [isLoading, setIsLoading] = useState(true);
+
+    /* 결제 목록 조회 */
+    const fetchPayments = (p, s) => {
+        setIsLoading(true);
+
+        getAdminPayments(p, 10, s)
+            .then(res => {
+                setPayments(res.data.content);
+                setTotalPages(res.data.totalPages);
+                setIsLast(res.data.last);
+            })
+            .catch(() => alert('결제 내역 조회에 실패했습니다.'))
+            .finally(() => setIsLoading(false));
+    };
+
+    /* 페이지 또는 상태 필터 변경 시 재조회 */
+    useEffect(() => {
+        fetchPayments(page, status);
+    }, [page, status]);
+
+    /* 상태 필터 변경 시 페이지 초기화 */
+    const handleStatusChange = (newStatus) => {
+        setStatus(newStatus);
+        setPage(0);
+    };
+
+    return (
+        <>
+            {/* 상태 필터 */}
+            <div className="flex gap-2 mb-6">
+                {STATUS_FILTERS.map(filter => (
+                    <button
+                        key={filter.key}
+                        onClick={() => handleStatusChange(filter.key)}
+                        className={`px-4 py-1.5 text-sm font-semibold rounded-full border transition-colors cursor-pointer ${
+                            status === filter.key
+                                ? 'bg-blue-600 text-white border-blue-600'
+                                : 'text-gray-500 border-gray-300 hover:border-gray-400'
+                        }`}
+                    >
+                        {filter.label}
+                    </button>
+                ))}
+            </div>
+
+            {isLoading ? (
+                <div className="text-center py-20 text-gray-400">로딩 중...</div>
+            ) : payments.length === 0 ? (
+                <div className="text-center text-gray-400 py-32 border-2 border-dashed border-gray-100 rounded-2xl">
+                    결제 내역이 없습니다.
+                </div>
+            ) : (
+                <>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm text-left">
+                            {/* 테이블 헤더 */}
+                            <thead>
+                                <tr className="border-b border-gray-200 text-gray-500 text-xs uppercase">
+                                    <th className="pb-3 pr-6 font-semibold">사용자명</th>
+                                    <th className="pb-3 pr-6 font-semibold">강의명</th>
+                                    <th className="pb-3 pr-6 font-semibold">금액</th>
+                                    <th className="pb-3 pr-6 font-semibold">상태</th>
+                                    <th className="pb-3 pr-6 font-semibold">결제일</th>
+                                    <th className="pb-3 font-semibold">환불일</th>
+                                </tr>
+                            </thead>
+                            {/* 테이블 바디 */}
+                            <tbody className="divide-y divide-gray-100">
+                                {payments.map(payment => (
+                                    <tr key={payment.id} className="hover:bg-gray-50">
+                                        <td className="py-4 pr-6 font-medium text-gray-900">{payment.userName}</td>
+                                        <td className="py-4 pr-6 text-gray-700 max-w-xs truncate">{payment.courseName}</td>
+                                        <td className="py-4 pr-6 font-semibold text-gray-900">{payment.amount.toLocaleString()}원</td>
+                                        <td className="py-4 pr-6">
+                                            <span className={`text-xs font-bold px-2 py-0.5 rounded border ${PAYMENT_STATUS_BADGE_STYLE[payment.status]}`}>
+                                                {PAYMENT_STATUS_LABEL[payment.status]}
+                                            </span>
+                                        </td>
+                                        <td className="py-4 pr-6 text-gray-500">{payment.paidAt?.substring(0, 10) ?? '-'}</td>
+                                        <td className="py-4 text-gray-500">{payment.canceledAt?.substring(0, 10) ?? '-'}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* 페이징 */}
+                    {totalPages > 1 && (
+                        <div className="flex justify-center items-center gap-4 mt-8">
+                            <button disabled={page === 0}
+                                onClick={() => setPage(prev => prev - 1)}
+                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M15 19l-7-7 7-7" />
+                                </svg>
+                            </button>
+                            <span className="text-sm font-medium text-gray-700">
+                                <span className="text-blue-600">{page + 1}</span> / {totalPages}
+                            </span>
+                            <button disabled={isLast}
+                                onClick={() => setPage(prev => prev + 1)}
+                                className="p-2 border rounded-full hover:bg-gray-50 disabled:opacity-30 cursor-pointer transition-colors">
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
+                                </svg>
+                            </button>
+                        </div>
+                    )}
+                </>
+            )}
+        </>
+    );
+};
+
+export default PaymentManagementTab;


### PR DESCRIPTION
  ## 작업 내용                                                                                                                                                                                                                                                                                                                                                
  결제/환불                                                                                                                                                                         
  - 관리자 결제 내역 조회 구현 (#85)                                                                                                                                                
  - 강제 폐강 환불 최종 실패 시 REFUND_FAILED 마킹 및 수동 재시도 기능 추가 (#87)                                                                                                   
                                                                                                                                                                                    
  사용자/관리자                                                                                                                                                                     
  - 관리자 결제 내역 조회 UI 추가 (#85)                                                                                                                                             
  - 관리자 결제 관리 탭 결제실패·환불실패 상태 배지·필터·재시도 버튼 추가 (#87)                                                                                                     
                                                                                                                                                                                    
  기타                                                                                                                                                                              
  - 로그인 페이지 테스트 계정 빠른 로그인 버튼 추가 (#89)